### PR TITLE
Return `Vec` in WASM bindings natively

### DIFF
--- a/synedrion-wasm/Cargo.toml
+++ b/synedrion-wasm/Cargo.toml
@@ -14,7 +14,7 @@ synedrion = { path = "../synedrion" }
 js-sys = "0.3.55"
 getrandom = { version = "0.2", features = ["js"] }
 rand_core = { version = "0.6.4", features = ["getrandom"] }
-wasm-bindgen = "0.2.85"
+wasm-bindgen = "0.2.88"
 wasm-bindgen-derive = "0.2"
 
 [dev-dependencies]

--- a/synedrion-wasm/src/lib.rs
+++ b/synedrion-wasm/src/lib.rs
@@ -7,7 +7,7 @@ use bincode::{
 };
 use js_sys::Error;
 use rand_core::OsRng;
-use wasm_bindgen::{prelude::wasm_bindgen, JsCast, JsValue};
+use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 use wasm_bindgen_derive::TryFromJsValue;
 
 use synedrion::TestParams;
@@ -19,9 +19,6 @@ const MAX_MSG_LEN: u64 = 1000 * 1000; // 1 MB
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(typescript_type = "KeyShare[]")]
-    pub type KeyShareArray;
-
     #[wasm_bindgen(typescript_type = "SigningKey | undefined")]
     pub type OptionalSigningKey;
 }
@@ -66,7 +63,7 @@ impl KeyShare {
     pub fn new_centralized(
         num_parties: usize,
         signing_key: &OptionalSigningKey,
-    ) -> Result<KeyShareArray, Error> {
+    ) -> Result<Vec<KeyShare>, Error> {
         let sk_js: &JsValue = signing_key.as_ref();
         let typed_sk: Option<SigningKey> = if sk_js.is_undefined() {
             None
@@ -81,13 +78,7 @@ impl KeyShare {
             num_parties,
             backend_sk.as_ref(),
         );
-        Ok(shares
-            .into_vec()
-            .into_iter()
-            .map(KeyShare)
-            .map(JsValue::from)
-            .collect::<js_sys::Array>()
-            .unchecked_into::<KeyShareArray>())
+        Ok(shares.into_vec().into_iter().map(KeyShare).collect())
     }
 }
 

--- a/synedrion-wasm/tests/wasm.rs
+++ b/synedrion-wasm/tests/wasm.rs
@@ -3,18 +3,6 @@ use wasm_bindgen_test::wasm_bindgen_test;
 
 use synedrion_wasm::{KeyShare, SigningKey};
 
-fn try_from_js_array<T>(val: impl Into<JsValue>) -> Vec<T>
-where
-    for<'a> T: TryFrom<&'a JsValue>,
-    for<'a> <T as TryFrom<&'a JsValue>>::Error: core::fmt::Debug,
-{
-    let js_array: js_sys::Array = val.into().dyn_into().unwrap();
-    js_array
-        .iter()
-        .map(|js| T::try_from(&js).unwrap())
-        .collect()
-}
-
 fn into_js_option<T, U>(val: Option<U>) -> T
 where
     JsValue: From<U>,
@@ -30,8 +18,7 @@ where
 #[wasm_bindgen_test]
 fn test_make_key_shares() {
     let sk: Option<SigningKey> = None;
-    let shares_js = KeyShare::new_centralized(3, &into_js_option(sk)).unwrap();
-    let shares = try_from_js_array::<KeyShare>(shares_js);
+    let shares: Vec<KeyShare> = KeyShare::new_centralized(3, &into_js_option(sk)).unwrap();
     let _shares_serialized = shares
         .iter()
         .map(|share| share.to_bytes())


### PR DESCRIPTION
Since `wasm-bindgen` 0.2.88 we don't need to go through `wasm-bindgen-derive` anymore. Unfortunately, `Option` is still not supported.