### PR TITLE
Implement a key resharing protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.2.0] - In development
+
+### Added
+
+- A basic implementation of threshold key resharing protocol. ([#96])
+
+
+[#96]: https://github.com/entropyxyz/synedrion/pull/96
+
+
 ## [0.1.0] - 2023-12-07
 
 Initial release.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The initial state for each protocol is instantiated by calling a function from t
 Note that the order of the verifiers corresponds to the order of parties in the [`KeyShare`](https://docs.rs/synedrion/latest/synedrion/struct.KeyShare.html) object. That is, if you are executing a KeyGen protocol, the returned `KeyShare` will have shares in the order of the given `verifiers`, and if you are executing a KeyRefresh or InteractiveSigning protocol (which take a `KeyShare` as one of the inputs), the order of the shares in the used `KeyShare` must match the order in `verifiers`.
 
 After the initial state is created, it goes through several rounds, in each of which it is used to create outgoing messages, verify and process the incoming messages, and finalize the round, creating a new state or the result. This would typically happen in a loop:
-```rust
+```ignore
 // <<< `session` was created by one of the constructors >>>
 
 let mut session = session;

--- a/synedrion/src/cggmp21/protocols.rs
+++ b/synedrion/src/cggmp21/protocols.rs
@@ -4,6 +4,7 @@ pub(crate) mod interactive_signing;
 pub(crate) mod key_gen;
 pub(crate) mod key_init;
 pub(crate) mod key_refresh;
+pub(crate) mod key_resharing;
 pub(crate) mod presigning;
 pub(crate) mod signing;
 mod threshold;

--- a/synedrion/src/cggmp21/protocols.rs
+++ b/synedrion/src/cggmp21/protocols.rs
@@ -20,7 +20,7 @@ pub(crate) mod test_utils;
 #[cfg(feature = "bench-internals")]
 pub(crate) use common::PresigningData;
 
-pub use common::{KeyShare, KeyShareChange, KeyShareSeed, PartyIdx};
+pub use common::{KeyShare, KeyShareChange, PartyIdx};
 pub use generic::ProtocolResult;
 pub use interactive_signing::{
     InteractiveSigningError, InteractiveSigningProof, InteractiveSigningResult,

--- a/synedrion/src/cggmp21/protocols/generic.rs
+++ b/synedrion/src/cggmp21/protocols/generic.rs
@@ -1,4 +1,5 @@
 use alloc::string::String;
+use alloc::vec::Vec;
 use core::fmt::Debug;
 
 use rand_core::CryptoRngCore;
@@ -20,7 +21,7 @@ pub(crate) trait BroadcastRound: BaseRound {
 
     /// The indices of the parties that should receive the broadcast,
     /// or `None` if this round does not send any broadcasts.
-    fn broadcast_destinations(&self) -> Option<HoleRange> {
+    fn broadcast_destinations(&self) -> Option<Vec<PartyIdx>> {
         None
     }
 
@@ -55,7 +56,7 @@ pub(crate) trait DirectRound: BaseRound {
 
     /// The indices of the parties that should receive the direct messages,
     /// or `None` if this round does not send any direct messages.
-    fn direct_message_destinations(&self) -> Option<HoleRange> {
+    fn direct_message_destinations(&self) -> Option<Vec<PartyIdx>> {
         None
     }
 
@@ -169,4 +170,10 @@ pub(crate) trait FirstRound: Round + Sized {
         party_idx: PartyIdx,
         context: Self::Context,
     ) -> Result<Self, InitError>;
+}
+
+pub(crate) fn all_parties_except(num_parties: usize, party_idx: PartyIdx) -> Vec<PartyIdx> {
+    HoleRange::new(num_parties, party_idx.as_usize())
+        .map(PartyIdx::from_usize)
+        .collect()
 }

--- a/synedrion/src/cggmp21/protocols/generic.rs
+++ b/synedrion/src/cggmp21/protocols/generic.rs
@@ -126,6 +126,7 @@ pub(crate) enum FinalizationRequirement {
     AllBroadcasts,
     AllDms,
     AllBroadcastsAndDms,
+    Custom,
 }
 
 pub(crate) trait Finalizable: BroadcastRound + DirectRound {
@@ -150,6 +151,7 @@ pub(crate) trait Finalizable: BroadcastRound + DirectRound {
                     && contains_all_except(dm_payloads, self.num_parties(), self.party_idx())
                     && contains_all_except(dm_artifacts, self.num_parties(), self.party_idx())
             }
+            FinalizationRequirement::Custom => panic!("`can_finalize` must be implemented"),
         }
     }
 
@@ -188,6 +190,7 @@ pub(crate) trait Finalizable: BroadcastRound + DirectRound {
                 ));
                 missing
             }
+            FinalizationRequirement::Custom => panic!("`missing_payloads` must be implemented"),
         }
     }
 }

--- a/synedrion/src/cggmp21/protocols/generic.rs
+++ b/synedrion/src/cggmp21/protocols/generic.rs
@@ -1,3 +1,4 @@
+use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt::Debug;
@@ -6,7 +7,7 @@ use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
 
 use super::common::PartyIdx;
-use crate::tools::collections::{HoleRange, HoleVec};
+use crate::tools::collections::{HoleRange, HoleVec, HoleVecAccum};
 
 /// A round that sends out a broadcast.
 pub(crate) trait BroadcastRound: BaseRound {
@@ -111,19 +112,93 @@ pub(crate) trait BaseRound {
     const ROUND_NUM: u8;
     // TODO (#78): find a way to derive it from `ROUND_NUM`
     const NEXT_ROUND_NUM: Option<u8>;
+
+    fn num_parties(&self) -> usize;
+    fn party_idx(&self) -> PartyIdx;
 }
 
-pub(crate) trait Round: BroadcastRound + DirectRound + BaseRound {}
+pub(crate) trait Round: BroadcastRound + DirectRound + BaseRound + Finalizable {}
 
-impl<R: BroadcastRound + DirectRound + BaseRound> Round for R {}
+impl<R: BroadcastRound + DirectRound + BaseRound + Finalizable> Round for R {}
+
+#[allow(clippy::enum_variant_names)]
+pub(crate) enum FinalizationRequirement {
+    AllBroadcasts,
+    AllDms,
+    AllBroadcastsAndDms,
+}
+
+pub(crate) trait Finalizable: BroadcastRound + DirectRound {
+    fn requirement() -> FinalizationRequirement;
+
+    fn can_finalize<'a>(
+        &self,
+        bc_payloads: impl Iterator<Item = &'a PartyIdx>,
+        dm_payloads: impl Iterator<Item = &'a PartyIdx>,
+        dm_artifacts: impl Iterator<Item = &'a PartyIdx>,
+    ) -> bool {
+        match Self::requirement() {
+            FinalizationRequirement::AllBroadcasts => {
+                contains_all_except(bc_payloads, self.num_parties(), self.party_idx())
+            }
+            FinalizationRequirement::AllDms => {
+                contains_all_except(dm_payloads, self.num_parties(), self.party_idx())
+                    && contains_all_except(dm_artifacts, self.num_parties(), self.party_idx())
+            }
+            FinalizationRequirement::AllBroadcastsAndDms => {
+                contains_all_except(bc_payloads, self.num_parties(), self.party_idx())
+                    && contains_all_except(dm_payloads, self.num_parties(), self.party_idx())
+                    && contains_all_except(dm_artifacts, self.num_parties(), self.party_idx())
+            }
+        }
+    }
+
+    fn missing_payloads<'a>(
+        &self,
+        bc_payloads: impl Iterator<Item = &'a PartyIdx>,
+        dm_payloads: impl Iterator<Item = &'a PartyIdx>,
+        dm_artifacts: impl Iterator<Item = &'a PartyIdx>,
+    ) -> BTreeSet<PartyIdx> {
+        match Self::requirement() {
+            FinalizationRequirement::AllBroadcasts => {
+                missing_payloads(bc_payloads, self.num_parties(), self.party_idx())
+            }
+            FinalizationRequirement::AllDms => {
+                let mut missing =
+                    missing_payloads(dm_payloads, self.num_parties(), self.party_idx());
+                missing.append(&mut missing_payloads(
+                    dm_artifacts,
+                    self.num_parties(),
+                    self.party_idx(),
+                ));
+                missing
+            }
+            FinalizationRequirement::AllBroadcastsAndDms => {
+                let mut missing =
+                    missing_payloads(bc_payloads, self.num_parties(), self.party_idx());
+                missing.append(&mut missing_payloads(
+                    dm_payloads,
+                    self.num_parties(),
+                    self.party_idx(),
+                ));
+                missing.append(&mut missing_payloads(
+                    dm_artifacts,
+                    self.num_parties(),
+                    self.party_idx(),
+                ));
+                missing
+            }
+        }
+    }
+}
 
 pub(crate) trait FinalizableToResult: Round + BaseRound<Type = ToResult> {
     fn finalize_to_result(
         self,
         rng: &mut impl CryptoRngCore,
-        bc_payloads: Option<HoleVec<<Self as BroadcastRound>::Payload>>,
-        dm_payloads: Option<HoleVec<<Self as DirectRound>::Payload>>,
-        dm_artifacts: Option<HoleVec<<Self as DirectRound>::Artifact>>,
+        bc_payloads: BTreeMap<PartyIdx, <Self as BroadcastRound>::Payload>,
+        dm_payloads: BTreeMap<PartyIdx, <Self as DirectRound>::Payload>,
+        dm_artifacts: BTreeMap<PartyIdx, <Self as DirectRound>::Artifact>,
     ) -> Result<<Self::Result as ProtocolResult>::Success, FinalizeError<Self::Result>>;
 }
 
@@ -132,9 +207,9 @@ pub(crate) trait FinalizableToNextRound: Round + BaseRound<Type = ToNextRound> {
     fn finalize_to_next_round(
         self,
         rng: &mut impl CryptoRngCore,
-        bc_payloads: Option<HoleVec<<Self as BroadcastRound>::Payload>>,
-        dm_payloads: Option<HoleVec<<Self as DirectRound>::Payload>>,
-        dm_artifacts: Option<HoleVec<<Self as DirectRound>::Artifact>>,
+        bc_payloads: BTreeMap<PartyIdx, <Self as BroadcastRound>::Payload>,
+        dm_payloads: BTreeMap<PartyIdx, <Self as DirectRound>::Payload>,
+        dm_artifacts: BTreeMap<PartyIdx, <Self as DirectRound>::Artifact>,
     ) -> Result<Self::NextRound, FinalizeError<Self::Result>>;
 }
 
@@ -176,4 +251,46 @@ pub(crate) fn all_parties_except(num_parties: usize, party_idx: PartyIdx) -> Vec
     HoleRange::new(num_parties, party_idx.as_usize())
         .map(PartyIdx::from_usize)
         .collect()
+}
+
+fn contains_all_except<'a>(
+    party_idxs: impl Iterator<Item = &'a PartyIdx>,
+    num_parties: usize,
+    party_idx: PartyIdx,
+) -> bool {
+    let set = party_idxs.cloned().collect::<BTreeSet<_>>();
+    for idx in HoleRange::new(num_parties, party_idx.as_usize()) {
+        if !set.contains(&PartyIdx::from_usize(idx)) {
+            return false;
+        }
+    }
+    true
+}
+
+fn missing_payloads<'a>(
+    party_idxs: impl Iterator<Item = &'a PartyIdx>,
+    num_parties: usize,
+    party_idx: PartyIdx,
+) -> BTreeSet<PartyIdx> {
+    let set = party_idxs.cloned().collect::<BTreeSet<_>>();
+    let mut missing = BTreeSet::new();
+    for idx in HoleRange::new(num_parties, party_idx.as_usize()) {
+        let party_idx = PartyIdx::from_usize(idx);
+        if !set.contains(&party_idx) {
+            missing.insert(party_idx);
+        }
+    }
+    missing
+}
+
+pub(crate) fn try_to_holevec<T>(
+    payloads: BTreeMap<PartyIdx, T>,
+    num_parties: usize,
+    party_idx: PartyIdx,
+) -> Option<HoleVec<T>> {
+    let mut accum = HoleVecAccum::new(num_parties, party_idx.as_usize());
+    for (idx, elem) in payloads.into_iter() {
+        accum.insert(idx.as_usize(), elem)?;
+    }
+    accum.finalize()
 }

--- a/synedrion/src/cggmp21/protocols/interactive_signing.rs
+++ b/synedrion/src/cggmp21/protocols/interactive_signing.rs
@@ -1,4 +1,5 @@
 use alloc::boxed::Box;
+use alloc::collections::BTreeMap;
 use core::marker::PhantomData;
 
 use rand_core::CryptoRngCore;
@@ -13,7 +14,6 @@ use super::signing::{self, SigningResult};
 use super::wrappers::{wrap_finalize_error, ResultWrapper, RoundWrapper};
 use crate::cggmp21::params::SchemeParams;
 use crate::curve::{RecoverableSignature, Scalar};
-use crate::tools::collections::HoleVec;
 
 /// Possible results of the merged Presigning and Signing protocols.
 #[derive(Debug, Clone, Copy)]
@@ -127,9 +127,9 @@ impl<P: SchemeParams> FinalizableToNextRound for Round1<P> {
     fn finalize_to_next_round(
         self,
         rng: &mut impl CryptoRngCore,
-        bc_payloads: Option<HoleVec<<Self as BroadcastRound>::Payload>>,
-        dm_payloads: Option<HoleVec<<Self as DirectRound>::Payload>>,
-        dm_artifacts: Option<HoleVec<<Self as DirectRound>::Artifact>>,
+        bc_payloads: BTreeMap<PartyIdx, <Self as BroadcastRound>::Payload>,
+        dm_payloads: BTreeMap<PartyIdx, <Self as DirectRound>::Payload>,
+        dm_artifacts: BTreeMap<PartyIdx, <Self as DirectRound>::Artifact>,
     ) -> Result<Self::NextRound, FinalizeError<Self::Result>> {
         let round = self
             .round
@@ -163,9 +163,9 @@ impl<P: SchemeParams> FinalizableToNextRound for Round2<P> {
     fn finalize_to_next_round(
         self,
         rng: &mut impl CryptoRngCore,
-        bc_payloads: Option<HoleVec<<Self as BroadcastRound>::Payload>>,
-        dm_payloads: Option<HoleVec<<Self as DirectRound>::Payload>>,
-        dm_artifacts: Option<HoleVec<<Self as DirectRound>::Artifact>>,
+        bc_payloads: BTreeMap<PartyIdx, <Self as BroadcastRound>::Payload>,
+        dm_payloads: BTreeMap<PartyIdx, <Self as DirectRound>::Payload>,
+        dm_artifacts: BTreeMap<PartyIdx, <Self as DirectRound>::Artifact>,
     ) -> Result<Self::NextRound, FinalizeError<Self::Result>> {
         let round = self
             .round
@@ -199,9 +199,9 @@ impl<P: SchemeParams> FinalizableToNextRound for Round3<P> {
     fn finalize_to_next_round(
         self,
         rng: &mut impl CryptoRngCore,
-        bc_payloads: Option<HoleVec<<Self as BroadcastRound>::Payload>>,
-        dm_payloads: Option<HoleVec<<Self as DirectRound>::Payload>>,
-        dm_artifacts: Option<HoleVec<<Self as DirectRound>::Artifact>>,
+        bc_payloads: BTreeMap<PartyIdx, <Self as BroadcastRound>::Payload>,
+        dm_payloads: BTreeMap<PartyIdx, <Self as DirectRound>::Payload>,
+        dm_artifacts: BTreeMap<PartyIdx, <Self as DirectRound>::Artifact>,
     ) -> Result<Self::NextRound, FinalizeError<Self::Result>> {
         let presigning_data = self
             .round
@@ -250,9 +250,9 @@ impl<P: SchemeParams> FinalizableToResult for Round4<P> {
     fn finalize_to_result(
         self,
         rng: &mut impl CryptoRngCore,
-        bc_payloads: Option<HoleVec<<Self as BroadcastRound>::Payload>>,
-        dm_payloads: Option<HoleVec<<Self as DirectRound>::Payload>>,
-        dm_artifacts: Option<HoleVec<<Self as DirectRound>::Artifact>>,
+        bc_payloads: BTreeMap<PartyIdx, <Self as BroadcastRound>::Payload>,
+        dm_payloads: BTreeMap<PartyIdx, <Self as DirectRound>::Payload>,
+        dm_artifacts: BTreeMap<PartyIdx, <Self as DirectRound>::Artifact>,
     ) -> Result<<Self::Result as ProtocolResult>::Success, FinalizeError<Self::Result>> {
         self.round
             .finalize_to_result(rng, bc_payloads, dm_payloads, dm_artifacts)

--- a/synedrion/src/cggmp21/protocols/key_gen.rs
+++ b/synedrion/src/cggmp21/protocols/key_gen.rs
@@ -2,6 +2,7 @@
 //! Since both take three rounds and are independent, we can execute them in parallel.
 
 use alloc::string::String;
+use alloc::vec::Vec;
 use core::marker::PhantomData;
 
 use rand_core::CryptoRngCore;
@@ -16,7 +17,7 @@ use super::key_init::{self, KeyInitResult};
 use super::key_refresh::{self, KeyRefreshResult};
 use super::wrappers::{wrap_finalize_error, wrap_receive_error, ResultWrapper};
 use crate::cggmp21::SchemeParams;
-use crate::tools::collections::{HoleRange, HoleVec};
+use crate::tools::collections::HoleVec;
 
 /// Possible results of the merged KeyGen and KeyRefresh protocols.
 #[derive(Debug, Clone, Copy)]
@@ -124,7 +125,7 @@ impl<P: SchemeParams> BroadcastRound for Round1<P> {
         <key_init::Round1<P> as BroadcastRound>::Payload,
         <key_refresh::Round1<P> as BroadcastRound>::Payload,
     );
-    fn broadcast_destinations(&self) -> Option<HoleRange> {
+    fn broadcast_destinations(&self) -> Option<Vec<PartyIdx>> {
         let key_init_dest = self.key_init_round.broadcast_destinations();
         let key_refresh_dest = self.key_refresh_round.broadcast_destinations();
         assert!(key_init_dest == key_refresh_dest);
@@ -226,7 +227,7 @@ impl<P: SchemeParams> BroadcastRound for Round2<P> {
         <key_refresh::Round2<P> as BroadcastRound>::Payload,
     );
 
-    fn broadcast_destinations(&self) -> Option<HoleRange> {
+    fn broadcast_destinations(&self) -> Option<Vec<PartyIdx>> {
         let key_init_dest = self.key_init_round.broadcast_destinations();
         let key_refresh_dest = self.key_refresh_round.broadcast_destinations();
         assert!(key_init_dest == key_refresh_dest);
@@ -311,7 +312,7 @@ impl<P: SchemeParams> BroadcastRound for Round3<P> {
     type Message = <key_init::Round3<P> as BroadcastRound>::Message;
     type Payload = <key_init::Round3<P> as BroadcastRound>::Payload;
 
-    fn broadcast_destinations(&self) -> Option<HoleRange> {
+    fn broadcast_destinations(&self) -> Option<Vec<PartyIdx>> {
         self.key_init_round.broadcast_destinations()
     }
     fn make_broadcast(&self, rng: &mut impl CryptoRngCore) -> Result<Self::Message, String> {
@@ -334,7 +335,7 @@ impl<P: SchemeParams> DirectRound for Round3<P> {
     type Message = <key_refresh::Round3<P> as DirectRound>::Message;
     type Payload = <key_refresh::Round3<P> as DirectRound>::Payload;
 
-    fn direct_message_destinations(&self) -> Option<HoleRange> {
+    fn direct_message_destinations(&self) -> Option<Vec<PartyIdx>> {
         self.key_refresh_round.direct_message_destinations()
     }
     fn make_direct_message(

--- a/synedrion/src/cggmp21/protocols/key_init.rs
+++ b/synedrion/src/cggmp21/protocols/key_init.rs
@@ -4,6 +4,7 @@
 
 use alloc::boxed::Box;
 use alloc::string::String;
+use alloc::vec::Vec;
 use core::marker::PhantomData;
 
 use rand_core::CryptoRngCore;
@@ -11,15 +12,16 @@ use serde::{Deserialize, Serialize};
 
 use super::common::{KeyShareSeed, PartyIdx};
 use super::generic::{
-    BaseRound, BroadcastRound, DirectRound, FinalizableToNextRound, FinalizableToResult,
-    FinalizeError, FirstRound, InitError, ProtocolResult, ReceiveError, ToNextRound, ToResult,
+    all_parties_except, BaseRound, BroadcastRound, DirectRound, FinalizableToNextRound,
+    FinalizableToResult, FinalizeError, FirstRound, InitError, ProtocolResult, ReceiveError,
+    ToNextRound, ToResult,
 };
 use crate::cggmp21::{
     sigma::{SchCommitment, SchProof, SchSecret},
     SchemeParams,
 };
 use crate::curve::{Point, Scalar};
-use crate::tools::collections::{HoleRange, HoleVec};
+use crate::tools::collections::HoleVec;
 use crate::tools::hashing::{Chain, Hash, HashOutput, Hashable};
 use crate::tools::random::random_bits;
 use crate::tools::serde_bytes;
@@ -147,10 +149,10 @@ impl<P: SchemeParams> BroadcastRound for Round1<P> {
     type Message = Round1Bcast;
     type Payload = HashOutput;
 
-    fn broadcast_destinations(&self) -> Option<HoleRange> {
-        Some(HoleRange::new(
+    fn broadcast_destinations(&self) -> Option<Vec<PartyIdx>> {
+        Some(all_parties_except(
             self.context.num_parties,
-            self.context.party_idx.as_usize(),
+            self.context.party_idx,
         ))
     }
     fn make_broadcast(&self, _rng: &mut impl CryptoRngCore) -> Result<Self::Message, String> {
@@ -217,10 +219,10 @@ impl<P: SchemeParams> BroadcastRound for Round2<P> {
     type Message = Round2Bcast;
     type Payload = FullData;
 
-    fn broadcast_destinations(&self) -> Option<HoleRange> {
-        Some(HoleRange::new(
+    fn broadcast_destinations(&self) -> Option<Vec<PartyIdx>> {
+        Some(all_parties_except(
             self.context.num_parties,
-            self.context.party_idx.as_usize(),
+            self.context.party_idx,
         ))
     }
     fn make_broadcast(&self, _rng: &mut impl CryptoRngCore) -> Result<Self::Message, String> {
@@ -303,10 +305,10 @@ impl<P: SchemeParams> BroadcastRound for Round3<P> {
     type Message = Round3Bcast;
     type Payload = ();
 
-    fn broadcast_destinations(&self) -> Option<HoleRange> {
-        Some(HoleRange::new(
+    fn broadcast_destinations(&self) -> Option<Vec<PartyIdx>> {
+        Some(all_parties_except(
             self.context.num_parties,
-            self.context.party_idx.as_usize(),
+            self.context.party_idx,
         ))
     }
 

--- a/synedrion/src/cggmp21/protocols/key_init.rs
+++ b/synedrion/src/cggmp21/protocols/key_init.rs
@@ -3,6 +3,7 @@
 //! auxiliary parameters need to be generated as well (during the KeyRefresh protocol).
 
 use alloc::boxed::Box;
+use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
@@ -12,9 +13,9 @@ use serde::{Deserialize, Serialize};
 
 use super::common::{KeyShareSeed, PartyIdx};
 use super::generic::{
-    all_parties_except, BaseRound, BroadcastRound, DirectRound, FinalizableToNextRound,
-    FinalizableToResult, FinalizeError, FirstRound, InitError, ProtocolResult, ReceiveError,
-    ToNextRound, ToResult,
+    all_parties_except, try_to_holevec, BaseRound, BroadcastRound, DirectRound, Finalizable,
+    FinalizableToNextRound, FinalizableToResult, FinalizationRequirement, FinalizeError,
+    FirstRound, InitError, ProtocolResult, ReceiveError, ToNextRound, ToResult,
 };
 use crate::cggmp21::{
     sigma::{SchCommitment, SchProof, SchSecret},
@@ -142,6 +143,14 @@ impl<P: SchemeParams> BaseRound for Round1<P> {
     type Result = KeyInitResult;
     const ROUND_NUM: u8 = 1;
     const NEXT_ROUND_NUM: Option<u8> = Some(2);
+
+    fn num_parties(&self) -> usize {
+        self.context.num_parties
+    }
+
+    fn party_idx(&self) -> PartyIdx {
+        self.context.party_idx
+    }
 }
 
 impl<P: SchemeParams> BroadcastRound for Round1<P> {
@@ -150,16 +159,13 @@ impl<P: SchemeParams> BroadcastRound for Round1<P> {
     type Payload = HashOutput;
 
     fn broadcast_destinations(&self) -> Option<Vec<PartyIdx>> {
-        Some(all_parties_except(
-            self.context.num_parties,
-            self.context.party_idx,
-        ))
+        Some(all_parties_except(self.num_parties(), self.party_idx()))
     }
     fn make_broadcast(&self, _rng: &mut impl CryptoRngCore) -> Result<Self::Message, String> {
         let hash = self
             .context
             .data
-            .hash(&self.context.shared_randomness, self.context.party_idx);
+            .hash(&self.context.shared_randomness, self.party_idx());
         Ok(Round1Bcast { hash })
     }
     fn verify_broadcast(
@@ -177,19 +183,28 @@ impl<P: SchemeParams> DirectRound for Round1<P> {
     type Artifact = ();
 }
 
+impl<P: SchemeParams> Finalizable for Round1<P> {
+    fn requirement() -> FinalizationRequirement {
+        FinalizationRequirement::AllBroadcasts
+    }
+}
+
 impl<P: SchemeParams> FinalizableToNextRound for Round1<P> {
     type NextRound = Round2<P>;
     fn finalize_to_next_round(
         self,
         _rng: &mut impl CryptoRngCore,
-        bc_payloads: Option<HoleVec<<Self as BroadcastRound>::Payload>>,
-        dm_payloads: Option<HoleVec<<Self as DirectRound>::Payload>>,
-        dm_artifacts: Option<HoleVec<<Self as DirectRound>::Artifact>>,
+        bc_payloads: BTreeMap<PartyIdx, <Self as BroadcastRound>::Payload>,
+        _dm_payloads: BTreeMap<PartyIdx, <Self as DirectRound>::Payload>,
+        _dm_artifacts: BTreeMap<PartyIdx, <Self as DirectRound>::Artifact>,
     ) -> Result<Self::NextRound, FinalizeError<Self::Result>> {
-        assert!(dm_payloads.is_none());
-        assert!(dm_artifacts.is_none());
         Ok(Round2 {
-            hashes: bc_payloads.unwrap(),
+            hashes: try_to_holevec(
+                bc_payloads,
+                self.context.num_parties,
+                self.context.party_idx,
+            )
+            .unwrap(),
             context: self.context,
             phantom: PhantomData,
         })
@@ -212,6 +227,14 @@ impl<P: SchemeParams> BaseRound for Round2<P> {
     type Result = KeyInitResult;
     const ROUND_NUM: u8 = 2;
     const NEXT_ROUND_NUM: Option<u8> = Some(3);
+
+    fn num_parties(&self) -> usize {
+        self.context.num_parties
+    }
+
+    fn party_idx(&self) -> PartyIdx {
+        self.context.party_idx
+    }
 }
 
 impl<P: SchemeParams> BroadcastRound for Round2<P> {
@@ -220,10 +243,7 @@ impl<P: SchemeParams> BroadcastRound for Round2<P> {
     type Payload = FullData;
 
     fn broadcast_destinations(&self) -> Option<Vec<PartyIdx>> {
-        Some(all_parties_except(
-            self.context.num_parties,
-            self.context.party_idx,
-        ))
+        Some(all_parties_except(self.num_parties(), self.party_idx()))
     }
     fn make_broadcast(&self, _rng: &mut impl CryptoRngCore) -> Result<Self::Message, String> {
         Ok(Round2Bcast {
@@ -251,18 +271,27 @@ impl<P: SchemeParams> DirectRound for Round2<P> {
     type Artifact = ();
 }
 
+impl<P: SchemeParams> Finalizable for Round2<P> {
+    fn requirement() -> FinalizationRequirement {
+        FinalizationRequirement::AllBroadcasts
+    }
+}
+
 impl<P: SchemeParams> FinalizableToNextRound for Round2<P> {
     type NextRound = Round3<P>;
     fn finalize_to_next_round(
         self,
         _rng: &mut impl CryptoRngCore,
-        bc_payloads: Option<HoleVec<<Self as BroadcastRound>::Payload>>,
-        dm_payloads: Option<HoleVec<<Self as DirectRound>::Payload>>,
-        dm_artifacts: Option<HoleVec<<Self as DirectRound>::Artifact>>,
+        bc_payloads: BTreeMap<PartyIdx, <Self as BroadcastRound>::Payload>,
+        _dm_payloads: BTreeMap<PartyIdx, <Self as DirectRound>::Payload>,
+        _dm_artifacts: BTreeMap<PartyIdx, <Self as DirectRound>::Artifact>,
     ) -> Result<Self::NextRound, FinalizeError<Self::Result>> {
-        assert!(dm_payloads.is_none());
-        assert!(dm_artifacts.is_none());
-        let bc_payloads = bc_payloads.unwrap();
+        let bc_payloads = try_to_holevec(
+            bc_payloads,
+            self.context.num_parties,
+            self.context.party_idx,
+        )
+        .unwrap();
         // XOR the vectors together
         // TODO (#61): is there a better way?
         let mut rid = self.context.data.rid.clone();
@@ -298,6 +327,14 @@ impl<P: SchemeParams> BaseRound for Round3<P> {
     type Result = KeyInitResult;
     const ROUND_NUM: u8 = 3;
     const NEXT_ROUND_NUM: Option<u8> = None;
+
+    fn num_parties(&self) -> usize {
+        self.context.num_parties
+    }
+
+    fn party_idx(&self) -> PartyIdx {
+        self.context.party_idx
+    }
 }
 
 impl<P: SchemeParams> BroadcastRound for Round3<P> {
@@ -306,16 +343,13 @@ impl<P: SchemeParams> BroadcastRound for Round3<P> {
     type Payload = ();
 
     fn broadcast_destinations(&self) -> Option<Vec<PartyIdx>> {
-        Some(all_parties_except(
-            self.context.num_parties,
-            self.context.party_idx,
-        ))
+        Some(all_parties_except(self.num_parties(), self.party_idx()))
     }
 
     fn make_broadcast(&self, _rng: &mut impl CryptoRngCore) -> Result<Self::Message, String> {
         let aux = (
             &self.context.shared_randomness,
-            &self.context.party_idx,
+            &self.party_idx(),
             &self.rid,
         );
         let proof = SchProof::new(
@@ -352,16 +386,20 @@ impl<P: SchemeParams> DirectRound for Round3<P> {
     type Artifact = ();
 }
 
+impl<P: SchemeParams> Finalizable for Round3<P> {
+    fn requirement() -> FinalizationRequirement {
+        FinalizationRequirement::AllBroadcasts
+    }
+}
+
 impl<P: SchemeParams> FinalizableToResult for Round3<P> {
     fn finalize_to_result(
         self,
         _rng: &mut impl CryptoRngCore,
-        _bc_payloads: Option<HoleVec<<Self as BroadcastRound>::Payload>>,
-        dm_payloads: Option<HoleVec<<Self as DirectRound>::Payload>>,
-        dm_artifacts: Option<HoleVec<<Self as DirectRound>::Artifact>>,
+        _bc_payloads: BTreeMap<PartyIdx, <Self as BroadcastRound>::Payload>,
+        _dm_payloads: BTreeMap<PartyIdx, <Self as DirectRound>::Payload>,
+        _dm_artifacts: BTreeMap<PartyIdx, <Self as DirectRound>::Artifact>,
     ) -> Result<<Self::Result as ProtocolResult>::Success, FinalizeError<Self::Result>> {
-        assert!(dm_payloads.is_none());
-        assert!(dm_artifacts.is_none());
         let datas = self.datas.into_vec(self.context.data);
         let public_keys = datas.into_iter().map(|data| data.public).collect();
         Ok(KeyShareSeed {

--- a/synedrion/src/cggmp21/protocols/key_refresh.rs
+++ b/synedrion/src/cggmp21/protocols/key_refresh.rs
@@ -12,8 +12,9 @@ use serde::{Deserialize, Serialize};
 
 use super::common::{KeyShareChange, PartyIdx, PublicAuxInfo, SecretAuxInfo};
 use super::generic::{
-    BaseRound, BroadcastRound, DirectRound, FinalizableToNextRound, FinalizableToResult,
-    FinalizeError, FirstRound, InitError, ProtocolResult, ReceiveError, ToNextRound, ToResult,
+    all_parties_except, BaseRound, BroadcastRound, DirectRound, FinalizableToNextRound,
+    FinalizableToResult, FinalizeError, FirstRound, InitError, ProtocolResult, ReceiveError,
+    ToNextRound, ToResult,
 };
 use crate::cggmp21::{
     sigma::{FacProof, ModProof, PrmProof, SchCommitment, SchProof, SchSecret},
@@ -24,7 +25,7 @@ use crate::paillier::{
     Ciphertext, PaillierParams, PublicKeyPaillier, PublicKeyPaillierPrecomputed, RPParams,
     RPParamsMod, RPSecret, Randomizer, SecretKeyPaillier, SecretKeyPaillierPrecomputed,
 };
-use crate::tools::collections::{HoleRange, HoleVec};
+use crate::tools::collections::HoleVec;
 use crate::tools::hashing::{Chain, Hash, HashOutput, Hashable};
 use crate::tools::random::random_bits;
 use crate::tools::serde_bytes;
@@ -230,10 +231,10 @@ impl<P: SchemeParams> BroadcastRound for Round1<P> {
     type Message = Round1Bcast;
     type Payload = HashOutput;
 
-    fn broadcast_destinations(&self) -> Option<HoleRange> {
-        Some(HoleRange::new(
+    fn broadcast_destinations(&self) -> Option<Vec<PartyIdx>> {
+        Some(all_parties_except(
             self.context.num_parties,
-            self.context.party_idx.as_usize(),
+            self.context.party_idx,
         ))
     }
 
@@ -304,10 +305,10 @@ impl<P: SchemeParams> BroadcastRound for Round2<P> {
     type Message = Round2Bcast<P>;
     type Payload = FullDataPrecomp<P>;
 
-    fn broadcast_destinations(&self) -> Option<HoleRange> {
-        Some(HoleRange::new(
+    fn broadcast_destinations(&self) -> Option<Vec<PartyIdx>> {
+        Some(all_parties_except(
             self.context.num_parties,
-            self.context.party_idx.as_usize(),
+            self.context.party_idx,
         ))
     }
 
@@ -462,10 +463,10 @@ impl<P: SchemeParams> DirectRound for Round3<P> {
     type Payload = Scalar;
     type Artifact = ();
 
-    fn direct_message_destinations(&self) -> Option<HoleRange> {
-        Some(HoleRange::new(
+    fn direct_message_destinations(&self) -> Option<Vec<PartyIdx>> {
+        Some(all_parties_except(
             self.context.num_parties,
-            self.context.party_idx.as_usize(),
+            self.context.party_idx,
         ))
     }
 

--- a/synedrion/src/cggmp21/protocols/key_resharing.rs
+++ b/synedrion/src/cggmp21/protocols/key_resharing.rs
@@ -1,0 +1,525 @@
+//! This protocol is technically not a part of GG'21,
+//! but it is needed to add threshold capabilities.
+//!
+//! Based on T. M. Wong, C. Wang, J. M. Wing "Verifiable Secret Redistribution for Archive Systems"
+//! https://www.cs.cmu.edu/~wing/publications/Wong-Winga02.pdf
+//! https://doi.org/10.1109/SISW.2002.1183515
+//! (Specifically, REDIST protocol).
+
+use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use rand_core::CryptoRngCore;
+use serde::{Deserialize, Serialize};
+
+use super::common::PartyIdx;
+use super::generic::{
+    BaseRound, BroadcastRound, DirectRound, Finalizable, FinalizableToResult,
+    FinalizationRequirement, FinalizeError, FirstRound, InitError, ProtocolResult, ReceiveError,
+    ToResult,
+};
+use super::threshold::ThresholdKeyShareSeed;
+use crate::curve::{Point, Scalar};
+use crate::tools::sss::{
+    interpolation_coeff, shamir_join_points, shamir_join_scalars, Polynomial, PublicPolynomial,
+    ShareIdx,
+};
+
+#[derive(Debug)]
+pub struct KeyResharingResult;
+
+impl ProtocolResult for KeyResharingResult {
+    type Success = Option<ThresholdKeyShareSeed>;
+    type ProvableError = KeyResharingError;
+    type CorrectnessProof = ();
+}
+
+#[derive(Debug, Clone)]
+pub enum KeyResharingError {
+    UnexpectedSender,
+    SubshareMismatch,
+}
+
+pub struct OldHolder {
+    key_share_seed: ThresholdKeyShareSeed,
+}
+
+pub struct NewHolder {
+    verifying_key: Point,
+    old_threshold: usize,
+    old_holders: Vec<PartyIdx>,
+}
+
+pub struct KeyResharingContext {
+    old_holder: Option<OldHolder>,
+    new_holder: Option<NewHolder>,
+    new_holders: Vec<PartyIdx>,
+    new_threshold: usize,
+}
+
+struct OldHolderData {
+    context: OldHolder,
+    polynomial: Polynomial,
+    public_polynomial: PublicPolynomial,
+}
+
+struct NewHolderData {
+    context: NewHolder,
+}
+
+pub struct Round1 {
+    old_holder: Option<OldHolderData>,
+    new_holder: Option<NewHolderData>,
+    new_share_idxs: BTreeMap<PartyIdx, ShareIdx>,
+    new_threshold: usize,
+    num_parties: usize,
+    party_idx: PartyIdx,
+}
+
+impl FirstRound for Round1 {
+    type Context = KeyResharingContext;
+    fn new(
+        rng: &mut impl CryptoRngCore,
+        _shared_randomness: &[u8],
+        num_parties: usize,
+        party_idx: PartyIdx,
+        context: Self::Context,
+    ) -> Result<Self, InitError> {
+        // Start new share indices from 1.
+        let new_share_idxs = context
+            .new_holders
+            .iter()
+            .enumerate()
+            .map(|(idx, party_idx)| (*party_idx, ShareIdx::new(idx + 1)))
+            .collect();
+
+        let old_holder = context.old_holder.map(|old_holder| {
+            let polynomial = Polynomial::random(
+                rng,
+                &old_holder.key_share_seed.secret(),
+                context.new_threshold,
+            );
+            let public_polynomial = polynomial.public();
+            OldHolderData {
+                polynomial,
+                public_polynomial,
+                context: old_holder,
+            }
+        });
+
+        let new_holder = context.new_holder.map(|new_holder| NewHolderData {
+            context: new_holder,
+        });
+
+        Ok(Round1 {
+            old_holder,
+            new_holder,
+            new_share_idxs,
+            new_threshold: context.new_threshold,
+            party_idx,
+            num_parties,
+        })
+    }
+}
+
+impl BaseRound for Round1 {
+    type Type = ToResult;
+    type Result = KeyResharingResult;
+    const ROUND_NUM: u8 = 1;
+    const NEXT_ROUND_NUM: Option<u8> = Some(2);
+
+    fn num_parties(&self) -> usize {
+        self.num_parties
+    }
+
+    fn party_idx(&self) -> PartyIdx {
+        self.party_idx
+    }
+}
+
+pub struct Round1DirectPayload {
+    subshare: Scalar,
+    public_subshare: Point,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Round1Direct {
+    subshare: Scalar,
+}
+
+impl DirectRound for Round1 {
+    type Message = Round1Direct;
+    type Payload = Round1DirectPayload;
+    type Artifact = ();
+
+    fn direct_message_destinations(&self) -> Option<Vec<PartyIdx>> {
+        if self.old_holder.is_some() {
+            Some(self.new_share_idxs.keys().cloned().collect())
+        } else {
+            None
+        }
+    }
+
+    fn make_direct_message(
+        &self,
+        _rng: &mut impl CryptoRngCore,
+        destination: PartyIdx,
+    ) -> Result<(Self::Message, Self::Artifact), String> {
+        if let Some(old_holder) = self.old_holder.as_ref() {
+            let subshare = old_holder
+                .polynomial
+                .evaluate(&self.new_share_idxs[&destination]);
+            Ok((Round1Direct { subshare }, ()))
+        } else {
+            Err("This node does not send direct messages in this round".into())
+        }
+    }
+
+    fn verify_direct_message(
+        &self,
+        from: PartyIdx,
+        msg: Self::Message,
+    ) -> Result<Self::Payload, ReceiveError<Self::Result>> {
+        if let Some(new_holder) = self.new_holder.as_ref() {
+            if new_holder
+                .context
+                .old_holders
+                .iter()
+                .any(|party_idx| party_idx == &from)
+            {
+                return Ok(Round1DirectPayload {
+                    subshare: msg.subshare,
+                    public_subshare: msg.subshare.mul_by_generator(),
+                });
+            }
+        }
+        Err(ReceiveError::Provable(KeyResharingError::UnexpectedSender))
+    }
+}
+
+pub struct Round1BcastPayload {
+    public_polynomial: PublicPolynomial,
+    public_subshare: Point,
+    old_share_idx: ShareIdx,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Round1Bcast {
+    public_polynomial: PublicPolynomial,
+    old_share_idx: ShareIdx,
+}
+
+impl BroadcastRound for Round1 {
+    const REQUIRES_CONSENSUS: bool = true;
+    type Message = Round1Bcast;
+    type Payload = Round1BcastPayload;
+
+    fn broadcast_destinations(&self) -> Option<Vec<PartyIdx>> {
+        if self.old_holder.is_some() {
+            Some(self.new_share_idxs.keys().cloned().collect())
+        } else {
+            None
+        }
+    }
+
+    fn make_broadcast(&self, _rng: &mut impl CryptoRngCore) -> Result<Self::Message, String> {
+        if let Some(old_holder) = self.old_holder.as_ref() {
+            Ok(Round1Bcast {
+                public_polynomial: old_holder.public_polynomial.clone(),
+                old_share_idx: old_holder.context.key_share_seed.index(),
+            })
+        } else {
+            Err("This node does not send broadcast messages in this round".into())
+        }
+    }
+
+    fn verify_broadcast(
+        &self,
+        from: PartyIdx,
+        msg: Self::Message,
+    ) -> Result<Self::Payload, ReceiveError<Self::Result>> {
+        if let Some(new_holder) = self.new_holder.as_ref() {
+            if new_holder
+                .context
+                .old_holders
+                .iter()
+                .any(|party_idx| party_idx == &from)
+            {
+                let public_subshare = msg
+                    .public_polynomial
+                    .evaluate(&self.new_share_idxs[&self.party_idx()]);
+                return Ok(Round1BcastPayload {
+                    public_polynomial: msg.public_polynomial,
+                    public_subshare,
+                    old_share_idx: msg.old_share_idx,
+                });
+            }
+        }
+        Err(ReceiveError::Provable(KeyResharingError::UnexpectedSender))
+    }
+}
+
+impl Finalizable for Round1 {
+    fn requirement() -> FinalizationRequirement {
+        FinalizationRequirement::Custom
+    }
+
+    fn can_finalize<'a>(
+        &self,
+        bc_payloads: impl Iterator<Item = &'a PartyIdx>,
+        dm_payloads: impl Iterator<Item = &'a PartyIdx>,
+        _dm_artifacts: impl Iterator<Item = &'a PartyIdx>,
+    ) -> bool {
+        if let Some(new_holder) = self.new_holder.as_ref() {
+            let bc_set = bc_payloads.cloned().collect::<BTreeSet<_>>();
+            let dm_set = dm_payloads.cloned().collect::<BTreeSet<_>>();
+            let threshold = new_holder.context.old_threshold;
+            bc_set.len() >= threshold && dm_set.len() >= threshold
+        } else {
+            true
+        }
+    }
+
+    fn missing_payloads<'a>(
+        &self,
+        bc_payloads: impl Iterator<Item = &'a PartyIdx>,
+        dm_payloads: impl Iterator<Item = &'a PartyIdx>,
+        _dm_artifacts: impl Iterator<Item = &'a PartyIdx>,
+    ) -> BTreeSet<PartyIdx> {
+        if let Some(new_holder) = self.new_holder.as_ref() {
+            let bc_set = bc_payloads.cloned().collect::<BTreeSet<_>>();
+            let dm_set = dm_payloads.cloned().collect::<BTreeSet<_>>();
+            new_holder
+                .context
+                .old_holders
+                .iter()
+                .cloned()
+                .filter(|idx| !bc_set.contains(idx) || !dm_set.contains(idx))
+                .collect()
+        } else {
+            BTreeSet::new()
+        }
+    }
+}
+
+impl FinalizableToResult for Round1 {
+    fn finalize_to_result(
+        self,
+        _rng: &mut impl CryptoRngCore,
+        bc_payloads: BTreeMap<PartyIdx, <Self as BroadcastRound>::Payload>,
+        dm_payloads: BTreeMap<PartyIdx, <Self as DirectRound>::Payload>,
+        _dm_artifacts: BTreeMap<PartyIdx, <Self as DirectRound>::Artifact>,
+    ) -> Result<<Self::Result as ProtocolResult>::Success, FinalizeError<Self::Result>> {
+        // If this party is not a new holder, exit.
+        let new_holder = match self.new_holder.as_ref() {
+            Some(new_holder) => new_holder,
+            None => return Ok(None),
+        };
+
+        let share_idx = self.new_share_idxs[&self.party_idx()];
+
+        // Check that the public polynomial sent in the broadcast corresponds to the secret share
+        // sent in the direct message.
+        for party_idx in new_holder.context.old_holders.iter() {
+            if dm_payloads[&party_idx].public_subshare != bc_payloads[&party_idx].public_subshare {
+                return Err(FinalizeError::Provable {
+                    party: *party_idx,
+                    error: KeyResharingError::SubshareMismatch,
+                });
+            }
+        }
+
+        // Check that the 0-th coefficients of public polynomials (that is, the old shares)
+        // add up to the expected verifying key.
+        let old_share_idxs = bc_payloads
+            .values()
+            .map(|payload| payload.old_share_idx)
+            .collect::<Vec<_>>();
+        let vkey = bc_payloads
+            .values()
+            .map(|payload| {
+                &payload.public_polynomial.coeff0()
+                    * &interpolation_coeff(&old_share_idxs, &payload.old_share_idx)
+            })
+            .sum();
+        if new_holder.context.verifying_key != vkey {
+            // TODO: this is unattributable.
+            // Should we add an enum variant to `FinalizeError`?
+            // or take the public shares as an input (assuming the nodes published those previously)
+            panic!("Invalid shares");
+        }
+
+        // Assemble the new share.
+        let subshares = new_holder
+            .context
+            .old_holders
+            .iter()
+            .map(|party_idx| {
+                (
+                    bc_payloads[&party_idx].old_share_idx,
+                    dm_payloads[&party_idx].subshare,
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        let secret_share = shamir_join_scalars(subshares.iter());
+
+        // Generate the public shares of all the new holders.
+        let public_shares = self
+            .new_share_idxs
+            .keys()
+            .map(|party_idx| {
+                let share_idx = self.new_share_idxs[&party_idx];
+                let public_subshares = bc_payloads
+                    .values()
+                    .map(|p| (p.old_share_idx, p.public_polynomial.evaluate(&share_idx)))
+                    .collect::<BTreeMap<_, _>>();
+                let public_share = shamir_join_points(public_subshares.iter());
+                (share_idx, public_share)
+            })
+            .collect();
+
+        Ok(Some(ThresholdKeyShareSeed {
+            index: share_idx,
+            threshold: self.new_threshold as u32,
+            secret_share,
+            public_shares,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand_core::{OsRng, RngCore};
+
+    use super::super::{
+        test_utils::{step_result, step_round},
+        threshold::ThresholdKeyShareSeed,
+        FirstRound,
+    };
+    use super::{KeyResharingContext, NewHolder, OldHolder, Round1};
+    use crate::cggmp21::PartyIdx;
+
+    #[test]
+    fn execute_key_reshare() {
+        let mut shared_randomness = [0u8; 32];
+        OsRng.fill_bytes(&mut shared_randomness);
+
+        let num_parties = 4;
+        let old_key_shares = ThresholdKeyShareSeed::new_centralized(&mut OsRng, 2, 3, None);
+        let old_vkey = old_key_shares[0].verifying_key_as_point();
+
+        let old_holders = vec![
+            PartyIdx::from_usize(0),
+            PartyIdx::from_usize(1),
+            PartyIdx::from_usize(2),
+        ];
+        let new_holders = vec![
+            PartyIdx::from_usize(1),
+            PartyIdx::from_usize(2),
+            PartyIdx::from_usize(3),
+        ];
+
+        let party0 = Round1::new(
+            &mut OsRng,
+            &shared_randomness,
+            num_parties,
+            PartyIdx::from_usize(0),
+            KeyResharingContext {
+                old_holder: Some(OldHolder {
+                    key_share_seed: old_key_shares[0].clone(),
+                }),
+                new_holder: None,
+                new_holders: new_holders.clone(),
+                new_threshold: 2,
+            },
+        )
+        .unwrap();
+
+        let party1 = Round1::new(
+            &mut OsRng,
+            &shared_randomness,
+            num_parties,
+            PartyIdx::from_usize(1),
+            KeyResharingContext {
+                old_holder: Some(OldHolder {
+                    key_share_seed: old_key_shares[1].clone(),
+                }),
+                new_holder: Some(NewHolder {
+                    verifying_key: old_vkey,
+                    old_threshold: 2,
+                    old_holders: old_holders.clone(),
+                }),
+                new_holders: new_holders.clone(),
+                new_threshold: 2,
+            },
+        )
+        .unwrap();
+
+        let party2 = Round1::new(
+            &mut OsRng,
+            &shared_randomness,
+            num_parties,
+            PartyIdx::from_usize(2),
+            KeyResharingContext {
+                old_holder: Some(OldHolder {
+                    key_share_seed: old_key_shares[2].clone(),
+                }),
+                new_holder: Some(NewHolder {
+                    verifying_key: old_vkey,
+                    old_threshold: 2,
+                    old_holders: old_holders.clone(),
+                }),
+                new_holders: new_holders.clone(),
+                new_threshold: 2,
+            },
+        )
+        .unwrap();
+
+        let party3 = Round1::new(
+            &mut OsRng,
+            &shared_randomness,
+            num_parties,
+            PartyIdx::from_usize(3),
+            KeyResharingContext {
+                old_holder: None,
+                new_holder: Some(NewHolder {
+                    verifying_key: old_vkey,
+                    old_threshold: 2,
+                    old_holders: old_holders.clone(),
+                }),
+                new_holders: new_holders.clone(),
+                new_threshold: 2,
+            },
+        )
+        .unwrap();
+
+        let r1 = vec![party0, party1, party2, party3];
+
+        let r1a = step_round(&mut OsRng, r1).unwrap();
+        let shares = step_result(&mut OsRng, r1a).unwrap();
+
+        // Check that the party that is not among the new holders gets None as a result
+        assert!(shares[0].is_none());
+
+        // Unwrap the results of the new holders
+        let shares: Vec<ThresholdKeyShareSeed> = shares[1..4]
+            .iter()
+            .cloned()
+            .map(|share| share.unwrap())
+            .collect::<Vec<_>>();
+
+        // Check that all public information is the same between the shares
+        let public_sets = shares
+            .iter()
+            .map(|s| s.public_shares.clone())
+            .collect::<Vec<_>>();
+        assert!(public_sets[1..].iter().all(|pk| pk == &public_sets[0]));
+
+        // Check that the public keys correspond to the secret key shares
+        for share in shares {
+            let public = share.secret_share.mul_by_generator();
+            assert_eq!(public, share.public_shares[&share.index()]);
+        }
+    }
+}

--- a/synedrion/src/cggmp21/protocols/presigning.rs
+++ b/synedrion/src/cggmp21/protocols/presigning.rs
@@ -10,8 +10,9 @@ use serde::{Deserialize, Serialize};
 
 use super::common::{KeyShare, KeySharePrecomputed, PartyIdx, PresigningData};
 use super::generic::{
-    BaseRound, BroadcastRound, DirectRound, FinalizableToNextRound, FinalizableToResult,
-    FinalizeError, FirstRound, InitError, ProtocolResult, ReceiveError, ToNextRound, ToResult,
+    all_parties_except, BaseRound, BroadcastRound, DirectRound, FinalizableToNextRound,
+    FinalizableToResult, FinalizeError, FirstRound, InitError, ProtocolResult, ReceiveError,
+    ToNextRound, ToResult,
 };
 use crate::cggmp21::{
     sigma::{AffGProof, DecProof, EncProof, LogStarProof, MulProof},
@@ -140,10 +141,10 @@ impl<P: SchemeParams> BroadcastRound for Round1<P> {
     type Message = Round1Bcast<P::Paillier>;
     type Payload = Round1Bcast<P::Paillier>;
 
-    fn broadcast_destinations(&self) -> Option<HoleRange> {
-        Some(HoleRange::new(
+    fn broadcast_destinations(&self) -> Option<Vec<PartyIdx>> {
+        Some(all_parties_except(
             self.context.key_share.num_parties(),
-            self.context.key_share.party_index().as_usize(),
+            self.context.key_share.party_index(),
         ))
     }
 
@@ -168,10 +169,10 @@ impl<P: SchemeParams> DirectRound for Round1<P> {
     type Payload = Round1Direct<P>;
     type Artifact = ();
 
-    fn direct_message_destinations(&self) -> Option<HoleRange> {
-        Some(HoleRange::new(
+    fn direct_message_destinations(&self) -> Option<Vec<PartyIdx>> {
+        Some(all_parties_except(
             self.context.key_share.num_parties(),
-            self.context.key_share.party_index().as_usize(),
+            self.context.key_share.party_index(),
         ))
     }
 
@@ -309,10 +310,10 @@ impl<P: SchemeParams> DirectRound for Round2<P> {
     type Payload = Round2Payload<P>;
     type Artifact = Round2Artifact<P>;
 
-    fn direct_message_destinations(&self) -> Option<HoleRange> {
-        Some(HoleRange::new(
+    fn direct_message_destinations(&self) -> Option<Vec<PartyIdx>> {
+        Some(all_parties_except(
             self.context.key_share.num_parties(),
-            self.context.key_share.party_index().as_usize(),
+            self.context.key_share.party_index(),
         ))
     }
 
@@ -599,10 +600,10 @@ impl<P: SchemeParams> DirectRound for Round3<P> {
     type Payload = Round3Payload;
     type Artifact = ();
 
-    fn direct_message_destinations(&self) -> Option<HoleRange> {
-        Some(HoleRange::new(
+    fn direct_message_destinations(&self) -> Option<Vec<PartyIdx>> {
+        Some(all_parties_except(
             self.context.key_share.num_parties(),
-            self.context.key_share.party_index().as_usize(),
+            self.context.key_share.party_index(),
         ))
     }
 

--- a/synedrion/src/cggmp21/protocols/signing.rs
+++ b/synedrion/src/cggmp21/protocols/signing.rs
@@ -10,8 +10,8 @@ use serde::{Deserialize, Serialize};
 
 use super::common::{KeySharePrecomputed, PartyIdx, PresigningData};
 use super::generic::{
-    BaseRound, BroadcastRound, DirectRound, FinalizableToResult, FinalizeError, FirstRound,
-    InitError, ProtocolResult, ReceiveError, ToResult,
+    all_parties_except, BaseRound, BroadcastRound, DirectRound, FinalizableToResult, FinalizeError,
+    FirstRound, InitError, ProtocolResult, ReceiveError, ToResult,
 };
 use crate::cggmp21::{
     sigma::{AffGProof, DecProof, MulStarProof},
@@ -96,8 +96,8 @@ impl<P: SchemeParams> BroadcastRound for Round1<P> {
     const REQUIRES_CONSENSUS: bool = false;
     type Message = Round1Bcast;
     type Payload = Scalar;
-    fn broadcast_destinations(&self) -> Option<HoleRange> {
-        Some(HoleRange::new(self.num_parties, self.party_idx.as_usize()))
+    fn broadcast_destinations(&self) -> Option<Vec<PartyIdx>> {
+        Some(all_parties_except(self.num_parties, self.party_idx))
     }
     fn make_broadcast(&self, _rng: &mut impl CryptoRngCore) -> Result<Self::Message, String> {
         Ok(Round1Bcast {

--- a/synedrion/src/cggmp21/protocols/signing.rs
+++ b/synedrion/src/cggmp21/protocols/signing.rs
@@ -1,6 +1,7 @@
 //! Signing using previously calculated presigning data, in the paper ECDSA Signing (Fig. 8).
 
 use alloc::boxed::Box;
+use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
@@ -10,8 +11,9 @@ use serde::{Deserialize, Serialize};
 
 use super::common::{KeySharePrecomputed, PartyIdx, PresigningData};
 use super::generic::{
-    all_parties_except, BaseRound, BroadcastRound, DirectRound, FinalizableToResult, FinalizeError,
-    FirstRound, InitError, ProtocolResult, ReceiveError, ToResult,
+    all_parties_except, try_to_holevec, BaseRound, BroadcastRound, DirectRound, Finalizable,
+    FinalizableToResult, FinalizationRequirement, FinalizeError, FirstRound, InitError,
+    ProtocolResult, ReceiveError, ToResult,
 };
 use crate::cggmp21::{
     sigma::{AffGProof, DecProof, MulStarProof},
@@ -19,7 +21,7 @@ use crate::cggmp21::{
 };
 use crate::curve::{RecoverableSignature, Scalar};
 use crate::paillier::RandomizerMod;
-use crate::tools::collections::{HoleRange, HoleVec};
+use crate::tools::collections::HoleRange;
 use crate::uint::{Bounded, FromScalar, Signed};
 
 /// Possible results of the Signing protocol.
@@ -85,6 +87,14 @@ impl<P: SchemeParams> BaseRound for Round1<P> {
     type Result = SigningResult<P>;
     const ROUND_NUM: u8 = 1;
     const NEXT_ROUND_NUM: Option<u8> = None;
+
+    fn num_parties(&self) -> usize {
+        self.num_parties
+    }
+
+    fn party_idx(&self) -> PartyIdx {
+        self.party_idx
+    }
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -97,7 +107,7 @@ impl<P: SchemeParams> BroadcastRound for Round1<P> {
     type Message = Round1Bcast;
     type Payload = Scalar;
     fn broadcast_destinations(&self) -> Option<Vec<PartyIdx>> {
-        Some(all_parties_except(self.num_parties, self.party_idx))
+        Some(all_parties_except(self.num_parties(), self.party_idx()))
     }
     fn make_broadcast(&self, _rng: &mut impl CryptoRngCore) -> Result<Self::Message, String> {
         Ok(Round1Bcast {
@@ -120,15 +130,21 @@ impl<P: SchemeParams> DirectRound for Round1<P> {
     type Artifact = ();
 }
 
+impl<P: SchemeParams> Finalizable for Round1<P> {
+    fn requirement() -> FinalizationRequirement {
+        FinalizationRequirement::AllBroadcasts
+    }
+}
+
 impl<P: SchemeParams> FinalizableToResult for Round1<P> {
     fn finalize_to_result(
         self,
         rng: &mut impl CryptoRngCore,
-        bc_payloads: Option<HoleVec<<Self as BroadcastRound>::Payload>>,
-        _dm_payloads: Option<HoleVec<<Self as DirectRound>::Payload>>,
-        _dm_artifacts: Option<HoleVec<<Self as DirectRound>::Artifact>>,
+        bc_payloads: BTreeMap<PartyIdx, <Self as BroadcastRound>::Payload>,
+        _dm_payloads: BTreeMap<PartyIdx, <Self as DirectRound>::Payload>,
+        _dm_artifacts: BTreeMap<PartyIdx, <Self as DirectRound>::Artifact>,
     ) -> Result<<Self::Result as ProtocolResult>::Success, FinalizeError<Self::Result>> {
-        let shares = bc_payloads.unwrap();
+        let shares = try_to_holevec(bc_payloads, self.num_parties, self.party_idx).unwrap();
         let s: Scalar = shares.iter().sum();
         let s = s + self.s_part;
 

--- a/synedrion/src/cggmp21/protocols/test_utils.rs
+++ b/synedrion/src/cggmp21/protocols/test_utils.rs
@@ -47,12 +47,10 @@ where
 
         if let Some(destinations) = round.direct_message_destinations() {
             for idx_to in destinations {
-                let (message, artifact) = round
-                    .make_direct_message(rng, PartyIdx::from_usize(idx_to))
-                    .unwrap();
-                direct_messages.push((PartyIdx::from_usize(idx_to), idx_from, message));
+                let (message, artifact) = round.make_direct_message(rng, idx_to).unwrap();
+                direct_messages.push((idx_to, idx_from, message));
                 dm_artifact_accums[idx_from.as_usize()]
-                    .insert(idx_to, artifact)
+                    .insert(idx_to.as_usize(), artifact)
                     .unwrap();
             }
         }
@@ -60,7 +58,7 @@ where
         if let Some(destinations) = round.broadcast_destinations() {
             let message = round.make_broadcast(rng).unwrap();
             for idx_to in destinations {
-                broadcasts.push((PartyIdx::from_usize(idx_to), idx_from, message.clone()));
+                broadcasts.push((idx_to, idx_from, message.clone()));
             }
         }
     }

--- a/synedrion/src/cggmp21/protocols/test_utils.rs
+++ b/synedrion/src/cggmp21/protocols/test_utils.rs
@@ -1,3 +1,4 @@
+use alloc::collections::BTreeMap;
 use alloc::format;
 use alloc::string::String;
 use alloc::vec::Vec;
@@ -9,7 +10,6 @@ use super::generic::{
     BroadcastRound, DirectRound, FinalizableToNextRound, FinalizableToResult, ProtocolResult, Round,
 };
 use super::{FinalizeError, PartyIdx};
-use crate::tools::collections::{HoleVec, HoleVecAccum};
 
 #[derive(Debug)]
 pub(crate) enum StepError {
@@ -19,9 +19,9 @@ pub(crate) enum StepError {
 
 pub(crate) struct AssembledRound<R: Round> {
     round: R,
-    bc_payloads: Option<HoleVec<<R as BroadcastRound>::Payload>>,
-    dm_payloads: Option<HoleVec<<R as DirectRound>::Payload>>,
-    dm_artifacts: Option<HoleVec<<R as DirectRound>::Artifact>>,
+    bc_payloads: BTreeMap<PartyIdx, <R as BroadcastRound>::Payload>,
+    dm_payloads: BTreeMap<PartyIdx, <R as DirectRound>::Payload>,
+    dm_artifacts: BTreeMap<PartyIdx, <R as DirectRound>::Artifact>,
 }
 
 pub(crate) fn step_round<R>(
@@ -35,7 +35,7 @@ where
     // Collect outgoing messages
 
     let mut dm_artifact_accums = (0..rounds.len())
-        .map(|idx| HoleVecAccum::<<R as DirectRound>::Artifact>::new(rounds.len(), idx))
+        .map(|_| BTreeMap::new())
         .collect::<Vec<_>>();
 
     // `to, from, message`
@@ -49,9 +49,9 @@ where
             for idx_to in destinations {
                 let (message, artifact) = round.make_direct_message(rng, idx_to).unwrap();
                 direct_messages.push((idx_to, idx_from, message));
-                dm_artifact_accums[idx_from.as_usize()]
-                    .insert(idx_to.as_usize(), artifact)
-                    .unwrap();
+                assert!(dm_artifact_accums[idx_from.as_usize()]
+                    .insert(idx_to, artifact)
+                    .is_none());
             }
         }
 
@@ -66,67 +66,42 @@ where
     // Deliver direct messages
 
     let mut dm_payload_accums = (0..rounds.len())
-        .map(|idx| HoleVecAccum::<<R as DirectRound>::Payload>::new(rounds.len(), idx))
+        .map(|_| BTreeMap::new())
         .collect::<Vec<_>>();
     for (idx_to, idx_from, message) in direct_messages.into_iter() {
         let round = &rounds[idx_to.as_usize()];
         let payload = round
             .verify_direct_message(idx_from, message)
             .map_err(|err| StepError::Receive(format!("{:?}", err)))?;
-        dm_payload_accums[idx_to.as_usize()].insert(idx_from.as_usize(), payload);
+        dm_payload_accums[idx_to.as_usize()].insert(idx_from, payload);
     }
 
     // Deliver broadcasts
 
     let mut bc_payload_accums = (0..rounds.len())
-        .map(|idx| HoleVecAccum::<<R as BroadcastRound>::Payload>::new(rounds.len(), idx))
+        .map(|_| BTreeMap::new())
         .collect::<Vec<_>>();
     for (idx_to, idx_from, message) in broadcasts.into_iter() {
         let round = &rounds[idx_to.as_usize()];
         let payload = round
             .verify_broadcast(idx_from, message)
             .map_err(|err| StepError::Receive(format!("{:?}", err)))?;
-        bc_payload_accums[idx_to.as_usize()].insert(idx_from.as_usize(), payload);
-    }
-
-    // Finalize accumulators
-
-    let mut dm_payloads = Vec::new();
-    for accum in dm_payload_accums.into_iter() {
-        let payloads = if accum.is_empty() {
-            None
-        } else {
-            Some(accum.finalize().ok_or(StepError::AccumFinalize)?)
-        };
-        dm_payloads.push(payloads);
-    }
-
-    let mut dm_artifacts = Vec::new();
-    for accum in dm_artifact_accums.into_iter() {
-        let artifacts = if accum.is_empty() {
-            None
-        } else {
-            Some(accum.finalize().ok_or(StepError::AccumFinalize)?)
-        };
-        dm_artifacts.push(artifacts);
-    }
-
-    let mut bc_payloads = Vec::new();
-    for accum in bc_payload_accums.into_iter() {
-        let payloads = if accum.is_empty() {
-            None
-        } else {
-            Some(accum.finalize().ok_or(StepError::AccumFinalize)?)
-        };
-        bc_payloads.push(payloads);
+        bc_payload_accums[idx_to.as_usize()].insert(idx_from, payload);
     }
 
     // Assemble
 
     let mut assembled = Vec::new();
-    for (round, bc_payloads, dm_payloads, dm_artifacts) in
-        izip!(rounds, bc_payloads, dm_payloads, dm_artifacts)
-    {
+    for (round, bc_payloads, dm_payloads, dm_artifacts) in izip!(
+        rounds,
+        bc_payload_accums,
+        dm_payload_accums,
+        dm_artifact_accums
+    ) {
+        if !round.can_finalize(bc_payloads.keys(), dm_payloads.keys(), dm_artifacts.keys()) {
+            return Err(StepError::AccumFinalize);
+        };
+
         assembled.push(AssembledRound {
             round,
             bc_payloads,

--- a/synedrion/src/cggmp21/protocols/threshold.rs
+++ b/synedrion/src/cggmp21/protocols/threshold.rs
@@ -1,5 +1,5 @@
 use alloc::boxed::Box;
-use alloc::vec::Vec;
+use alloc::collections::BTreeMap;
 
 use k256::ecdsa::VerifyingKey;
 use rand_core::CryptoRngCore;
@@ -8,7 +8,9 @@ use serde::{Deserialize, Serialize};
 use super::common::{make_aux_info, KeyShare, PartyIdx, PublicAuxInfo, SecretAuxInfo};
 use crate::cggmp21::SchemeParams;
 use crate::curve::{Point, Scalar};
-use crate::tools::sss::{interpolation_coeff, shamir_evaluation_points, shamir_split};
+use crate::tools::sss::{
+    interpolation_coeff, shamir_evaluation_points, shamir_join_points, shamir_split, ShareIdx,
+};
 
 /// A threshold variant of the key share, where any `threshold` shares our of the total number
 /// is enough to perform signing.
@@ -20,12 +22,12 @@ use crate::tools::sss::{interpolation_coeff, shamir_evaluation_points, shamir_sp
 #[serde(bound(deserialize = "SecretAuxInfo<P>: for <'x> Deserialize<'x>,
         PublicAuxInfo<P>: for <'x> Deserialize<'x>"))]
 pub struct ThresholdKeyShare<P: SchemeParams> {
-    pub(crate) index: PartyIdx,
-    pub(crate) threshold: u32, // TODO (#31): make typed? Can it be `ShareIdx`?
+    pub(crate) index: ShareIdx,
+    pub(crate) threshold: u32,
     pub(crate) secret_share: Scalar,
-    pub(crate) public_shares: Box<[Point]>,
+    pub(crate) public_shares: BTreeMap<ShareIdx, Point>,
     pub(crate) secret_aux: SecretAuxInfo<P>,
-    pub(crate) public_aux: Box<[PublicAuxInfo<P>]>,
+    pub(crate) public_aux: BTreeMap<ShareIdx, PublicAuxInfo<P>>,
 }
 
 impl<P: SchemeParams> ThresholdKeyShare<P> {
@@ -44,27 +46,30 @@ impl<P: SchemeParams> ThresholdKeyShare<P> {
             Some(sk) => Scalar::from(sk.as_nonzero_scalar()),
         };
 
-        let secret_shares = shamir_split(
-            rng,
-            &secret,
-            threshold,
-            &shamir_evaluation_points(num_parties),
-        );
+        let share_idxs = shamir_evaluation_points(num_parties);
+        let secret_shares = shamir_split(rng, &secret, threshold, &share_idxs);
         let public_shares = secret_shares
             .iter()
-            .map(|s| s.mul_by_generator())
-            .collect::<Box<_>>();
+            .map(|(idx, share)| (*idx, share.mul_by_generator()))
+            .collect::<BTreeMap<_, _>>();
 
         let (secret_aux, public_aux) = make_aux_info(rng, num_parties);
+
+        let public_aux = public_aux
+            .into_vec()
+            .into_iter()
+            .enumerate()
+            .map(|(idx, public)| (share_idxs[idx], public))
+            .collect::<BTreeMap<_, _>>();
 
         secret_aux
             .into_vec()
             .into_iter()
             .enumerate()
             .map(|(idx, secret_aux)| ThresholdKeyShare {
-                index: PartyIdx::from_usize(idx),
+                index: share_idxs[idx],
                 threshold: threshold as u32,
-                secret_share: secret_shares[idx],
+                secret_share: secret_shares[&share_idxs[idx]],
                 public_shares: public_shares.clone(),
                 secret_aux,
                 public_aux: public_aux.clone(),
@@ -73,12 +78,7 @@ impl<P: SchemeParams> ThresholdKeyShare<P> {
     }
 
     pub(crate) fn verifying_key_as_point(&self) -> Point {
-        let points = shamir_evaluation_points(self.num_parties());
-        self.public_shares[0..self.threshold as usize]
-            .iter()
-            .enumerate()
-            .map(|(idx, p)| p * &interpolation_coeff(&points[0..self.threshold as usize], idx))
-            .sum()
+        shamir_join_points(self.public_shares.iter().take(self.threshold as usize))
     }
 
     /// Return the verifying key to which this set of shares corresponds.
@@ -88,52 +88,42 @@ impl<P: SchemeParams> ThresholdKeyShare<P> {
         self.verifying_key_as_point().to_verifying_key().unwrap()
     }
 
-    /// Returns the number of parties in this set of shares.
-    pub fn num_parties(&self) -> usize {
-        // TODO (#31): technically it is `num_shares`, but for now we are equating the two,
-        // since we assume that one party has one share.
-        self.public_shares.len()
-    }
-
     /// Returns the index of this share's party.
-    pub fn party_index(&self) -> usize {
-        // TODO (#31): technically it is the share index, but for now we are equating the two,
-        // since we assume that one party has one share.
-        self.index.as_usize()
+    pub fn index(&self) -> ShareIdx {
+        self.index
     }
 
     /// Converts a t-of-n key share into a t-of-t key share
-    /// (for the `t` parties supplied as `party_idxs`)
+    /// (for the `t` share indices supplied as `share_idxs`)
     /// that can be used in the presigning/signing protocols.
-    pub fn to_key_share(&self, party_idxs: &[PartyIdx]) -> KeyShare<P> {
-        debug_assert!(party_idxs.len() == self.threshold as usize);
+    pub fn to_key_share(&self, share_idxs: &[ShareIdx]) -> KeyShare<P> {
+        debug_assert!(share_idxs.len() == self.threshold as usize);
         // TODO (#68): assert that all indices are distinct
-        let mapped_idx = party_idxs
+        let my_idx_position = share_idxs
             .iter()
             .position(|idx| idx == &self.index)
             .unwrap();
 
-        let all_points = shamir_evaluation_points(self.num_parties());
-        let points = party_idxs
-            .iter()
-            .map(|idx| all_points[idx.as_usize()])
-            .collect::<Vec<_>>();
-
-        let secret_share = self.secret_share * interpolation_coeff(&points, mapped_idx);
-        let public_shares = party_idxs
+        let secret_share = self.secret_share * interpolation_coeff(share_idxs, my_idx_position);
+        let public_shares = share_idxs
             .iter()
             .enumerate()
-            .map(|(mapped_idx, idx)| {
-                &self.public_shares[idx.as_usize()] * &interpolation_coeff(&points, mapped_idx)
+            .map(|(position, share_idx)| {
+                &self.public_shares[share_idx] * &interpolation_coeff(share_idxs, position)
             })
             .collect();
 
+        let public_aux = share_idxs
+            .iter()
+            .map(|idx| self.public_aux[idx].clone())
+            .collect();
+
         KeyShare {
-            index: PartyIdx::from_usize(mapped_idx),
+            index: PartyIdx::from_usize(my_idx_position),
             secret_share,
             public_shares,
             secret_aux: self.secret_aux.clone(),
-            public_aux: self.public_aux.clone(),
+            public_aux,
         }
     }
 }
@@ -164,17 +154,23 @@ mod tests {
     use rand_core::OsRng;
 
     use super::ThresholdKeyShare;
-    use crate::cggmp21::{PartyIdx, TestParams};
+    use crate::cggmp21::TestParams;
     use crate::curve::Scalar;
 
     #[test]
     fn threshold_key_share_centralized() {
         let sk = SigningKey::random(&mut OsRng);
         let shares = ThresholdKeyShare::<TestParams>::new_centralized(&mut OsRng, 2, 3, Some(&sk));
+
+        assert_eq!(&shares[0].verifying_key(), sk.verifying_key());
+        assert_eq!(&shares[1].verifying_key(), sk.verifying_key());
+        assert_eq!(&shares[2].verifying_key(), sk.verifying_key());
+
         assert_eq!(&shares[0].verifying_key(), sk.verifying_key());
 
-        let nt_share0 = shares[0].to_key_share(&[PartyIdx::from_usize(2), PartyIdx::from_usize(0)]);
-        let nt_share1 = shares[2].to_key_share(&[PartyIdx::from_usize(2), PartyIdx::from_usize(0)]);
+        let share_idxs = [shares[2].index(), shares[0].index()];
+        let nt_share0 = shares[0].to_key_share(&share_idxs);
+        let nt_share1 = shares[2].to_key_share(&share_idxs);
 
         assert_eq!(&nt_share0.verifying_key(), sk.verifying_key());
         assert_eq!(&nt_share1.verifying_key(), sk.verifying_key());

--- a/synedrion/src/cggmp21/protocols/wrappers.rs
+++ b/synedrion/src/cggmp21/protocols/wrappers.rs
@@ -5,8 +5,8 @@ use rand_core::CryptoRngCore;
 
 use super::common::PartyIdx;
 use super::generic::{
-    BaseRound, BroadcastRound, DirectRound, FinalizableType, FinalizeError, ProtocolResult,
-    ReceiveError, Round,
+    BaseRound, BroadcastRound, DirectRound, Finalizable, FinalizableType, FinalizationRequirement,
+    FinalizeError, ProtocolResult, ReceiveError, Round,
 };
 
 pub(crate) trait ResultWrapper<Res: ProtocolResult>: ProtocolResult {
@@ -50,6 +50,13 @@ impl<T: RoundWrapper> BaseRound for T {
     type Result = T::Result;
     const ROUND_NUM: u8 = T::ROUND_NUM;
     const NEXT_ROUND_NUM: Option<u8> = T::NEXT_ROUND_NUM;
+
+    fn num_parties(&self) -> usize {
+        self.inner_round().num_parties()
+    }
+    fn party_idx(&self) -> PartyIdx {
+        self.inner_round().party_idx()
+    }
 }
 
 impl<T: RoundWrapper> BroadcastRound for T {
@@ -95,5 +102,11 @@ impl<T: RoundWrapper> DirectRound for T {
         self.inner_round()
             .verify_direct_message(from, msg)
             .map_err(wrap_receive_error)
+    }
+}
+
+impl<T: RoundWrapper> Finalizable for T {
+    fn requirement() -> FinalizationRequirement {
+        T::InnerRound::requirement()
     }
 }

--- a/synedrion/src/cggmp21/protocols/wrappers.rs
+++ b/synedrion/src/cggmp21/protocols/wrappers.rs
@@ -1,4 +1,5 @@
 use alloc::string::String;
+use alloc::vec::Vec;
 
 use rand_core::CryptoRngCore;
 
@@ -7,7 +8,6 @@ use super::generic::{
     BaseRound, BroadcastRound, DirectRound, FinalizableType, FinalizeError, ProtocolResult,
     ReceiveError, Round,
 };
-use crate::tools::collections::HoleRange;
 
 pub(crate) trait ResultWrapper<Res: ProtocolResult>: ProtocolResult {
     fn wrap_error(error: Res::ProvableError) -> Self::ProvableError;
@@ -56,7 +56,7 @@ impl<T: RoundWrapper> BroadcastRound for T {
     const REQUIRES_CONSENSUS: bool = T::InnerRound::REQUIRES_CONSENSUS;
     type Message = <T::InnerRound as BroadcastRound>::Message;
     type Payload = <T::InnerRound as BroadcastRound>::Payload;
-    fn broadcast_destinations(&self) -> Option<HoleRange> {
+    fn broadcast_destinations(&self) -> Option<Vec<PartyIdx>> {
         self.inner_round().broadcast_destinations()
     }
     fn make_broadcast(&self, rng: &mut impl CryptoRngCore) -> Result<Self::Message, String> {
@@ -77,7 +77,7 @@ impl<T: RoundWrapper> DirectRound for T {
     type Message = <T::InnerRound as DirectRound>::Message;
     type Payload = <T::InnerRound as DirectRound>::Payload;
     type Artifact = <T::InnerRound as DirectRound>::Artifact;
-    fn direct_message_destinations(&self) -> Option<HoleRange> {
+    fn direct_message_destinations(&self) -> Option<Vec<PartyIdx>> {
         self.inner_round().direct_message_destinations()
     }
     fn make_direct_message(

--- a/synedrion/src/curve/arithmetic.rs
+++ b/synedrion/src/curve/arithmetic.rs
@@ -33,7 +33,7 @@ pub(crate) type CompressedPointSize =
 
 pub(crate) const ORDER: U256 = Secp256k1::ORDER;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default, PartialOrd, Ord)]
 pub struct Scalar(BackendScalar);
 
 impl Scalar {
@@ -227,6 +227,12 @@ impl Default for Point {
 impl From<u32> for Scalar {
     fn from(val: u32) -> Self {
         Self(BackendScalar::from(val))
+    }
+}
+
+impl From<usize> for Scalar {
+    fn from(val: usize) -> Self {
+        Self(BackendScalar::from(u64::try_from(val).unwrap()))
     }
 }
 

--- a/synedrion/src/sessions/states.rs
+++ b/synedrion/src/sessions/states.rs
@@ -237,7 +237,8 @@ where
         match &self.tp {
             SessionType::Normal(round) => round.broadcast_destinations().map(|range| {
                 range
-                    .map(|idx| self.context.verifiers[idx].clone())
+                    .iter()
+                    .map(|idx| self.context.verifiers[idx.as_usize()].clone())
                     .collect()
             }),
             SessionType::Bc { .. } => {
@@ -294,7 +295,8 @@ where
         match &self.tp {
             SessionType::Normal(round) => round.direct_message_destinations().map(|range| {
                 range
-                    .map(|idx| self.context.verifiers[idx].clone())
+                    .iter()
+                    .map(|idx| self.context.verifiers[idx.as_usize()].clone())
                     .collect()
             }),
             _ => None,

--- a/synedrion/src/sessions/type_erased.rs
+++ b/synedrion/src/sessions/type_erased.rs
@@ -18,7 +18,7 @@ use crate::cggmp21::{
     self, BroadcastRound, DirectRound, FinalizableToNextRound, FinalizableToResult, PartyIdx,
     ProtocolResult, Round, ToNextRound, ToResult,
 };
-use crate::tools::collections::{HoleRange, HoleVec, HoleVecAccum};
+use crate::tools::collections::{HoleVec, HoleVecAccum};
 
 pub(crate) fn serialize_message(message: &impl Serialize) -> Result<Box<[u8]>, LocalError> {
     bincode::serialize(message)
@@ -100,10 +100,10 @@ pub(crate) trait DynRound<Res: ProtocolResult>: Send {
     fn round_num(&self) -> u8;
     fn next_round_num(&self) -> Option<u8>;
 
-    fn broadcast_destinations(&self) -> Option<HoleRange>;
+    fn broadcast_destinations(&self) -> Option<Vec<PartyIdx>>;
     fn make_broadcast(&self, rng: &mut dyn CryptoRngCore) -> Result<Box<[u8]>, LocalError>;
     fn requires_broadcast_consensus(&self) -> bool;
-    fn direct_message_destinations(&self) -> Option<HoleRange>;
+    fn direct_message_destinations(&self) -> Option<Vec<PartyIdx>>;
     fn make_direct_message(
         &self,
         rng: &mut dyn CryptoRngCore,
@@ -171,7 +171,7 @@ where
         Ok(DynDmPayload(Box::new(payload)))
     }
 
-    fn broadcast_destinations(&self) -> Option<HoleRange> {
+    fn broadcast_destinations(&self) -> Option<Vec<PartyIdx>> {
         self.broadcast_destinations()
     }
 
@@ -187,7 +187,7 @@ where
         <R as BroadcastRound>::REQUIRES_CONSENSUS
     }
 
-    fn direct_message_destinations(&self) -> Option<HoleRange> {
+    fn direct_message_destinations(&self) -> Option<Vec<PartyIdx>> {
         self.direct_message_destinations()
     }
 

--- a/synedrion/src/sessions/type_erased.rs
+++ b/synedrion/src/sessions/type_erased.rs
@@ -4,7 +4,7 @@ This way they can be used in a state machine loop without code repetition.
 */
 
 use alloc::boxed::Box;
-use alloc::collections::BTreeSet;
+use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
@@ -18,7 +18,6 @@ use crate::cggmp21::{
     self, BroadcastRound, DirectRound, FinalizableToNextRound, FinalizableToResult, PartyIdx,
     ProtocolResult, Round, ToNextRound, ToResult,
 };
-use crate::tools::collections::{HoleVec, HoleVecAccum};
 
 pub(crate) fn serialize_message(message: &impl Serialize) -> Result<Box<[u8]>, LocalError> {
     bincode::serialize(message)
@@ -41,13 +40,10 @@ pub(crate) enum FinalizeOutcome<Res: ProtocolResult> {
 pub enum AccumAddError {
     /// An item with the given origin has already been added to the accumulator.
     SlotTaken,
-    /// Trying to add an item to an accumulator that was not initialized on construction.
-    NoAccumulator,
 }
 
 #[derive(Debug, Clone)]
 pub enum AccumFinalizeError {
-    NotEnoughMessages,
     Downcast(String),
 }
 
@@ -120,6 +116,8 @@ pub(crate) trait DynRound<Res: ProtocolResult>: Send {
         from: PartyIdx,
         message: &[u8],
     ) -> Result<DynDmPayload, ReceiveError<Res>>;
+    fn can_finalize(&self, accum: &DynRoundAccum) -> bool;
+    fn missing_payloads(&self, accum: &DynRoundAccum) -> BTreeSet<PartyIdx>;
 }
 
 impl<R> DynRound<R::Result> for R
@@ -203,72 +201,51 @@ where
         let message = serialize_message(&typed_message)?;
         Ok((message, DynDmArtifact(Box::new(typed_artifact))))
     }
+
+    fn can_finalize(&self, accum: &DynRoundAccum) -> bool {
+        self.can_finalize(
+            accum.bc_payloads.keys(),
+            accum.dm_payloads.keys(),
+            accum.dm_artifacts.keys(),
+        )
+    }
+
+    fn missing_payloads(&self, accum: &DynRoundAccum) -> BTreeSet<PartyIdx> {
+        self.missing_payloads(
+            accum.bc_payloads.keys(),
+            accum.dm_payloads.keys(),
+            accum.dm_artifacts.keys(),
+        )
+    }
 }
 
 pub(crate) struct DynRoundAccum {
-    bc_payloads: Option<HoleVecAccum<DynBcPayload>>,
-    dm_payloads: Option<HoleVecAccum<DynDmPayload>>,
-    dm_artifacts: Option<HoleVecAccum<DynDmArtifact>>,
+    bc_payloads: BTreeMap<PartyIdx, DynBcPayload>,
+    dm_payloads: BTreeMap<PartyIdx, DynDmPayload>,
+    dm_artifacts: BTreeMap<PartyIdx, DynDmArtifact>,
 }
 
 struct RoundAccum<R: Round> {
-    bc_payloads: Option<HoleVec<<R as BroadcastRound>::Payload>>,
-    dm_payloads: Option<HoleVec<<R as DirectRound>::Payload>>,
-    dm_artifacts: Option<HoleVec<<R as DirectRound>::Artifact>>,
+    bc_payloads: BTreeMap<PartyIdx, <R as BroadcastRound>::Payload>,
+    dm_payloads: BTreeMap<PartyIdx, <R as DirectRound>::Payload>,
+    dm_artifacts: BTreeMap<PartyIdx, <R as DirectRound>::Artifact>,
 }
 
 impl DynRoundAccum {
-    pub fn new(num_parties: usize, idx: PartyIdx, is_bc_round: bool, is_dm_round: bool) -> Self {
+    pub fn new() -> Self {
         Self {
-            bc_payloads: if is_bc_round {
-                Some(HoleVecAccum::new(num_parties, idx.as_usize()))
-            } else {
-                None
-            },
-            dm_payloads: if is_dm_round {
-                Some(HoleVecAccum::new(num_parties, idx.as_usize()))
-            } else {
-                None
-            },
-            dm_artifacts: if is_dm_round {
-                Some(HoleVecAccum::new(num_parties, idx.as_usize()))
-            } else {
-                None
-            },
+            bc_payloads: BTreeMap::new(),
+            dm_payloads: BTreeMap::new(),
+            dm_artifacts: BTreeMap::new(),
         }
     }
 
     pub fn contains(&self, from: PartyIdx, broadcast: bool) -> bool {
         if broadcast {
-            return self
-                .bc_payloads
-                .as_ref()
-                .unwrap()
-                .contains(from.as_usize())
-                .unwrap();
+            self.bc_payloads.contains_key(&from)
         } else {
-            return self
-                .dm_payloads
-                .as_ref()
-                .unwrap()
-                .contains(from.as_usize())
-                .unwrap();
+            self.dm_payloads.contains_key(&from)
         }
-    }
-
-    pub fn missing_messages(&self) -> Vec<PartyIdx> {
-        let mut idxs = BTreeSet::new();
-        if let Some(payloads) = &self.bc_payloads {
-            for idx in payloads.missing() {
-                idxs.insert(idx);
-            }
-        }
-        if let Some(payloads) = &self.dm_payloads {
-            for idx in payloads.missing() {
-                idxs.insert(idx);
-            }
-        }
-        idxs.into_iter().map(PartyIdx::from_usize).collect()
     }
 
     pub fn add_bc_payload(
@@ -276,12 +253,11 @@ impl DynRoundAccum {
         from: PartyIdx,
         payload: DynBcPayload,
     ) -> Result<(), AccumAddError> {
-        match &mut self.bc_payloads {
-            Some(payloads) => payloads
-                .insert(from.as_usize(), payload)
-                .ok_or(AccumAddError::SlotTaken),
-            None => Err(AccumAddError::NoAccumulator),
+        if self.bc_payloads.contains_key(&from) {
+            return Err(AccumAddError::SlotTaken);
         }
+        self.bc_payloads.insert(from, payload);
+        Ok(())
     }
 
     pub fn add_dm_payload(
@@ -289,12 +265,11 @@ impl DynRoundAccum {
         from: PartyIdx,
         payload: DynDmPayload,
     ) -> Result<(), AccumAddError> {
-        match &mut self.dm_payloads {
-            Some(payloads) => payloads
-                .insert(from.as_usize(), payload)
-                .ok_or(AccumAddError::SlotTaken),
-            None => Err(AccumAddError::NoAccumulator),
+        if self.dm_payloads.contains_key(&from) {
+            return Err(AccumAddError::SlotTaken);
         }
+        self.dm_payloads.insert(from, payload);
+        Ok(())
     }
 
     pub fn add_dm_artifact(
@@ -302,27 +277,11 @@ impl DynRoundAccum {
         destination: PartyIdx,
         artifact: DynDmArtifact,
     ) -> Result<(), AccumAddError> {
-        match &mut self.dm_artifacts {
-            Some(artifacts) => artifacts
-                .insert(destination.as_usize(), artifact)
-                .ok_or(AccumAddError::SlotTaken),
-            None => Err(AccumAddError::NoAccumulator),
+        if self.dm_artifacts.contains_key(&destination) {
+            return Err(AccumAddError::SlotTaken);
         }
-    }
-
-    pub fn can_finalize(&self) -> bool {
-        // TODO (#85): should this be the job of the round itself?
-        self.bc_payloads
-            .as_ref()
-            .map_or(true, |accum| accum.can_finalize())
-            && self
-                .dm_payloads
-                .as_ref()
-                .map_or(true, |accum| accum.can_finalize())
-            && self
-                .dm_artifacts
-                .as_ref()
-                .map_or(true, |accum| accum.can_finalize())
+        self.dm_artifacts.insert(destination, artifact);
+        Ok(())
     }
 
     fn finalize<R: Round>(self) -> Result<RoundAccum<R>, AccumFinalizeError>
@@ -331,33 +290,27 @@ impl DynRoundAccum {
         <R as DirectRound>::Payload: 'static,
         <R as DirectRound>::Artifact: 'static,
     {
-        let bc_payloads = match self.bc_payloads {
-            Some(accum) => {
-                let hvec = accum
-                    .finalize()
-                    .ok_or(AccumFinalizeError::NotEnoughMessages)?;
-                Some(hvec.map_fallible(|elem| downcast::<<R as BroadcastRound>::Payload>(elem.0))?)
-            }
-            None => None,
-        };
-        let dm_payloads = match self.dm_payloads {
-            Some(accum) => {
-                let hvec = accum
-                    .finalize()
-                    .ok_or(AccumFinalizeError::NotEnoughMessages)?;
-                Some(hvec.map_fallible(|elem| downcast::<<R as DirectRound>::Payload>(elem.0))?)
-            }
-            None => None,
-        };
-        let dm_artifacts = match self.dm_artifacts {
-            Some(accum) => {
-                let hvec = accum
-                    .finalize()
-                    .ok_or(AccumFinalizeError::NotEnoughMessages)?;
-                Some(hvec.map_fallible(|elem| downcast::<<R as DirectRound>::Artifact>(elem.0))?)
-            }
-            None => None,
-        };
+        let bc_payloads = self
+            .bc_payloads
+            .into_iter()
+            .map(|(idx, elem)| {
+                downcast::<<R as BroadcastRound>::Payload>(elem.0).map(|elem| (idx, elem))
+            })
+            .collect::<Result<BTreeMap<_, _>, _>>()?;
+        let dm_payloads = self
+            .dm_payloads
+            .into_iter()
+            .map(|(idx, elem)| {
+                downcast::<<R as DirectRound>::Payload>(elem.0).map(|elem| (idx, elem))
+            })
+            .collect::<Result<BTreeMap<_, _>, _>>()?;
+        let dm_artifacts = self
+            .dm_artifacts
+            .into_iter()
+            .map(|(idx, elem)| {
+                downcast::<<R as DirectRound>::Artifact>(elem.0).map(|elem| (idx, elem))
+            })
+            .collect::<Result<BTreeMap<_, _>, _>>()?;
         Ok(RoundAccum {
             bc_payloads,
             dm_payloads,

--- a/synedrion/src/tools/collections.rs
+++ b/synedrion/src/tools/collections.rs
@@ -57,11 +57,6 @@ impl<T> HoleVecAccum<T> {
         self.elems.iter().all(|elem| elem.is_some())
     }
 
-    #[cfg(any(test, feature = "bench-internals"))]
-    pub fn is_empty(&self) -> bool {
-        self.elems.iter().all(|elem| elem.is_none())
-    }
-
     fn len(&self) -> usize {
         self.elems.len() + 1
     }
@@ -193,20 +188,6 @@ impl<T> HoleVec<T> {
             elems: self.elems.into_iter().map(f).collect(),
             hole_at: self.hole_at,
         }
-    }
-
-    pub fn map_fallible<F, V, E>(self, f: F) -> Result<HoleVec<V>, E>
-    where
-        F: FnMut(T) -> Result<V, E>,
-    {
-        Ok(HoleVec {
-            elems: self
-                .elems
-                .into_iter()
-                .map(f)
-                .collect::<Result<Vec<_>, E>>()?,
-            hole_at: self.hole_at,
-        })
     }
 }
 

--- a/synedrion/src/tools/collections.rs
+++ b/synedrion/src/tools/collections.rs
@@ -141,7 +141,7 @@ pub(crate) struct HoleVec<T> {
 
 impl<T> HoleVec<T> {
     pub fn hole_at(&self) -> usize {
-        self.hole_at.try_into().unwrap()
+        self.hole_at.into()
     }
 
     pub fn len(&self) -> usize {

--- a/synedrion/src/tools/sss.rs
+++ b/synedrion/src/tools/sss.rs
@@ -1,64 +1,104 @@
+use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 
 use rand_core::CryptoRngCore;
+use serde::{Deserialize, Serialize};
 
-use crate::curve::Scalar;
+use crate::curve::{Point, Scalar};
 
-pub(crate) fn shamir_evaluation_points(num_shares: usize) -> Vec<Scalar> {
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ShareIdx(Scalar);
+
+impl ShareIdx {
+    pub fn new(idx: usize) -> Self {
+        Self(Scalar::from(idx))
+    }
+}
+
+pub(crate) fn shamir_evaluation_points(num_shares: usize) -> Vec<ShareIdx> {
     // For now we are hardcoding the points to be 1, 2, ..., n.
     // TODO (#87): it should be still secure, right?
     // Potentially we can derive them from Session ID.
     (1..=u32::try_from(num_shares).expect("The number of shares cannot be over 2^32-1"))
-        .map(Scalar::from)
+        .map(|idx| ShareIdx(Scalar::from(idx)))
         .collect()
+}
+
+pub(crate) struct Polynomial(Vec<Scalar>);
+
+impl Polynomial {
+    pub fn random(rng: &mut impl CryptoRngCore, coeff0: &Scalar, degree: usize) -> Self {
+        let mut coeffs = Vec::with_capacity(degree);
+        coeffs.push(*coeff0);
+        for _ in 1..degree {
+            coeffs.push(Scalar::random_nonzero(rng));
+        }
+        Self(coeffs)
+    }
+
+    pub fn evaluate(&self, x: &ShareIdx) -> Scalar {
+        let mut res = self.0[0];
+        let mut xp = x.0;
+        for coeff in self.0[1..].iter() {
+            res = res + coeff * &xp;
+            xp = xp * x.0;
+        }
+        res
+    }
 }
 
 pub(crate) fn shamir_split(
     rng: &mut impl CryptoRngCore,
     secret: &Scalar,
     threshold: usize,
-    points: &[Scalar],
-) -> Vec<Scalar> {
-    let coeffs = (0..threshold - 1)
-        .map(|_| Scalar::random_nonzero(rng))
-        .collect::<Vec<_>>();
-    points
+    indices: &[ShareIdx],
+) -> BTreeMap<ShareIdx, Scalar> {
+    let polynomial = Polynomial::random(rng, secret, threshold);
+    indices
         .iter()
-        .map(|x| {
-            let mut res = *secret;
-            let mut xp = *x;
-            for coeff in coeffs.iter() {
-                res = res + coeff * &xp;
-                xp = &xp * x;
-            }
-            res
-        })
+        .map(|idx| (*idx, polynomial.evaluate(idx)))
         .collect()
 }
 
-pub(crate) fn interpolation_coeff(points: &[Scalar], idx: usize) -> Scalar {
-    points
+pub(crate) fn interpolation_coeff(idxs: &[ShareIdx], exclude_idx: usize) -> Scalar {
+    // TODO: the inversions can be precalculated if we calculate multiple interpolation coeffs
+    // for the same set of shares.
+    idxs.iter()
+        .enumerate()
+        .filter(|(i, _)| i != &exclude_idx)
+        .map(|(_, idx)| idx.0 * (idx.0 - idxs[exclude_idx].0).invert().unwrap())
+        .product()
+}
+
+#[cfg(test)]
+pub(crate) fn shamir_join_scalars<'a>(
+    pairs: impl Iterator<Item = (&'a ShareIdx, &'a Scalar)>,
+) -> Scalar {
+    let (share_idxs, values): (Vec<_>, Vec<_>) = pairs.map(|(k, v)| (*k, *v)).unzip();
+    values
         .iter()
         .enumerate()
-        .filter(|(j, _)| j != &idx)
-        .map(|(_, x)| x * &(x - &points[idx]).invert().unwrap())
-        .product()
+        .map(|(i, val)| val * &interpolation_coeff(&share_idxs, i))
+        .sum()
+}
+
+pub(crate) fn shamir_join_points<'a>(
+    pairs: impl Iterator<Item = (&'a ShareIdx, &'a Point)>,
+) -> Point {
+    let (share_idxs, values): (Vec<_>, Vec<_>) = pairs.map(|(k, v)| (*k, *v)).unzip();
+    values
+        .iter()
+        .enumerate()
+        .map(|(i, val)| val * &interpolation_coeff(&share_idxs, i))
+        .sum()
 }
 
 #[cfg(test)]
 mod tests {
     use rand_core::OsRng;
 
-    use super::{interpolation_coeff, shamir_evaluation_points, shamir_split};
+    use super::{shamir_evaluation_points, shamir_join_scalars, shamir_split};
     use crate::curve::Scalar;
-
-    fn shamir_join(secrets: &[Scalar], points: &[Scalar]) -> Scalar {
-        secrets
-            .iter()
-            .enumerate()
-            .map(|(idx, secret)| secret * &interpolation_coeff(points, idx))
-            .sum()
-    }
 
     #[test]
     fn split_and_join() {
@@ -66,12 +106,12 @@ mod tests {
         let num_shares = 5;
         let secret = Scalar::random(&mut OsRng);
         let points = shamir_evaluation_points(num_shares);
-        let shares = shamir_split(&mut OsRng, &secret, threshold, &points);
+        let mut shares = shamir_split(&mut OsRng, &secret, threshold, &points);
 
-        let recovered_secret = shamir_join(
-            &[shares[1], shares[2], shares[4]],
-            &[points[1], points[2], points[4]],
-        );
+        shares.remove(&points[0]);
+        shares.remove(&points[3]);
+
+        let recovered_secret = shamir_join_scalars(shares.iter());
         assert_eq!(recovered_secret, secret);
     }
 }

--- a/synedrion/tests/sessions.rs
+++ b/synedrion/tests/sessions.rs
@@ -93,7 +93,7 @@ async fn run_session<Res: ProtocolResult>(
 
         while !session.can_finalize(&accum).unwrap() {
             // This can be checked if a timeout expired, to see which nodes have not responded yet.
-            let unresponsive_parties = session.missing_messages(&accum);
+            let unresponsive_parties = session.missing_messages(&accum).unwrap();
             assert!(!unresponsive_parties.is_empty());
 
             println!("{key_str}: waiting for a message");


### PR DESCRIPTION
A part of #20. Not closing it yet since I'm not certain it's the best protocol to use, and it needs to be properly integrated with the rest of the framework. Also there is one pathway where a possible error is not attributable to any party - can be avoided by assuming that each party has access to public parts of keyshares of other nodes.

Merging this now because it has grown pretty big. Still more work needed to close the mentioned issues. 

Public:
- Added a "key resharing" protocol based on T. M. Wong, C. Wang, J. M. Wing "Verifiable Secret Redistribution for Archive Systems"(https://www.cs.cmu.edu/~wing/publications/Wong-Winga02.pdf, https://doi.org/10.1109/SISW.2002.1183515). Specifically, REDIST protocol.

Internal:
- Switched from using `HoleVec` to `BTreeMap` when accumulating messages from other nodes.
- Added a `Finalizable` trait to handle tasks or checking whether the round can be finalized, and if not, whose messages are missing. (see #85)
- Added `num_parties()` and `party_idx()` methods to `Round`
- Added `ShareIdx` type (a part of #31, decoupling `PartyIdx` from the share index)
