### PR TITLE
Move specific implementations of PaillierParams

### DIFF
--- a/synedrion/src/cggmp21/params.rs
+++ b/synedrion/src/cggmp21/params.rs
@@ -1,6 +1,69 @@
 use crate::curve::ORDER;
-use crate::paillier::{PaillierParams, PaillierProduction, PaillierTest};
-use crate::uint::upcast_uint;
+use crate::paillier::PaillierParams;
+use crate::uint::{
+    upcast_uint, U1024Mod, U2048Mod, U4096Mod, U512Mod, U1024, U2048, U4096, U512, U8192,
+};
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct PaillierTest;
+
+impl PaillierParams for PaillierTest {
+    // We need 257-bit primes because we need MODULUS_BITS to accommodate all the possible
+    // values of curve scalar squared, which is 512 bits.
+
+    /*
+    The prime size is chosen to be minimal for which the `TestSchemeParams` still work.
+    In the presigning, we are effectively constructing a ciphertext of
+        d = x * sum(j=1..P) y_i + sum(j=1..2*(P-1)) z_j
+    where
+        0 < x, y_i < q < 2^L, and
+        -2^LP < z < 2^LP
+    (`q` is the curve order, `L` and `LP` are constants in `TestSchemeParams`,
+    `P` is the number of parties).
+    This is `delta_i`, an additive share of the product of two secret values.
+
+    We need the final result to be `-N/2 < d < N/2`
+    (that is, it may be negative, and it cannot wrap around modulo N).
+
+    `N` is a product of two primes of the size `PRIME_BITS`, so `N > 2^(2 * PRIME_BITS - 2)`.
+    The upper bound on `log2(d)` is
+        max(2 * L, LP + 2) + ceil(log2(P))
+
+    Note in reality, due to numbers being random, the distribution will have a distinct peak,
+    and the upper bound will have a low probability of being reached.
+
+    Therefore we require `max(2 * L, LP + 2) + ceil(log2(P)) < 2 * PRIME_BITS - 2`.
+    For tests we assume `ceil(log2(P)) = 5` (we won't run tests with more than 32 nodes),
+    and since in `TestSchemeParams` `L = LP = 256`, this leads to `PRIME_BITS >= L + 4`.
+
+    For production it does not matter since both 2*L and LP are much smaller than 2*PRIME_BITS.
+
+    TODO: add an assertion for `SchemeParams` checking that?
+    */
+
+    const PRIME_BITS: usize = 260;
+    type HalfUint = U512;
+    type HalfUintMod = U512Mod;
+    type Uint = U1024;
+    type UintMod = U1024Mod;
+    type WideUint = U2048;
+    type WideUintMod = U2048Mod;
+    type ExtraWideUint = U4096;
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct PaillierProduction;
+
+impl PaillierParams for PaillierProduction {
+    const PRIME_BITS: usize = 1024;
+    type HalfUint = U1024;
+    type HalfUintMod = U1024Mod;
+    type Uint = U2048;
+    type UintMod = U2048Mod;
+    type WideUint = U4096;
+    type WideUintMod = U4096Mod;
+    type ExtraWideUint = U8192;
+}
 
 /// Signing scheme parameters.
 // TODO (#27): this trait can include curve scalar/point types as well,

--- a/synedrion/src/paillier.rs
+++ b/synedrion/src/paillier.rs
@@ -8,5 +8,5 @@ pub(crate) use keys::{
     PublicKeyPaillier, PublicKeyPaillierPrecomputed, SecretKeyPaillier,
     SecretKeyPaillierPrecomputed,
 };
-pub(crate) use params::{PaillierParams, PaillierProduction, PaillierTest};
+pub(crate) use params::PaillierParams;
 pub(crate) use ring_pedersen::{RPCommitment, RPParams, RPParamsMod, RPSecret};

--- a/synedrion/src/paillier/encryption.rs
+++ b/synedrion/src/paillier/encryption.rs
@@ -337,8 +337,10 @@ impl<P: PaillierParams> Hashable for Ciphertext<P> {
 mod tests {
     use rand_core::OsRng;
 
+    use super::super::params::PaillierTest;
+    use super::super::{PaillierParams, SecretKeyPaillier};
     use super::{Ciphertext, RandomizerMod};
-    use crate::paillier::{PaillierParams, PaillierTest, SecretKeyPaillier};
+
     use crate::uint::{
         subtle::ConditionallyNegatable, HasWide, NonZero, RandomMod, Signed, UintLike,
     };

--- a/synedrion/src/paillier/keys.rs
+++ b/synedrion/src/paillier/keys.rs
@@ -289,8 +289,8 @@ impl<P: PaillierParams> Hashable for PublicKeyPaillier<P> {
 mod tests {
     use rand_core::OsRng;
 
+    use super::super::params::PaillierTest;
     use super::SecretKeyPaillier;
-    use crate::paillier::PaillierTest;
 
     #[test]
     fn basics() {

--- a/synedrion/src/paillier/params.rs
+++ b/synedrion/src/paillier/params.rs
@@ -1,9 +1,9 @@
 use serde::{Deserialize, Serialize};
 
-use crate::uint::{
-    FromScalar, HasWide, U1024Mod, U2048Mod, U4096Mod, U512Mod, UintLike, UintModLike, U1024,
-    U2048, U4096, U512, U8192,
-};
+use crate::uint::{FromScalar, HasWide, UintLike, UintModLike};
+
+#[cfg(test)]
+use crate::uint::{U1024Mod, U2048Mod, U512Mod, U1024, U2048, U4096, U512};
 
 pub trait PaillierParams: PartialEq + Eq + Clone + core::fmt::Debug + Send {
     /// The size of one of the pair of RSA primes.
@@ -38,44 +38,14 @@ pub trait PaillierParams: PartialEq + Eq + Clone + core::fmt::Debug + Send {
     type ExtraWideUint: UintLike + Serialize + for<'de> Deserialize<'de>;
 }
 
+/// Paillier parameters for unit tests in this submodule.
+#[cfg(test)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct PaillierTest;
+pub(crate) struct PaillierTest;
 
+#[cfg(test)]
 impl PaillierParams for PaillierTest {
-    // We need 257-bit primes because we need MODULUS_BITS to accommodate all the possible
-    // values of curve scalar squared, which is 512 bits.
-
-    /*
-    The prime size is chosen to be minimal for which the `TestSchemeParams` still work.
-    In the presigning, we are effectively constructing a ciphertext of
-        d = x * sum(j=1..P) y_i + sum(j=1..2*(P-1)) z_j
-    where
-        0 < x, y_i < q < 2^L, and
-        -2^LP < z < 2^LP
-    (`q` is the curve order, `L` and `LP` are constants in `TestSchemeParams`,
-    `P` is the number of parties).
-    This is `delta_i`, an additive share of the product of two secret values.
-
-    We need the final result to be `-N/2 < d < N/2`
-    (that is, it may be negative, and it cannot wrap around modulo N).
-
-    `N` is a product of two primes of the size `PRIME_BITS`, so `N > 2^(2 * PRIME_BITS - 2)`.
-    The upper bound on `log2(d)` is
-        max(2 * L, LP + 2) + ceil(log2(P))
-
-    Note in reality, due to numbers being random, the distribution will have a distinct peak,
-    and the upper bound will have a low probability of being reached.
-
-    Therefore we require `max(2 * L, LP + 2) + ceil(log2(P)) < 2 * PRIME_BITS - 2`.
-    For tests we assume `ceil(log2(P)) = 5` (we won't run tests with more than 32 nodes),
-    and since in `TestSchemeParams` `L = LP = 256`, this leads to `PRIME_BITS >= L + 4`.
-
-    For production it does not matter since both 2*L and LP are much smaller than 2*PRIME_BITS.
-
-    TODO: add an assertion for `SchemeParams` checking that?
-    */
-
-    const PRIME_BITS: usize = 260;
+    const PRIME_BITS: usize = 512;
     type HalfUint = U512;
     type HalfUintMod = U512Mod;
     type Uint = U1024;
@@ -83,18 +53,4 @@ impl PaillierParams for PaillierTest {
     type WideUint = U2048;
     type WideUintMod = U2048Mod;
     type ExtraWideUint = U4096;
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct PaillierProduction;
-
-impl PaillierParams for PaillierProduction {
-    const PRIME_BITS: usize = 1024;
-    type HalfUint = U1024;
-    type HalfUintMod = U1024Mod;
-    type Uint = U2048;
-    type UintMod = U2048Mod;
-    type WideUint = U4096;
-    type WideUintMod = U4096Mod;
-    type ExtraWideUint = U8192;
 }


### PR DESCRIPTION
Since the test Paillier params must have some values set to accommodate CGGMP requirements, which is out of scope of `paillier` submodule, they are now created in the same file as the `SchemeParameters` impls. The `paillier` submodule uses its own independent test params.

It would be nice to gate test parameters under a feature, but `cargo` currently does not support enabling a feature by default for integration tests (see https://github.com/rust-lang/cargo/issues/2911), and running integration tests with production parameters takes 10x more time - not too convenient for active development. 