### PR TITLE
Add message preprocessing

### DIFF
--- a/synedrion/src/sessions/broadcast.rs
+++ b/synedrion/src/sessions/broadcast.rs
@@ -98,6 +98,12 @@ impl BcConsensusAccum {
         }
     }
 
+    pub fn contains(&self, party_idx: PartyIdx) -> bool {
+        self.received_echo_from
+            .contains(party_idx.as_usize())
+            .unwrap()
+    }
+
     pub fn add_echo_received(&mut self, from: PartyIdx) -> Option<()> {
         self.received_echo_from.insert(from.as_usize(), ())
     }

--- a/synedrion/src/sessions/type_erased.rs
+++ b/synedrion/src/sessions/type_erased.rs
@@ -236,6 +236,24 @@ impl DynRoundAccum {
         }
     }
 
+    pub fn contains(&self, from: PartyIdx, broadcast: bool) -> bool {
+        if broadcast {
+            return self
+                .bc_payloads
+                .as_ref()
+                .unwrap()
+                .contains(from.as_usize())
+                .unwrap();
+        } else {
+            return self
+                .dm_payloads
+                .as_ref()
+                .unwrap()
+                .contains(from.as_usize())
+                .unwrap();
+        }
+    }
+
     pub fn add_bc_payload(
         &mut self,
         from: PartyIdx,

--- a/synedrion/src/tools/collections.rs
+++ b/synedrion/src/tools/collections.rs
@@ -24,16 +24,24 @@ impl<T> HoleVecAccum<T> {
         Self { hole_at, elems }
     }
 
-    pub fn get_mut(&mut self, index: usize) -> Option<&mut Option<T>> {
-        if index == self.hole_at {
+    fn shifted_index(&self, index: usize) -> Option<usize> {
+        if index == self.hole_at || index > self.elems.len() {
             return None;
         }
-        let index = if index > self.hole_at {
+        Some(if index > self.hole_at {
             index - 1
         } else {
             index
-        };
-        self.elems.get_mut(index)
+        })
+    }
+
+    pub fn contains(&self, index: usize) -> Option<bool> {
+        Some(self.elems[self.shifted_index(index)?].is_some())
+    }
+
+    pub fn get_mut(&mut self, index: usize) -> Option<&mut Option<T>> {
+        let idx = self.shifted_index(index)?;
+        self.elems.get_mut(idx)
     }
 
     pub fn insert(&mut self, index: usize, value: T) -> Option<()> {


### PR DESCRIPTION
This eliminates some duplicate incoming message checks, eliminates task spawning for messages intended for the next round (they are now cached right away), and slightly reduces the complexity of the user API.

Some `unwrap()`s were added, to be removed in a big unwrap cleanup.