### PR TITLE
Use an XOF instead of a PRNG to derive ZK proof challenges.

### DIFF
--- a/synedrion/Cargo.toml
+++ b/synedrion/Cargo.toml
@@ -18,7 +18,6 @@ sha3 = { version = "0.10", default-features = false }
 digest = { version = "0.10", default-features = false, features = ["alloc"]}
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 base64 = { version = "0.21", default-features = false, features = ["alloc"] }
-rand_chacha = { version = "0.3", default-features = false }
 
 crypto-bigint = { version = "0.5.3", features = ["serde"] }
 crypto-primes = "0.5"

--- a/synedrion/src/cggmp21/sigma/dec.rs
+++ b/synedrion/src/cggmp21/sigma/dec.rs
@@ -9,7 +9,7 @@ use crate::paillier::{
     Ciphertext, PaillierParams, PublicKeyPaillierPrecomputed, RPCommitment, RPParamsMod,
     Randomizer, RandomizerMod,
 };
-use crate::tools::hashing::{Chain, Hash, Hashable};
+use crate::tools::hashing::{Chain, Hashable, XofHash};
 use crate::uint::{FromScalar, NonZero, Signed};
 
 const HASH_TAG: &[u8] = b"P_dec";
@@ -34,10 +34,13 @@ impl<P: SchemeParams> DecProof<P> {
         aux_rp: &RPParamsMod<P::Paillier>,              // $\hat{N}$, $s$, $t$
         aux: &impl Hashable,
     ) -> Self {
-        let mut aux_rng = Hash::new_with_dst(HASH_TAG).chain(aux).finalize_to_rng();
+        let mut reader = XofHash::new_with_dst(HASH_TAG)
+            .chain(aux)
+            .finalize_to_reader();
 
         // Non-interactive challenge
-        let e = Signed::random_bounded(&mut aux_rng, &NonZero::new(P::CURVE_ORDER).unwrap());
+        let e =
+            Signed::from_xof_reader_bounded(&mut reader, &NonZero::new(P::CURVE_ORDER).unwrap());
 
         let hat_cap_n = &aux_rp.public_key().modulus_nonzero(); // $\hat{N}$
 
@@ -75,10 +78,13 @@ impl<P: SchemeParams> DecProof<P> {
         aux_rp: &RPParamsMod<P::Paillier>,              // $\hat{N}$, $s$, $t$
         aux: &impl Hashable,
     ) -> bool {
-        let mut aux_rng = Hash::new_with_dst(HASH_TAG).chain(aux).finalize_to_rng();
+        let mut reader = XofHash::new_with_dst(HASH_TAG)
+            .chain(aux)
+            .finalize_to_reader();
 
         // Non-interactive challenge
-        let e = Signed::random_bounded(&mut aux_rng, &NonZero::new(P::CURVE_ORDER).unwrap());
+        let e =
+            Signed::from_xof_reader_bounded(&mut reader, &NonZero::new(P::CURVE_ORDER).unwrap());
 
         // enc(z_1, \omega) == A (+) C (*) e
         if Ciphertext::new_with_randomizer_signed(pk, &self.z1, &self.omega)

--- a/synedrion/src/cggmp21/sigma/log_star.rs
+++ b/synedrion/src/cggmp21/sigma/log_star.rs
@@ -9,7 +9,7 @@ use crate::paillier::{
     Ciphertext, PaillierParams, PublicKeyPaillierPrecomputed, RPCommitment, RPParamsMod,
     Randomizer, RandomizerMod,
 };
-use crate::tools::hashing::{Chain, Hash, Hashable};
+use crate::tools::hashing::{Chain, Hashable, XofHash};
 use crate::uint::{FromScalar, NonZero, Signed};
 
 const HASH_TAG: &[u8] = b"P_log*";
@@ -36,10 +36,13 @@ impl<P: SchemeParams> LogStarProof<P> {
         aux_rp: &RPParamsMod<P::Paillier>,                 // $\hat{N}$, $s$, $t$
         aux: &impl Hashable,
     ) -> Self {
-        let mut aux_rng = Hash::new_with_dst(HASH_TAG).chain(aux).finalize_to_rng();
+        let mut reader = XofHash::new_with_dst(HASH_TAG)
+            .chain(aux)
+            .finalize_to_reader();
 
         // Non-interactive challenge
-        let e = Signed::random_bounded(&mut aux_rng, &NonZero::new(P::CURVE_ORDER).unwrap());
+        let e =
+            Signed::from_xof_reader_bounded(&mut reader, &NonZero::new(P::CURVE_ORDER).unwrap());
 
         let hat_cap_n = &aux_rp.public_key().modulus_nonzero(); // $\hat{N}$
 
@@ -78,10 +81,13 @@ impl<P: SchemeParams> LogStarProof<P> {
         aux_rp: &RPParamsMod<P::Paillier>, // $s$, $t$
         aux: &impl Hashable,
     ) -> bool {
-        let mut aux_rng = Hash::new_with_dst(HASH_TAG).chain(aux).finalize_to_rng();
+        let mut reader = XofHash::new_with_dst(HASH_TAG)
+            .chain(aux)
+            .finalize_to_reader();
 
         // Non-interactive challenge
-        let e = Signed::random_bounded(&mut aux_rng, &NonZero::new(P::CURVE_ORDER).unwrap());
+        let e =
+            Signed::from_xof_reader_bounded(&mut reader, &NonZero::new(P::CURVE_ORDER).unwrap());
 
         // enc_0(z1, z2) == A (+) C (*) e
         let c = Ciphertext::new_with_randomizer_signed(pk, &self.z1, &self.z2);

--- a/synedrion/src/cggmp21/sigma/mul_star.rs
+++ b/synedrion/src/cggmp21/sigma/mul_star.rs
@@ -11,7 +11,7 @@ use crate::paillier::{
     Ciphertext, PaillierParams, PublicKeyPaillierPrecomputed, RPCommitment, RPParamsMod,
     Randomizer, RandomizerMod,
 };
-use crate::tools::hashing::{Chain, Hash, Hashable};
+use crate::tools::hashing::{Chain, Hashable, XofHash};
 use crate::uint::{FromScalar, NonZero, Signed};
 
 const HASH_TAG: &[u8] = b"P_mul*";
@@ -46,10 +46,13 @@ impl<P: SchemeParams> MulStarProof<P> {
           (and judging by the condition the verifier checks, it should be == 0)
         */
 
-        let mut aux_rng = Hash::new_with_dst(HASH_TAG).chain(aux).finalize_to_rng();
+        let mut reader = XofHash::new_with_dst(HASH_TAG)
+            .chain(aux)
+            .finalize_to_reader();
 
         // Non-interactive challenge
-        let e = Signed::random_bounded(&mut aux_rng, &NonZero::new(P::CURVE_ORDER).unwrap());
+        let e =
+            Signed::from_xof_reader_bounded(&mut reader, &NonZero::new(P::CURVE_ORDER).unwrap());
 
         let hat_cap_n = &aux_rp.public_key().modulus_nonzero(); // $\hat{N}$
 
@@ -90,10 +93,13 @@ impl<P: SchemeParams> MulStarProof<P> {
         aux_rp: &RPParamsMod<P::Paillier>, // $\hat{N}$, $s$, $t$
         aux: &impl Hashable,
     ) -> bool {
-        let mut aux_rng = Hash::new_with_dst(HASH_TAG).chain(aux).finalize_to_rng();
+        let mut reader = XofHash::new_with_dst(HASH_TAG)
+            .chain(aux)
+            .finalize_to_reader();
 
         // Non-interactive challenge
-        let e = Signed::random_bounded(&mut aux_rng, &NonZero::new(P::CURVE_ORDER).unwrap());
+        let e =
+            Signed::from_xof_reader_bounded(&mut reader, &NonZero::new(P::CURVE_ORDER).unwrap());
 
         let aux_pk = aux_rp.public_key();
 


### PR DESCRIPTION
- This signals the intent better, and XOF implementations have better consistency guarantees. See https://crypto.stackexchange.com/questions/107631/what-is-the-difference-between-a-seeded-rng-and-an-xof-hash for some discussion.
- This fixes the issue with consistency between 32- and 64-bit targets. `crypto-bigint` currently produces a different stream of `Uint`s under certain conditions on 32- and 64-bit targets (see https://github.com/RustCrypto/crypto-bigint/pull/285 for the fix). This PR uses `UintLike::from_xof()` to generate challenges which creates `Uint`s directly from the XOF bytestream.