### PR TITLE
ZK proof cleanup

### DIFF
--- a/synedrion/src/cggmp21/params.rs
+++ b/synedrion/src/cggmp21/params.rs
@@ -1,7 +1,9 @@
+use crate::curve::Scalar;
 use crate::curve::ORDER;
 use crate::paillier::PaillierParams;
 use crate::uint::{
-    upcast_uint, U1024Mod, U2048Mod, U4096Mod, U512Mod, U1024, U2048, U4096, U512, U8192,
+    subtle::ConditionallySelectable, upcast_uint, Bounded, Encoding, NonZero, Signed, U1024Mod,
+    U2048Mod, U4096Mod, U512Mod, Zero, U1024, U2048, U4096, U512, U8192,
 };
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -68,7 +70,7 @@ impl PaillierParams for PaillierProduction {
 // but for now they are hardcoded to `k256`.
 pub trait SchemeParams: Clone + Send + PartialEq + Eq + core::fmt::Debug + 'static {
     /// The order of the curve.
-    const CURVE_ORDER: <Self::Paillier as PaillierParams>::Uint; // $q$
+    const CURVE_ORDER: NonZero<<Self::Paillier as PaillierParams>::Uint>; // $q$
     /// The sheme's statistical security parameter.
     const SECURITY_PARAMETER: usize; // $\kappa$
     /// The bound for secret values.
@@ -79,6 +81,48 @@ pub trait SchemeParams: Clone + Send + PartialEq + Eq + core::fmt::Debug + 'stat
     const EPS_BOUND: usize; // $\eps$, in paper $= 2 \ell$ (see Table 2)
     /// The parameters of the Paillier encryption.
     type Paillier: PaillierParams;
+
+    /// Converts a curve scalar to the associated integer type.
+    fn uint_from_scalar(value: &Scalar) -> <Self::Paillier as PaillierParams>::Uint {
+        let scalar_bytes = value.to_bytes();
+        let mut repr = <Self::Paillier as PaillierParams>::Uint::ZERO.to_be_bytes();
+
+        let uint_len = repr.as_ref().len();
+        let scalar_len = scalar_bytes.len();
+
+        debug_assert!(uint_len >= scalar_len);
+        repr.as_mut()[uint_len - scalar_len..].copy_from_slice(&scalar_bytes);
+        <Self::Paillier as PaillierParams>::Uint::from_be_bytes(repr)
+    }
+
+    /// Converts a curve scalar to the associated integer type, wrapped in `Bounded`.
+    fn bounded_from_scalar(value: &Scalar) -> Bounded<<Self::Paillier as PaillierParams>::Uint> {
+        const ORDER_BITS: usize = ORDER.bits_vartime();
+        Bounded::new(Self::uint_from_scalar(value), ORDER_BITS as u32).unwrap()
+    }
+
+    /// Converts a curve scalar to the associated integer type, wrapped in `Signed`.
+    fn signed_from_scalar(value: &Scalar) -> Signed<<Self::Paillier as PaillierParams>::Uint> {
+        Self::bounded_from_scalar(value).into_signed().unwrap()
+    }
+
+    /// Converts an integer to the associated curve scalar type.
+    fn scalar_from_uint(value: &<Self::Paillier as PaillierParams>::Uint) -> Scalar {
+        let r = *value % Self::CURVE_ORDER;
+
+        let repr = r.to_be_bytes();
+        let uint_len = repr.as_ref().len();
+        let scalar_len = Scalar::repr_len();
+
+        // Can unwrap here since the value is within the Scalar range
+        Scalar::try_from_bytes(&repr.as_ref()[uint_len - scalar_len..]).unwrap()
+    }
+
+    /// Converts a `Signed`-wrapped integer to the associated curve scalar type.
+    fn scalar_from_signed(value: &Signed<<Self::Paillier as PaillierParams>::Uint>) -> Scalar {
+        let abs_value = Self::scalar_from_uint(&value.abs());
+        Scalar::conditional_select(&abs_value, &-abs_value, value.is_negative())
+    }
 }
 
 /// Scheme parameters **for testing purposes only**.
@@ -100,7 +144,8 @@ impl SchemeParams for TestParams {
     const LP_BOUND: usize = 256;
     const EPS_BOUND: usize = 320;
     type Paillier = PaillierTest;
-    const CURVE_ORDER: <Self::Paillier as PaillierParams>::Uint = upcast_uint(ORDER);
+    const CURVE_ORDER: NonZero<<Self::Paillier as PaillierParams>::Uint> =
+        NonZero::<<Self::Paillier as PaillierParams>::Uint>::const_new(upcast_uint(ORDER)).0;
 }
 
 /// Production strength parameters.
@@ -113,5 +158,6 @@ impl SchemeParams for ProductionParams {
     const LP_BOUND: usize = Self::L_BOUND * 5;
     const EPS_BOUND: usize = Self::L_BOUND * 2;
     type Paillier = PaillierProduction;
-    const CURVE_ORDER: <Self::Paillier as PaillierParams>::Uint = upcast_uint(ORDER);
+    const CURVE_ORDER: NonZero<<Self::Paillier as PaillierParams>::Uint> =
+        NonZero::<<Self::Paillier as PaillierParams>::Uint>::const_new(upcast_uint(ORDER)).0;
 }

--- a/synedrion/src/cggmp21/protocols/presigning.rs
+++ b/synedrion/src/cggmp21/protocols/presigning.rs
@@ -893,7 +893,9 @@ impl<P: SchemeParams> FinalizableToResult for Round3<P> {
             &self.context.rho,
             &rho,
             pk,
+            &self.k_ciphertexts[my_idx],
             &self.g_ciphertexts[my_idx],
+            &cap_h,
             &aux,
         );
         assert!(p_mul.verify(

--- a/synedrion/src/cggmp21/protocols/presigning.rs
+++ b/synedrion/src/cggmp21/protocols/presigning.rs
@@ -920,6 +920,8 @@ impl<P: SchemeParams> FinalizableToResult for Round3<P> {
                 &self.delta,
                 &rho,
                 pk,
+                &delta_i,
+                &ciphertext,
                 &self.context.key_share.public_aux[j].rp_params,
                 &aux,
             );

--- a/synedrion/src/cggmp21/protocols/presigning.rs
+++ b/synedrion/src/cggmp21/protocols/presigning.rs
@@ -430,7 +430,9 @@ impl<P: SchemeParams> DirectRound for Round2<P> {
             &P::signed_from_scalar(&self.context.gamma),
             &self.context.nu,
             pk,
+            &self.g_ciphertexts[self.party_idx().as_usize()],
             &Point::GENERATOR,
+            &gamma,
             rp,
             &aux,
         );
@@ -691,7 +693,9 @@ impl<P: SchemeParams> DirectRound for Round3<P> {
             &P::signed_from_scalar(&self.context.ephemeral_scalar_share),
             &self.context.rho,
             pk,
+            &self.k_ciphertexts[self.party_idx().as_usize()],
             &self.big_gamma,
+            &self.big_delta,
             rp,
             &aux,
         );

--- a/synedrion/src/cggmp21/protocols/presigning.rs
+++ b/synedrion/src/cggmp21/protocols/presigning.rs
@@ -189,7 +189,8 @@ impl<P: SchemeParams> DirectRound for Round1<P> {
             rng,
             &P::signed_from_scalar(&self.context.ephemeral_scalar_share),
             &self.context.rho,
-            &self.context.key_share.secret_aux.paillier_sk,
+            self.context.key_share.secret_aux.paillier_sk.public_key(),
+            &self.k_ciphertext,
             &self.context.key_share.public_aux[destination.as_usize()].rp_params,
             &aux,
         );

--- a/synedrion/src/cggmp21/protocols/presigning.rs
+++ b/synedrion/src/cggmp21/protocols/presigning.rs
@@ -401,6 +401,9 @@ impl<P: SchemeParams> DirectRound for Round2<P> {
             target_pk,
             pk,
             &self.k_ciphertexts[idx],
+            &d,
+            &cap_f,
+            &gamma,
             rp,
             &aux,
         );
@@ -414,6 +417,9 @@ impl<P: SchemeParams> DirectRound for Round2<P> {
             target_pk,
             pk,
             &self.k_ciphertexts[idx],
+            &d_hat,
+            &f_hat,
+            &self.context.key_share.public_shares[self.party_idx().as_usize()],
             rp,
             &aux,
         );
@@ -841,6 +847,9 @@ impl<P: SchemeParams> FinalizableToResult for Round3<P> {
                     target_pk,
                     pk,
                     &self.k_ciphertexts[j],
+                    &r2_artefacts.cap_d,
+                    &r2_artefacts.cap_f,
+                    &cap_gamma,
                     rp,
                     &aux,
                 );

--- a/synedrion/src/cggmp21/protocols/presigning.rs
+++ b/synedrion/src/cggmp21/protocols/presigning.rs
@@ -840,8 +840,11 @@ impl<P: SchemeParams> FinalizableToResult for Round3<P> {
         // Mul proof
 
         let rho = RandomizerMod::random(rng, pk);
-        let cap_h = self.k_ciphertexts[my_idx]
-            .homomorphic_mul_unsigned(pk, &P::bounded_from_scalar(&self.context.gamma))
+        let cap_h = self.g_ciphertexts[my_idx]
+            .homomorphic_mul_unsigned(
+                pk,
+                &P::bounded_from_scalar(&self.context.ephemeral_scalar_share),
+            )
             .mul_randomizer(pk, &rho.retrieve());
 
         let p_mul = MulProof::<P>::new(

--- a/synedrion/src/cggmp21/protocols/signing.rs
+++ b/synedrion/src/cggmp21/protocols/signing.rs
@@ -218,6 +218,7 @@ impl<P: SchemeParams> FinalizableToResult for Round1<P> {
         // mul* proofs
 
         let x = self.context.key_share.secret_share;
+        let cap_x = self.context.key_share.public_shares[self.party_idx().as_usize()];
 
         let rho = RandomizerMod::random(rng, pk);
         let hat_cap_h = self.context.presigning.cap_k[my_idx]
@@ -238,9 +239,20 @@ impl<P: SchemeParams> FinalizableToResult for Round1<P> {
                 &rho,
                 pk,
                 &self.context.presigning.cap_k[my_idx],
+                &hat_cap_h,
+                &cap_x,
                 &self.context.key_share.public_aux[l].rp_params,
                 &aux,
             );
+
+            assert!(p_mul.verify(
+                pk,
+                &self.context.presigning.cap_k[my_idx],
+                &hat_cap_h,
+                &cap_x,
+                &self.context.key_share.public_aux[l].rp_params,
+                &aux,
+            ));
 
             mul_star_proofs.push((PartyIdx::from_usize(l), p_mul));
         }

--- a/synedrion/src/cggmp21/protocols/signing.rs
+++ b/synedrion/src/cggmp21/protocols/signing.rs
@@ -282,6 +282,8 @@ impl<P: SchemeParams> FinalizableToResult for Round1<P> {
                 &s_part_nonreduced,
                 &rho,
                 pk,
+                &self.s_part,
+                &ciphertext,
                 &self.context.key_share.public_aux[l].rp_params,
                 &aux,
             );

--- a/synedrion/src/cggmp21/protocols/signing.rs
+++ b/synedrion/src/cggmp21/protocols/signing.rs
@@ -22,7 +22,6 @@ use crate::rounds::{
     ProtocolResult, ReceiveError, ToResult,
 };
 use crate::tools::collections::HoleRange;
-use crate::uint::{Bounded, FromScalar, Signed};
 
 /// Possible results of the Signing protocol.
 #[derive(Debug, Clone, Copy)]
@@ -181,7 +180,7 @@ impl<P: SchemeParams> FinalizableToResult for Round1<P> {
 
                 let p_aff_g = AffGProof::<P>::new(
                     rng,
-                    &Signed::from_scalar(&self.context.key_share.secret_share),
+                    &P::signed_from_scalar(&self.context.key_share.secret_share),
                     self.context.presigning.hat_beta.get(j).unwrap(),
                     &self
                         .context
@@ -211,7 +210,7 @@ impl<P: SchemeParams> FinalizableToResult for Round1<P> {
             .context
             .presigning
             .cap_k
-            .homomorphic_mul_unsigned(pk, &Bounded::from_scalar(&x))
+            .homomorphic_mul_unsigned(pk, &P::bounded_from_scalar(&x))
             .mul_randomizer(pk, &rho.retrieve());
 
         let aux = (
@@ -224,7 +223,7 @@ impl<P: SchemeParams> FinalizableToResult for Round1<P> {
         for l in HoleRange::new(num_parties, my_idx) {
             let p_mul = MulStarProof::<P>::new(
                 rng,
-                &Signed::from_scalar(&x),
+                &P::signed_from_scalar(&x),
                 &rho,
                 pk,
                 &self.context.presigning.cap_k,
@@ -243,7 +242,7 @@ impl<P: SchemeParams> FinalizableToResult for Round1<P> {
                 .context
                 .presigning
                 .cap_k
-                .homomorphic_mul_unsigned(pk, &Bounded::from_scalar(&self.context.message)),
+                .homomorphic_mul_unsigned(pk, &P::bounded_from_scalar(&self.context.message)),
         );
 
         for j in HoleRange::new(num_parties, my_idx) {
@@ -258,7 +257,7 @@ impl<P: SchemeParams> FinalizableToResult for Round1<P> {
         for l in HoleRange::new(num_parties, my_idx) {
             let p_dec = DecProof::<P>::new(
                 rng,
-                &Signed::from_scalar(&s),
+                &P::signed_from_scalar(&s),
                 &rho,
                 pk,
                 &self.context.key_share.public_aux[l].rp_params,

--- a/synedrion/src/cggmp21/protocols/signing.rs
+++ b/synedrion/src/cggmp21/protocols/signing.rs
@@ -193,6 +193,9 @@ impl<P: SchemeParams> FinalizableToResult for Round1<P> {
                     target_pk,
                     pk,
                     &self.context.presigning.cap_k[j],
+                    self.context.presigning.hat_cap_d.get(j).unwrap(),
+                    self.context.presigning.hat_cap_f.get(j).unwrap(),
+                    &self.context.key_share.public_shares[my_idx],
                     rp,
                     &aux,
                 );

--- a/synedrion/src/cggmp21/sigma.rs
+++ b/synedrion/src/cggmp21/sigma.rs
@@ -1,17 +1,5 @@
 //! Sigma-protocols
 
-/*
-A general note about verification:
-
-In `verify()` methods we take both the auxiliary info (for reconstructing the challenge),
-and a challenge itself (as received with the proof from the other party).
-This is prescribed by Fig. 2 (ZK module for sigma-protocols).
-
-Taking `challenge` as a parameter when we are reconstructing it anyway
-may not seem necessary from the security perspective, but it provides a quick way
-to detect an invalid message at the cost of an increased message size.
-*/
-
 mod aff_g;
 mod dec;
 mod enc;

--- a/synedrion/src/cggmp21/sigma/aff_g.rs
+++ b/synedrion/src/cggmp21/sigma/aff_g.rs
@@ -16,6 +16,7 @@ const HASH_TAG: &[u8] = b"P_aff_g";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct AffGProof<P: SchemeParams> {
+    e: Signed<<P::Paillier as PaillierParams>::Uint>,
     cap_a: Ciphertext<P::Paillier>,
     cap_b_x: Point,
     cap_b_y: Ciphertext<P::Paillier>,
@@ -98,6 +99,7 @@ impl<P: SchemeParams> AffGProof<P> {
         let omega_y = (r_y_mod * rho_y_mod.pow_signed_vartime(&-e)).retrieve();
 
         Self {
+            e,
             cap_a,
             cap_b_x,
             cap_b_y,
@@ -138,6 +140,10 @@ impl<P: SchemeParams> AffGProof<P> {
         // Non-interactive challenge
         let e =
             Signed::from_xof_reader_bounded(&mut reader, &NonZero::new(P::CURVE_ORDER).unwrap());
+
+        if e != self.e {
+            return false;
+        }
 
         let aux_pk = setup.public_key();
 

--- a/synedrion/src/cggmp21/sigma/aff_g.rs
+++ b/synedrion/src/cggmp21/sigma/aff_g.rs
@@ -38,12 +38,12 @@ impl<P: SchemeParams> AffGProof<P> {
         rng: &mut impl CryptoRngCore,
         x: &Signed<<P::Paillier as PaillierParams>::Uint>,
         y: &Signed<<P::Paillier as PaillierParams>::Uint>,
-        rho_mod: &RandomizerMod<P::Paillier>, // Paillier randomizer for the public key $N_0$
-        rho_y_mod: &RandomizerMod<P::Paillier>, // Paillier randomizer for the public key $N_1$
+        rho: &RandomizerMod<P::Paillier>, // Paillier randomizer for the public key $N_0$
+        rho_y: &RandomizerMod<P::Paillier>, // Paillier randomizer for the public key $N_1$
         pk0: &PublicKeyPaillierPrecomputed<P::Paillier>, // $N_0$
         pk1: &PublicKeyPaillierPrecomputed<P::Paillier>, // $N_1$
-        cap_c: &Ciphertext<P::Paillier>,      // a ciphertext encrypted with `pk0`
-        setup: &RPParamsMod<P::Paillier>,     // $\hat{N}$, $s$, $t$
+        cap_c: &Ciphertext<P::Paillier>,  // a ciphertext encrypted with `pk0`
+        setup: &RPParamsMod<P::Paillier>, // $\hat{N}$, $s$, $t$
         aux: &impl Hashable,
     ) -> Self {
         let mut reader = XofHash::new_with_dst(HASH_TAG)
@@ -92,11 +92,11 @@ impl<P: SchemeParams> AffGProof<P> {
         let z3 = gamma + e_wide * m;
         let z4 = delta + e_wide * mu;
 
-        let omega = (r_mod * rho_mod.pow_signed_vartime(&e)).retrieve();
+        let omega = (r_mod * rho.pow_signed_vartime(&e)).retrieve();
 
         // NOTE: deviation from the paper to support a different $D$ (see the comment in `verify()`)
         // Original: $\rho_y^e$. Modified: $\rho_y^{-e}$.
-        let omega_y = (r_y_mod * rho_y_mod.pow_signed_vartime(&-e)).retrieve();
+        let omega_y = (r_y_mod * rho_y.pow_signed_vartime(&-e)).retrieve();
 
         Self {
             e,

--- a/synedrion/src/cggmp21/sigma/aff_g.rs
+++ b/synedrion/src/cggmp21/sigma/aff_g.rs
@@ -71,7 +71,7 @@ impl<P: SchemeParams> AffGProof<P> {
             pk0,
             &Ciphertext::new_with_randomizer_signed(pk0, &beta, &r_mod.retrieve()),
         );
-        let cap_b_x = &Point::GENERATOR * &P::scalar_from_signed(&alpha);
+        let cap_b_x = Point::GENERATOR * P::scalar_from_signed(&alpha);
         let cap_b_y = Ciphertext::new_with_randomizer_signed(pk1, &beta, &r_y_mod.retrieve());
         let cap_e = setup.commit(&alpha, &gamma).retrieve();
         let cap_s = setup.commit(x, &m).retrieve();
@@ -81,7 +81,7 @@ impl<P: SchemeParams> AffGProof<P> {
         // Original: $s^y$. Modified: $s^{-y}$
         let cap_t = setup.commit(&-y, &mu).retrieve();
 
-        let z1 = alpha + e * *x;
+        let z1 = alpha + e * x;
 
         // NOTE: deviation from the paper to support a different $D$ (see the comment in `verify()`)
         // Original: $z_2 = \beta + e y$
@@ -158,7 +158,7 @@ impl<P: SchemeParams> AffGProof<P> {
         }
 
         // g^{z_1} = B_x X^e
-        if &Point::GENERATOR * &P::scalar_from_signed(&self.z1)
+        if Point::GENERATOR * P::scalar_from_signed(&self.z1)
             != self.cap_b_x + cap_x * &P::scalar_from_signed(&e)
         {
             return false;
@@ -233,7 +233,7 @@ mod tests {
             &Ciphertext::new_with_randomizer_signed(pk0, &-y, &rho.retrieve()),
         );
         let cap_y = Ciphertext::new_with_randomizer_signed(pk1, &y, &rho_y.retrieve());
-        let cap_x = &Point::GENERATOR * &Params::scalar_from_signed(&x);
+        let cap_x = Point::GENERATOR * Params::scalar_from_signed(&x);
 
         let proof = AffGProof::<Params>::new(
             &mut OsRng, &x, &y, &rho, &rho_y, pk0, pk1, &cap_c, &setup, &aux,

--- a/synedrion/src/cggmp21/sigma/dec.rs
+++ b/synedrion/src/cggmp21/sigma/dec.rs
@@ -54,7 +54,7 @@ impl<P: SchemeParams> DecProof<P> {
         let cap_a = Ciphertext::new_with_randomizer_signed(pk, &alpha, &r.retrieve());
         let gamma = P::scalar_from_signed(&alpha);
 
-        let z1 = alpha + e * *y;
+        let z1 = alpha + e * y;
         let z2 = nu + e.into_wide() * mu;
 
         let omega = (r * rho.pow_signed_vartime(&e)).retrieve();

--- a/synedrion/src/cggmp21/sigma/dec.rs
+++ b/synedrion/src/cggmp21/sigma/dec.rs
@@ -30,9 +30,9 @@ impl<P: SchemeParams> DecProof<P> {
     pub fn new(
         rng: &mut impl CryptoRngCore,
         y: &Signed<<P::Paillier as PaillierParams>::Uint>,
-        rho: &RandomizerMod<P::Paillier>,
+        rho: &RandomizerMod<P::Paillier>, // Paillier randomizer for the public key $N$
         pk: &PublicKeyPaillierPrecomputed<P::Paillier>, // $N$
-        setup: &RPParamsMod<P::Paillier>,               // $\hat{N}$, $s$, $t$
+        setup: &RPParamsMod<P::Paillier>, // $\hat{N}$, $s$, $t$
         aux: &impl Hashable,
     ) -> Self {
         let mut reader = XofHash::new_with_dst(HASH_TAG)

--- a/synedrion/src/cggmp21/sigma/enc.rs
+++ b/synedrion/src/cggmp21/sigma/enc.rs
@@ -25,7 +25,7 @@ Public inputs:
 - Paillier ciphertext $K = enc_0(k, \rho)$,
 - Setup parameters ($\hat{N}$, $s$, $t$).
 */
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct EncProof<P: SchemeParams> {
     e: Signed<<P::Paillier as PaillierParams>::Uint>,
     cap_s: RPCommitment<P::Paillier>,

--- a/synedrion/src/cggmp21/sigma/enc.rs
+++ b/synedrion/src/cggmp21/sigma/enc.rs
@@ -9,7 +9,7 @@ use crate::paillier::{
     Randomizer, RandomizerMod, SecretKeyPaillierPrecomputed,
 };
 use crate::tools::hashing::{Chain, Hashable, XofHash};
-use crate::uint::{NonZero, Signed};
+use crate::uint::Signed;
 
 const HASH_TAG: &[u8] = b"P_enc";
 
@@ -38,8 +38,7 @@ impl<P: SchemeParams> EncProof<P> {
             .finalize_to_reader();
 
         // Non-interactive challenge
-        let e =
-            Signed::from_xof_reader_bounded(&mut reader, &NonZero::new(P::CURVE_ORDER).unwrap());
+        let e = Signed::from_xof_reader_bounded(&mut reader, &P::CURVE_ORDER);
 
         let pk = sk.public_key();
         let hat_cap_n = &setup.public_key().modulus_bounded(); // $\hat{N}$
@@ -82,8 +81,7 @@ impl<P: SchemeParams> EncProof<P> {
             .finalize_to_reader();
 
         // Non-interactive challenge
-        let e =
-            Signed::from_xof_reader_bounded(&mut reader, &NonZero::new(P::CURVE_ORDER).unwrap());
+        let e = Signed::from_xof_reader_bounded(&mut reader, &P::CURVE_ORDER);
 
         if e != self.e {
             return false;

--- a/synedrion/src/cggmp21/sigma/enc.rs
+++ b/synedrion/src/cggmp21/sigma/enc.rs
@@ -54,7 +54,7 @@ impl<P: SchemeParams> EncProof<P> {
         let cap_a = Ciphertext::new_with_randomizer_signed(pk, &alpha, &r.retrieve());
         let cap_c = setup.commit(&alpha, &gamma).retrieve();
 
-        let z1 = alpha + e * *k;
+        let z1 = alpha + e * k;
         let z2 = (r * rho.pow_signed_vartime(&e)).retrieve();
         let z3 = gamma + mu * e.into_wide();
 

--- a/synedrion/src/cggmp21/sigma/enc.rs
+++ b/synedrion/src/cggmp21/sigma/enc.rs
@@ -15,6 +15,7 @@ const HASH_TAG: &[u8] = b"P_enc";
 
 #[derive(Clone, Serialize, Deserialize)]
 pub(crate) struct EncProof<P: SchemeParams> {
+    e: Signed<<P::Paillier as PaillierParams>::Uint>,
     cap_s: RPCommitment<P::Paillier>,
     cap_a: Ciphertext<P::Paillier>,
     cap_c: RPCommitment<P::Paillier>,
@@ -59,6 +60,7 @@ impl<P: SchemeParams> EncProof<P> {
         let z3 = gamma + mu * e.into_wide();
 
         Self {
+            e,
             cap_s,
             cap_a,
             cap_c,
@@ -82,6 +84,10 @@ impl<P: SchemeParams> EncProof<P> {
         // Non-interactive challenge
         let e =
             Signed::from_xof_reader_bounded(&mut reader, &NonZero::new(P::CURVE_ORDER).unwrap());
+
+        if e != self.e {
+            return false;
+        }
 
         // z_1 \in \pm 2^{\ell + \eps}
         if !self.z1.in_range_bits(P::L_BOUND + P::EPS_BOUND) {

--- a/synedrion/src/cggmp21/sigma/fac.rs
+++ b/synedrion/src/cggmp21/sigma/fac.rs
@@ -9,7 +9,7 @@ use crate::paillier::{
     SecretKeyPaillierPrecomputed,
 };
 use crate::tools::hashing::{Chain, Hashable, XofHash};
-use crate::uint::{Bounded, Integer, NonZero, Signed};
+use crate::uint::{Bounded, Integer, Signed};
 
 const HASH_TAG: &[u8] = b"P_fac";
 
@@ -41,8 +41,7 @@ impl<P: SchemeParams> FacProof<P> {
             .finalize_to_reader();
 
         // Non-interactive challenge
-        let e =
-            Signed::from_xof_reader_bounded(&mut reader, &NonZero::new(P::CURVE_ORDER).unwrap());
+        let e = Signed::from_xof_reader_bounded(&mut reader, &P::CURVE_ORDER);
         let e_wide = e.into_wide();
 
         let pk = sk.public_key();
@@ -120,8 +119,7 @@ impl<P: SchemeParams> FacProof<P> {
             .finalize_to_reader();
 
         // Non-interactive challenge
-        let e =
-            Signed::from_xof_reader_bounded(&mut reader, &NonZero::new(P::CURVE_ORDER).unwrap());
+        let e = Signed::from_xof_reader_bounded(&mut reader, &P::CURVE_ORDER);
 
         if e != self.e {
             return false;

--- a/synedrion/src/cggmp21/sigma/fac.rs
+++ b/synedrion/src/cggmp21/sigma/fac.rs
@@ -32,8 +32,8 @@ pub(crate) struct FacProof<P: SchemeParams> {
 impl<P: SchemeParams> FacProof<P> {
     pub fn new(
         rng: &mut impl CryptoRngCore,
-        sk: &SecretKeyPaillierPrecomputed<P::Paillier>,
-        setup: &RPParamsMod<P::Paillier>, // $\hat{N}$, $s$, $t$
+        sk: &SecretKeyPaillierPrecomputed<P::Paillier>, // $N_0$
+        setup: &RPParamsMod<P::Paillier>,               // $\hat{N}$, $s$, $t$
         aux: &impl Hashable,
     ) -> Self {
         let mut reader = XofHash::new_with_dst(HASH_TAG)
@@ -111,8 +111,8 @@ impl<P: SchemeParams> FacProof<P> {
 
     pub fn verify(
         &self,
-        pk: &PublicKeyPaillierPrecomputed<P::Paillier>,
-        setup: &RPParamsMod<P::Paillier>, // $s$, $t$
+        pk: &PublicKeyPaillierPrecomputed<P::Paillier>, // $N_0$
+        setup: &RPParamsMod<P::Paillier>,               // $\hat{N}$, $s$, $t$
         aux: &impl Hashable,
     ) -> bool {
         let mut reader = XofHash::new_with_dst(HASH_TAG)

--- a/synedrion/src/cggmp21/sigma/fac.rs
+++ b/synedrion/src/cggmp21/sigma/fac.rs
@@ -36,7 +36,11 @@ impl<P: SchemeParams> FacProof<P> {
         setup: &RPParamsMod<P::Paillier>,               // $\hat{N}$, $s$, $t$
         aux: &impl Hashable,
     ) -> Self {
+        let pk = sk.public_key();
+
         let mut reader = XofHash::new_with_dst(HASH_TAG)
+            .chain(pk)
+            .chain(setup)
             .chain(aux)
             .finalize_to_reader();
 
@@ -44,7 +48,6 @@ impl<P: SchemeParams> FacProof<P> {
         let e = Signed::from_xof_reader_bounded(&mut reader, &P::CURVE_ORDER);
         let e_wide = e.into_wide();
 
-        let pk = sk.public_key();
         let hat_cap_n = &setup.public_key().modulus_bounded(); // $\hat{N}$
 
         // NOTE: using `2^(Paillier::PRIME_BITS - 1)` as $\sqrt{N_0}$ (which is its lower bound)
@@ -115,6 +118,8 @@ impl<P: SchemeParams> FacProof<P> {
         aux: &impl Hashable,
     ) -> bool {
         let mut reader = XofHash::new_with_dst(HASH_TAG)
+            .chain(pk)
+            .chain(setup)
             .chain(aux)
             .finalize_to_reader();
 

--- a/synedrion/src/cggmp21/sigma/fac.rs
+++ b/synedrion/src/cggmp21/sigma/fac.rs
@@ -23,7 +23,7 @@ Public inputs:
 - Paillier public key $N_0 = p * q$,
 - Setup parameters ($\hat{N}$, $s$, $t$).
 */
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct FacProof<P: SchemeParams> {
     e: Signed<<P::Paillier as PaillierParams>::Uint>,
     cap_p: RPCommitment<P::Paillier>,

--- a/synedrion/src/cggmp21/sigma/fac.rs
+++ b/synedrion/src/cggmp21/sigma/fac.rs
@@ -15,6 +15,7 @@ const HASH_TAG: &[u8] = b"P_fac";
 
 #[derive(Clone, Serialize, Deserialize)]
 pub(crate) struct FacProof<P: SchemeParams> {
+    e: Signed<<P::Paillier as PaillierParams>::Uint>,
     cap_p: RPCommitment<P::Paillier>,
     cap_q: RPCommitment<P::Paillier>,
     cap_a: RPCommitment<P::Paillier>,
@@ -93,6 +94,7 @@ impl<P: SchemeParams> FacProof<P> {
         let v = r + (e_wide.into_wide() * hat_sigma);
 
         Self {
+            e,
             cap_p,
             cap_q: cap_q.retrieve(),
             cap_a,
@@ -120,6 +122,10 @@ impl<P: SchemeParams> FacProof<P> {
         // Non-interactive challenge
         let e =
             Signed::from_xof_reader_bounded(&mut reader, &NonZero::new(P::CURVE_ORDER).unwrap());
+
+        if e != self.e {
+            return false;
+        }
 
         let aux_pk = setup.public_key();
 

--- a/synedrion/src/cggmp21/sigma/log_star.rs
+++ b/synedrion/src/cggmp21/sigma/log_star.rs
@@ -56,7 +56,7 @@ impl<P: SchemeParams> LogStarProof<P> {
         let cap_y = g * &P::scalar_from_signed(&alpha);
         let cap_d = setup.commit(&alpha, &gamma).retrieve();
 
-        let z1 = alpha + e * *x;
+        let z1 = alpha + e * x;
         let z2 = (r * rho.pow_signed_vartime(&e)).retrieve();
         let z3 = gamma + mu * e.into_wide();
 
@@ -141,11 +141,11 @@ mod tests {
 
         let aux: &[u8] = b"abcde";
 
-        let g = &Point::GENERATOR * &Scalar::random(&mut OsRng);
+        let g = Point::GENERATOR * Scalar::random(&mut OsRng);
         let x = Signed::random_bounded_bits(&mut OsRng, Params::L_BOUND);
         let rho = RandomizerMod::random(&mut OsRng, pk);
         let cap_c = Ciphertext::new_with_randomizer_signed(pk, &x, &rho.retrieve());
-        let cap_x = &g * &Params::scalar_from_signed(&x);
+        let cap_x = g * Params::scalar_from_signed(&x);
 
         let proof = LogStarProof::<Params>::new(&mut OsRng, &x, &rho, pk, &g, &setup, &aux);
         assert!(proof.verify(pk, &cap_c, &g, &cap_x, &setup, &aux));

--- a/synedrion/src/cggmp21/sigma/log_star.rs
+++ b/synedrion/src/cggmp21/sigma/log_star.rs
@@ -16,6 +16,7 @@ const HASH_TAG: &[u8] = b"P_log*";
 
 #[derive(Clone, Serialize, Deserialize)]
 pub(crate) struct LogStarProof<P: SchemeParams> {
+    e: Signed<<P::Paillier as PaillierParams>::Uint>,
     cap_s: RPCommitment<P::Paillier>,
     cap_a: Ciphertext<P::Paillier>,
     cap_y: Point,
@@ -61,6 +62,7 @@ impl<P: SchemeParams> LogStarProof<P> {
         let z3 = gamma + mu * e.into_wide();
 
         Self {
+            e,
             cap_s,
             cap_a,
             cap_y,
@@ -88,6 +90,10 @@ impl<P: SchemeParams> LogStarProof<P> {
         // Non-interactive challenge
         let e =
             Signed::from_xof_reader_bounded(&mut reader, &NonZero::new(P::CURVE_ORDER).unwrap());
+
+        if e != self.e {
+            return false;
+        }
 
         // enc_0(z1, z2) == A (+) C (*) e
         let c = Ciphertext::new_with_randomizer_signed(pk, &self.z1, &self.z2);

--- a/synedrion/src/cggmp21/sigma/log_star.rs
+++ b/synedrion/src/cggmp21/sigma/log_star.rs
@@ -28,7 +28,7 @@ Public inputs:
 - Point $X = g * x$,
 - Setup parameters ($\hat{N}$, $s$, $t$).
 */
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct LogStarProof<P: SchemeParams> {
     e: Signed<<P::Paillier as PaillierParams>::Uint>,
     cap_s: RPCommitment<P::Paillier>,

--- a/synedrion/src/cggmp21/sigma/log_star.rs
+++ b/synedrion/src/cggmp21/sigma/log_star.rs
@@ -31,10 +31,10 @@ impl<P: SchemeParams> LogStarProof<P> {
     pub fn new(
         rng: &mut impl CryptoRngCore,
         x: &Signed<<P::Paillier as PaillierParams>::Uint>, // $x \in +- 2^\ell$
-        rho: &RandomizerMod<P::Paillier>,                  // $\rho$
-        pk: &PublicKeyPaillierPrecomputed<P::Paillier>,    // $N_0$
-        g: &Point,                                         // $g$
-        setup: &RPParamsMod<P::Paillier>,                  // $\hat{N}$, $s$, $t$
+        rho: &RandomizerMod<P::Paillier>, // Paillier randomizer for the public key $N_0$
+        pk: &PublicKeyPaillierPrecomputed<P::Paillier>, // $N_0$
+        g: &Point,
+        setup: &RPParamsMod<P::Paillier>, // $\hat{N}$, $s$, $t$
         aux: &impl Hashable,
     ) -> Self {
         let mut reader = XofHash::new_with_dst(HASH_TAG)
@@ -77,10 +77,10 @@ impl<P: SchemeParams> LogStarProof<P> {
     pub fn verify(
         &self,
         pk: &PublicKeyPaillierPrecomputed<P::Paillier>,
-        cap_c: &Ciphertext<P::Paillier>,  // $C = encrypt(x, \rho)$
-        g: &Point,                        // $g$
+        cap_c: &Ciphertext<P::Paillier>, // $C = encrypt(x, \rho)$
+        g: &Point,
         cap_x: &Point,                    // $X = g^x$
-        setup: &RPParamsMod<P::Paillier>, // $s$, $t$
+        setup: &RPParamsMod<P::Paillier>, // $\hat{N}$, $s$, $t$
         aux: &impl Hashable,
     ) -> bool {
         let mut reader = XofHash::new_with_dst(HASH_TAG)

--- a/synedrion/src/cggmp21/sigma/mod_.rs
+++ b/synedrion/src/cggmp21/sigma/mod_.rs
@@ -16,7 +16,7 @@ const HASH_TAG: &[u8] = b"P_mod";
 struct ModCommitment<P: SchemeParams>(<P::Paillier as PaillierParams>::Uint);
 
 impl<P: SchemeParams> ModCommitment<P> {
-    pub fn random(
+    fn random(
         rng: &mut impl CryptoRngCore,
         pk: &PublicKeyPaillierPrecomputed<P::Paillier>,
     ) -> Self {
@@ -67,7 +67,7 @@ pub(crate) struct ModProof<P: SchemeParams> {
 }
 
 impl<P: SchemeParams> ModProof<P> {
-    pub(crate) fn new(
+    pub fn new(
         rng: &mut impl CryptoRngCore,
         sk: &SecretKeyPaillierPrecomputed<P::Paillier>,
         aux: &impl Hashable,
@@ -127,7 +127,7 @@ impl<P: SchemeParams> ModProof<P> {
         }
     }
 
-    pub(crate) fn verify(
+    pub fn verify(
         &self,
         pk: &PublicKeyPaillierPrecomputed<P::Paillier>,
         aux: &impl Hashable,

--- a/synedrion/src/cggmp21/sigma/mod_.rs
+++ b/synedrion/src/cggmp21/sigma/mod_.rs
@@ -56,6 +56,15 @@ struct ModProofElem<P: PaillierParams> {
     z: P::Uint,
 }
 
+/**
+ZK proof: Proof of Paillier-Blum modulus.
+
+Secret inputs:
+- primes $p$, $q$.
+
+Public inputs:
+- Paillier public key $N = p q$,
+*/
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(bound(serialize = "ModCommitment<P>: Serialize,
     ModChallenge<P>: Serialize"))]

--- a/synedrion/src/cggmp21/sigma/mod_.rs
+++ b/synedrion/src/cggmp21/sigma/mod_.rs
@@ -12,7 +12,7 @@ use crate::uint::{JacobiSymbol, JacobiSymbolTrait, RandomMod, Retrieve, UintLike
 
 const HASH_TAG: &[u8] = b"P_mod";
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct ModCommitment<P: SchemeParams>(<P::Paillier as PaillierParams>::Uint);
 
 impl<P: SchemeParams> ModCommitment<P> {
@@ -48,7 +48,7 @@ impl<P: SchemeParams> ModChallenge<P> {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct ModProofElem<P: PaillierParams> {
     x: P::Uint,
     a: bool,
@@ -65,7 +65,7 @@ Secret inputs:
 Public inputs:
 - Paillier public key $N = p q$,
 */
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound(serialize = "ModCommitment<P>: Serialize,
     ModChallenge<P>: Serialize"))]
 #[serde(bound(deserialize = "ModCommitment<P>: for<'x> Deserialize<'x>,

--- a/synedrion/src/cggmp21/sigma/mod_.rs
+++ b/synedrion/src/cggmp21/sigma/mod_.rs
@@ -34,8 +34,9 @@ impl<P: SchemeParams> ModCommitment<P> {
 struct ModChallenge<P: SchemeParams>(Vec<<P::Paillier as PaillierParams>::Uint>);
 
 impl<P: SchemeParams> ModChallenge<P> {
-    fn new(aux: &impl Hashable, pk: &PublicKeyPaillierPrecomputed<P::Paillier>) -> Self {
+    fn new(pk: &PublicKeyPaillierPrecomputed<P::Paillier>, aux: &impl Hashable) -> Self {
         let mut reader = XofHash::new_with_dst(HASH_TAG)
+            .chain(pk)
             .chain(aux)
             .finalize_to_reader();
 
@@ -73,7 +74,7 @@ impl<P: SchemeParams> ModProof<P> {
         aux: &impl Hashable,
     ) -> Self {
         let pk = sk.public_key();
-        let challenge = ModChallenge::<P>::new(aux, pk);
+        let challenge = ModChallenge::<P>::new(pk, aux);
 
         let commitment = ModCommitment::<P>::random(rng, pk);
 
@@ -132,7 +133,7 @@ impl<P: SchemeParams> ModProof<P> {
         pk: &PublicKeyPaillierPrecomputed<P::Paillier>,
         aux: &impl Hashable,
     ) -> bool {
-        let challenge = ModChallenge::new(aux, pk);
+        let challenge = ModChallenge::new(pk, aux);
         if challenge != self.challenge {
             return false;
         }

--- a/synedrion/src/cggmp21/sigma/mul.rs
+++ b/synedrion/src/cggmp21/sigma/mul.rs
@@ -8,7 +8,7 @@ use crate::paillier::{
     Ciphertext, PaillierParams, PublicKeyPaillierPrecomputed, Randomizer, RandomizerMod,
 };
 use crate::tools::hashing::{Chain, Hashable, XofHash};
-use crate::uint::{Bounded, NonZero, Retrieve, Signed};
+use crate::uint::{Bounded, Retrieve, Signed};
 
 const HASH_TAG: &[u8] = b"P_mul";
 
@@ -38,8 +38,7 @@ impl<P: SchemeParams> MulProof<P> {
             .finalize_to_reader();
 
         // Non-interactive challenge
-        let e =
-            Signed::from_xof_reader_bounded(&mut reader, &NonZero::new(P::CURVE_ORDER).unwrap());
+        let e = Signed::from_xof_reader_bounded(&mut reader, &P::CURVE_ORDER);
 
         let alpha_mod = pk.random_invertible_group_elem(rng);
         let r_mod = RandomizerMod::random(rng, pk);
@@ -85,8 +84,7 @@ impl<P: SchemeParams> MulProof<P> {
             .finalize_to_reader();
 
         // Non-interactive challenge
-        let e =
-            Signed::from_xof_reader_bounded(&mut reader, &NonZero::new(P::CURVE_ORDER).unwrap());
+        let e = Signed::from_xof_reader_bounded(&mut reader, &P::CURVE_ORDER);
 
         if e != self.e {
             return false;

--- a/synedrion/src/cggmp21/sigma/mul.rs
+++ b/synedrion/src/cggmp21/sigma/mul.rs
@@ -14,6 +14,7 @@ const HASH_TAG: &[u8] = b"P_mul";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct MulProof<P: SchemeParams> {
+    e: Signed<<P::Paillier as PaillierParams>::Uint>,
     cap_a: Ciphertext<P::Paillier>,
     cap_b: Ciphertext<P::Paillier>,
     z: Signed<<P::Paillier as PaillierParams>::WideUint>,
@@ -62,6 +63,7 @@ impl<P: SchemeParams> MulProof<P> {
         let v = (s_mod * rho_x_mod.pow_signed_vartime(&e)).retrieve();
 
         Self {
+            e,
             cap_a,
             cap_b,
             z,
@@ -85,6 +87,10 @@ impl<P: SchemeParams> MulProof<P> {
         // Non-interactive challenge
         let e =
             Signed::from_xof_reader_bounded(&mut reader, &NonZero::new(P::CURVE_ORDER).unwrap());
+
+        if e != self.e {
+            return false;
+        }
 
         // Y^z u^N = A * C^e \mod N^2
         if cap_y

--- a/synedrion/src/cggmp21/sigma/mul.rs
+++ b/synedrion/src/cggmp21/sigma/mul.rs
@@ -26,11 +26,11 @@ impl<P: SchemeParams> MulProof<P> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         rng: &mut impl CryptoRngCore,
-        secret: &Signed<<P::Paillier as PaillierParams>::Uint>, // $x$
-        rho_x_mod: &RandomizerMod<P::Paillier>,                 // $\rho_x$
-        rho_mod: &RandomizerMod<P::Paillier>,                   // $\rho$
-        pk: &PublicKeyPaillierPrecomputed<P::Paillier>,         // $N$
-        cap_y: &Ciphertext<P::Paillier>,                        // $Y$
+        x: &Signed<<P::Paillier as PaillierParams>::Uint>,
+        rho_x: &RandomizerMod<P::Paillier>,
+        rho: &RandomizerMod<P::Paillier>,
+        pk: &PublicKeyPaillierPrecomputed<P::Paillier>, // $N$
+        cap_y: &Ciphertext<P::Paillier>,
         aux: &impl Hashable,
     ) -> Self {
         let mut reader = XofHash::new_with_dst(HASH_TAG)
@@ -58,9 +58,9 @@ impl<P: SchemeParams> MulProof<P> {
             .mul_randomizer(pk, &r);
         let cap_b = Ciphertext::new_with_randomizer(pk, alpha.as_ref(), &s);
 
-        let z = alpha.into_wide().into_signed().unwrap() + e.mul_wide(secret);
-        let u = (r_mod * rho_mod.pow_signed_vartime(&e)).retrieve();
-        let v = (s_mod * rho_x_mod.pow_signed_vartime(&e)).retrieve();
+        let z = alpha.into_wide().into_signed().unwrap() + e.mul_wide(x);
+        let u = (r_mod * rho.pow_signed_vartime(&e)).retrieve();
+        let v = (s_mod * rho_x.pow_signed_vartime(&e)).retrieve();
 
         Self {
             e,

--- a/synedrion/src/cggmp21/sigma/mul.rs
+++ b/synedrion/src/cggmp21/sigma/mul.rs
@@ -22,6 +22,22 @@ pub(crate) struct MulProof<P: SchemeParams> {
     v: Randomizer<P::Paillier>,
 }
 
+/**
+ZK proof: Paillier multiplication.
+
+Secret inputs:
+- $x$ (technically any integer since it will be implicitly reduced modulo $q$ or $\phi(N)$,
+  but we limit its size to `Uint` since that's what we use in this library),
+- $\rho_x$, a Paillier randomizer for the public key $N$,
+- $\rho$, a Paillier randomizer for the public key $N$.
+
+Public inputs:
+- Paillier public key $N$,
+- Paillier ciphertext $X = enc(x, \rho_x)$,
+- Paillier ciphertext $Y$ encrypted with $N$,
+- Paillier ciphertext $C = (Y (*) x) * \rho^N \mod N^2$,
+- Setup parameters ($\hat{N}$, $s$, $t$).
+*/
 impl<P: SchemeParams> MulProof<P> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -29,10 +45,10 @@ impl<P: SchemeParams> MulProof<P> {
         x: &Signed<<P::Paillier as PaillierParams>::Uint>,
         rho_x: &RandomizerMod<P::Paillier>,
         rho: &RandomizerMod<P::Paillier>,
-        pk: &PublicKeyPaillierPrecomputed<P::Paillier>, // $N$
-        cap_x: &Ciphertext<P::Paillier>,                // $X = enc(x, \rho_x)$
-        cap_y: &Ciphertext<P::Paillier>,                // $Y$
-        cap_c: &Ciphertext<P::Paillier>,                // $C = (Y (*) x) * \rho^N$
+        pk: &PublicKeyPaillierPrecomputed<P::Paillier>,
+        cap_x: &Ciphertext<P::Paillier>,
+        cap_y: &Ciphertext<P::Paillier>,
+        cap_c: &Ciphertext<P::Paillier>,
         aux: &impl Hashable,
     ) -> Self {
         let mut reader = XofHash::new_with_dst(HASH_TAG)
@@ -79,10 +95,10 @@ impl<P: SchemeParams> MulProof<P> {
 
     pub fn verify(
         &self,
-        pk: &PublicKeyPaillierPrecomputed<P::Paillier>, // $N$
-        cap_x: &Ciphertext<P::Paillier>,                // $X = enc(x, \rho_x)$
-        cap_y: &Ciphertext<P::Paillier>,                // $Y$
-        cap_c: &Ciphertext<P::Paillier>,                // $C = (Y (*) x) * \rho^N$
+        pk: &PublicKeyPaillierPrecomputed<P::Paillier>,
+        cap_x: &Ciphertext<P::Paillier>,
+        cap_y: &Ciphertext<P::Paillier>,
+        cap_c: &Ciphertext<P::Paillier>,
         aux: &impl Hashable,
     ) -> bool {
         let mut reader = XofHash::new_with_dst(HASH_TAG)

--- a/synedrion/src/cggmp21/sigma/mul_star.rs
+++ b/synedrion/src/cggmp21/sigma/mul_star.rs
@@ -61,11 +61,11 @@ impl<P: SchemeParams> MulStarProof<P> {
         let cap_a = cap_c
             .homomorphic_mul(pk, &alpha)
             .mul_randomizer(pk, &r.retrieve());
-        let cap_b_x = &Point::GENERATOR * &P::scalar_from_signed(&alpha);
+        let cap_b_x = Point::GENERATOR * P::scalar_from_signed(&alpha);
         let cap_e = setup.commit(&alpha, &gamma).retrieve();
         let cap_s = setup.commit(x, &m).retrieve();
 
-        let z1 = alpha + e * *x;
+        let z1 = alpha + e * x;
         let z2 = gamma + e.into_wide() * m;
         let omega = (r * rho.pow_signed(&e)).retrieve();
 
@@ -117,7 +117,7 @@ impl<P: SchemeParams> MulStarProof<P> {
         }
 
         // g^{z_1} == B_x X^e
-        if &Point::GENERATOR * &P::scalar_from_signed(&self.z1)
+        if Point::GENERATOR * P::scalar_from_signed(&self.z1)
             != self.cap_b_x + cap_x * &P::scalar_from_signed(&e)
         {
             return false;
@@ -164,7 +164,7 @@ mod tests {
         let cap_d = cap_c
             .homomorphic_mul(pk, &x)
             .mul_randomizer(pk, &rho.retrieve());
-        let cap_x = &Point::GENERATOR * &Params::scalar_from_signed(&x);
+        let cap_x = Point::GENERATOR * Params::scalar_from_signed(&x);
 
         let proof = MulStarProof::<Params>::new(&mut OsRng, &x, &rho, pk, &cap_c, &setup, &aux);
         assert!(proof.verify(pk, &cap_c, &cap_d, &cap_x, &setup, &aux));

--- a/synedrion/src/cggmp21/sigma/mul_star.rs
+++ b/synedrion/src/cggmp21/sigma/mul_star.rs
@@ -16,13 +16,14 @@ const HASH_TAG: &[u8] = b"P_mul*";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct MulStarProof<P: SchemeParams> {
-    cap_a: Ciphertext<P::Paillier>,                        // $A$
-    cap_b_x: Point,                                        // $B_x$
-    cap_e: RPCommitment<P::Paillier>,                      // $E$
-    cap_s: RPCommitment<P::Paillier>,                      // $S$
-    z1: Signed<<P::Paillier as PaillierParams>::Uint>,     // $z_1$
-    z2: Signed<<P::Paillier as PaillierParams>::WideUint>, // $z_2$
-    omega: Randomizer<P::Paillier>,                        // $\omega$
+    e: Signed<<P::Paillier as PaillierParams>::Uint>,
+    cap_a: Ciphertext<P::Paillier>,
+    cap_b_x: Point,
+    cap_e: RPCommitment<P::Paillier>,
+    cap_s: RPCommitment<P::Paillier>,
+    z1: Signed<<P::Paillier as PaillierParams>::Uint>,
+    z2: Signed<<P::Paillier as PaillierParams>::WideUint>,
+    omega: Randomizer<P::Paillier>,
 }
 
 impl<P: SchemeParams> MulStarProof<P> {
@@ -70,6 +71,7 @@ impl<P: SchemeParams> MulStarProof<P> {
         let omega = (r * rho.pow_signed(&e)).retrieve();
 
         Self {
+            e,
             cap_a,
             cap_b_x,
             cap_e,
@@ -98,6 +100,10 @@ impl<P: SchemeParams> MulStarProof<P> {
         // Non-interactive challenge
         let e =
             Signed::from_xof_reader_bounded(&mut reader, &NonZero::new(P::CURVE_ORDER).unwrap());
+
+        if e != self.e {
+            return false;
+        }
 
         let aux_pk = setup.public_key();
 

--- a/synedrion/src/cggmp21/sigma/mul_star.rs
+++ b/synedrion/src/cggmp21/sigma/mul_star.rs
@@ -31,10 +31,10 @@ impl<P: SchemeParams> MulStarProof<P> {
     pub fn new(
         rng: &mut impl CryptoRngCore,
         x: &Signed<<P::Paillier as PaillierParams>::Uint>, // $x \in +- 2^\ell$
-        rho: &RandomizerMod<P::Paillier>,                  // $\rho \in \mathbb{Z}_{N_0}$
-        pk: &PublicKeyPaillierPrecomputed<P::Paillier>,    // $N_0$
-        cap_c: &Ciphertext<P::Paillier>,                   // $C$, a ciphertext encrypted with `pk`
-        setup: &RPParamsMod<P::Paillier>,                  // $\hat{N}$, $s$, $t$
+        rho: &RandomizerMod<P::Paillier>, // Paillier randomizer for the public key $N_0$
+        pk: &PublicKeyPaillierPrecomputed<P::Paillier>, // $N_0$
+        cap_c: &Ciphertext<P::Paillier>,  // $C$, a ciphertext encrypted with `pk`
+        setup: &RPParamsMod<P::Paillier>, // $\hat{N}$, $s$, $t$
         aux: &impl Hashable,
     ) -> Self {
         /*

--- a/synedrion/src/cggmp21/sigma/prm.rs
+++ b/synedrion/src/cggmp21/sigma/prm.rs
@@ -30,7 +30,7 @@ struct PrmSecret<P: SchemeParams> {
 }
 
 impl<P: SchemeParams> PrmSecret<P> {
-    pub(crate) fn random(
+    fn random(
         rng: &mut impl CryptoRngCore,
         sk: &SecretKeyPaillierPrecomputed<P::Paillier>,
     ) -> Self {
@@ -48,10 +48,7 @@ impl<P: SchemeParams> PrmSecret<P> {
 struct PrmCommitment<P: SchemeParams>(Vec<<P::Paillier as PaillierParams>::Uint>);
 
 impl<P: SchemeParams> PrmCommitment<P> {
-    pub(crate) fn new(
-        secret: &PrmSecret<P>,
-        base: &<P::Paillier as PaillierParams>::UintMod,
-    ) -> Self {
+    fn new(secret: &PrmSecret<P>, base: &<P::Paillier as PaillierParams>::UintMod) -> Self {
         let commitment = secret
             .secret
             .iter()
@@ -101,7 +98,7 @@ pub(crate) struct PrmProof<P: SchemeParams> {
 impl<P: SchemeParams> PrmProof<P> {
     /// Create a proof that we know the `secret`
     /// (the power that was used to create RP parameters).
-    pub(crate) fn new(
+    pub fn new(
         rng: &mut impl CryptoRngCore,
         sk: &SecretKeyPaillierPrecomputed<P::Paillier>,
         setup_secret: &RPSecret<P::Paillier>,
@@ -131,7 +128,7 @@ impl<P: SchemeParams> PrmProof<P> {
     }
 
     /// Verify that the proof is correct for a secret corresponding to the given RP parameters.
-    pub(crate) fn verify(&self, setup: &RPParamsMod<P::Paillier>, aux: &impl Hashable) -> bool {
+    pub fn verify(&self, setup: &RPParamsMod<P::Paillier>, aux: &impl Hashable) -> bool {
         let precomputed = setup.public_key().precomputed_modulus();
 
         let challenge = PrmChallenge::new(aux, &self.commitment);

--- a/synedrion/src/cggmp21/sigma/sch.rs
+++ b/synedrion/src/cggmp21/sigma/sch.rs
@@ -44,7 +44,7 @@ impl Hashable for SchCommitment {
 struct SchChallenge(Scalar);
 
 impl SchChallenge {
-    fn new(aux: &impl Hashable, public: &Point, commitment: &SchCommitment) -> Self {
+    fn new(public: &Point, commitment: &SchCommitment, aux: &impl Hashable) -> Self {
         Self(
             Hash::new_with_dst(HASH_TAG)
                 .chain(aux)
@@ -71,14 +71,14 @@ impl SchProof {
         public: &Point,
         aux: &impl Hashable,
     ) -> Self {
-        let challenge = SchChallenge::new(aux, public, commitment);
+        let challenge = SchChallenge::new(public, commitment, aux);
         let proof = proof_secret.0 + &challenge.0 * secret;
         Self { challenge, proof }
     }
 
     /// Verify that the proof is correct for a secret corresponding to the given `public`.
     pub fn verify(&self, commitment: &SchCommitment, public: &Point, aux: &impl Hashable) -> bool {
-        let challenge = SchChallenge::new(aux, public, commitment);
+        let challenge = SchChallenge::new(public, commitment, aux);
         challenge == self.challenge
             && self.proof.mul_by_generator() == commitment.0 + public * &challenge.0
     }

--- a/synedrion/src/cggmp21/sigma/sch.rs
+++ b/synedrion/src/cggmp21/sigma/sch.rs
@@ -55,7 +55,15 @@ impl SchChallenge {
     }
 }
 
-/// Schnorr PoK of a secret scalar.
+/**
+ZK proof: Schnorr proof of knowledge.
+
+Secret inputs:
+- scalar $x$.
+
+Public inputs:
+- Point $X = g * x$, where $g$ is the curve generator.
+*/
 #[derive(Clone, Serialize, Deserialize)]
 pub(crate) struct SchProof {
     challenge: SchChallenge,
@@ -63,24 +71,22 @@ pub(crate) struct SchProof {
 }
 
 impl SchProof {
-    /// Create a proof that we know the `secret`.
     pub fn new(
         proof_secret: &SchSecret,
-        secret: &Scalar,
+        x: &Scalar,
         commitment: &SchCommitment,
-        public: &Point,
+        cap_x: &Point,
         aux: &impl Hashable,
     ) -> Self {
-        let challenge = SchChallenge::new(public, commitment, aux);
-        let proof = proof_secret.0 + &challenge.0 * secret;
+        let challenge = SchChallenge::new(cap_x, commitment, aux);
+        let proof = proof_secret.0 + &challenge.0 * x;
         Self { challenge, proof }
     }
 
-    /// Verify that the proof is correct for a secret corresponding to the given `public`.
-    pub fn verify(&self, commitment: &SchCommitment, public: &Point, aux: &impl Hashable) -> bool {
-        let challenge = SchChallenge::new(public, commitment, aux);
+    pub fn verify(&self, commitment: &SchCommitment, cap_x: &Point, aux: &impl Hashable) -> bool {
+        let challenge = SchChallenge::new(cap_x, commitment, aux);
         challenge == self.challenge
-            && self.proof.mul_by_generator() == commitment.0 + public * &challenge.0
+            && self.proof.mul_by_generator() == commitment.0 + cap_x * &challenge.0
     }
 }
 

--- a/synedrion/src/cggmp21/sigma/sch.rs
+++ b/synedrion/src/cggmp21/sigma/sch.rs
@@ -19,7 +19,7 @@ pub(crate) struct SchSecret(
 );
 
 impl SchSecret {
-    pub(crate) fn random(rng: &mut impl CryptoRngCore) -> Self {
+    pub fn random(rng: &mut impl CryptoRngCore) -> Self {
         Self(Scalar::random(rng))
     }
 }
@@ -29,7 +29,7 @@ impl SchSecret {
 pub(crate) struct SchCommitment(Point);
 
 impl SchCommitment {
-    pub(crate) fn new(secret: &SchSecret) -> Self {
+    pub fn new(secret: &SchSecret) -> Self {
         Self(secret.0.mul_by_generator())
     }
 }
@@ -64,7 +64,7 @@ pub(crate) struct SchProof {
 
 impl SchProof {
     /// Create a proof that we know the `secret`.
-    pub(crate) fn new(
+    pub fn new(
         proof_secret: &SchSecret,
         secret: &Scalar,
         commitment: &SchCommitment,
@@ -77,12 +77,7 @@ impl SchProof {
     }
 
     /// Verify that the proof is correct for a secret corresponding to the given `public`.
-    pub(crate) fn verify(
-        &self,
-        commitment: &SchCommitment,
-        public: &Point,
-        aux: &impl Hashable,
-    ) -> bool {
+    pub fn verify(&self, commitment: &SchCommitment, public: &Point, aux: &impl Hashable) -> bool {
         let challenge = SchChallenge::new(aux, public, commitment);
         challenge == self.challenge
             && self.proof.mul_by_generator() == commitment.0 + public * &challenge.0

--- a/synedrion/src/cggmp21/sigma/sch.rs
+++ b/synedrion/src/cggmp21/sigma/sch.rs
@@ -25,7 +25,7 @@ impl SchSecret {
 }
 
 /// Public data for the proof (~ verifying key)
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct SchCommitment(Point);
 
 impl SchCommitment {
@@ -40,7 +40,7 @@ impl Hashable for SchCommitment {
     }
 }
 
-#[derive(Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct SchChallenge(Scalar);
 
 impl SchChallenge {
@@ -64,7 +64,7 @@ Secret inputs:
 Public inputs:
 - Point $X = g * x$, where $g$ is the curve generator.
 */
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct SchProof {
     challenge: SchChallenge,
     proof: Scalar,

--- a/synedrion/src/common.rs
+++ b/synedrion/src/common.rs
@@ -21,7 +21,6 @@ use crate::uint::Signed;
 use crate::{
     paillier::RandomizerMod,
     tools::collections::{HoleRange, HoleVecAccum},
-    uint::FromScalar,
 };
 
 /// The result of the KeyInit protocol.
@@ -298,13 +297,7 @@ impl<P: SchemeParams> PresigningData<P> {
         let cap_k = ephemeral_scalar_shares
             .iter()
             .enumerate()
-            .map(|(i, k)| {
-                Ciphertext::new(
-                    rng,
-                    &public_keys[i],
-                    &<<P as SchemeParams>::Paillier as PaillierParams>::Uint::from_scalar(k),
-                )
-            })
+            .map(|(i, k)| Ciphertext::new(rng, &public_keys[i], &P::uint_from_scalar(k)))
             .collect::<Vec<_>>();
 
         let mut presigning = Vec::new();
@@ -325,7 +318,7 @@ impl<P: SchemeParams> PresigningData<P> {
                 let hat_s = RandomizerMod::random(rng, &public_keys[j]).retrieve();
 
                 let hat_cap_d = cap_k[j]
-                    .homomorphic_mul(&public_keys[j], &Signed::from_scalar(&x))
+                    .homomorphic_mul(&public_keys[j], &P::signed_from_scalar(&x))
                     .homomorphic_add(
                         &public_keys[j],
                         &Ciphertext::new_with_randomizer_signed(

--- a/synedrion/src/common.rs
+++ b/synedrion/src/common.rs
@@ -279,7 +279,7 @@ impl<P: SchemeParams> PresigningData<P> {
         key_shares: &[KeyShare<P>],
     ) -> Box<[Self]> {
         let ephemeral_scalar = Scalar::random(rng);
-        let nonce = &Point::GENERATOR * &ephemeral_scalar.invert().unwrap();
+        let nonce = Point::GENERATOR * ephemeral_scalar.invert().unwrap();
         let ephemeral_scalar_shares = ephemeral_scalar.split(rng, key_shares.len());
         let secret: Scalar = key_shares
             .iter()

--- a/synedrion/src/common.rs
+++ b/synedrion/src/common.rs
@@ -116,8 +116,12 @@ pub struct PresigningData<P: SchemeParams> {
     pub(crate) ephemeral_scalar_share: Scalar, // $k_i$
     /// An additive share of `k * x` where `x` is the secret key.
     pub(crate) product_share: Scalar,
+
     // Values generated during presigning,
     // kept in case we need to generate a proof of correctness.
+
+    // We are keeping the non-reduced product share because we may need
+    pub(crate) product_share_nonreduced: Signed<<P::Paillier as PaillierParams>::Uint>,
     pub(crate) hat_beta: HoleVec<Signed<<P::Paillier as PaillierParams>::Uint>>,
     pub(crate) hat_r: HoleVec<Randomizer<P::Paillier>>,
     pub(crate) hat_s: HoleVec<Randomizer<P::Paillier>>,
@@ -282,13 +286,8 @@ impl<P: SchemeParams> PresigningData<P> {
         key_shares: &[KeyShare<P>],
     ) -> Box<[Self]> {
         let ephemeral_scalar = Scalar::random(rng);
-        let nonce = Point::GENERATOR * ephemeral_scalar.invert().unwrap();
+        let nonce = ephemeral_scalar.invert().unwrap().mul_by_generator();
         let ephemeral_scalar_shares = ephemeral_scalar.split(rng, key_shares.len());
-        let secret: Scalar = key_shares
-            .iter()
-            .map(|key_share| key_share.secret_share)
-            .sum();
-        let product_shares = (ephemeral_scalar * secret).split(rng, key_shares.len());
 
         let num_parties = key_shares.len();
         let public_keys = key_shares[0]
@@ -305,21 +304,19 @@ impl<P: SchemeParams> PresigningData<P> {
 
         let mut presigning = Vec::new();
 
-        for i in 0..key_shares.len() {
-            let mut hat_beta_vec = HoleVecAccum::new(num_parties, i);
-            let mut hat_r_vec = HoleVecAccum::new(num_parties, i);
-            let mut hat_s_vec = HoleVecAccum::new(num_parties, i);
-            let mut hat_cap_d_vec = HoleVecAccum::new(num_parties, i);
-            let mut hat_cap_f_vec = HoleVecAccum::new(num_parties, i);
+        let mut hat_betas = Vec::new();
+        let mut hat_ss = Vec::new();
+        let mut hat_cap_ds = Vec::new();
+        for (i, key_share) in key_shares.iter().enumerate() {
+            let x = key_share.secret_share;
 
-            let x = key_shares[i].secret_share;
-            let k = ephemeral_scalar_shares[i];
+            let mut hat_beta_vec = HoleVecAccum::new(num_parties, i);
+            let mut hat_s_vec = HoleVecAccum::new(num_parties, i);
+            let mut hat_cap_d_vec = HoleVecAccum::<Ciphertext<P::Paillier>>::new(num_parties, i);
 
             for j in HoleRange::new(num_parties, i) {
                 let hat_beta = Signed::random_bounded_bits(rng, P::LP_BOUND);
-                let hat_r = RandomizerMod::random(rng, &public_keys[i]).retrieve();
                 let hat_s = RandomizerMod::random(rng, &public_keys[j]).retrieve();
-
                 let hat_cap_d = cap_k[j]
                     .homomorphic_mul(&public_keys[j], &P::signed_from_scalar(&x))
                     .homomorphic_add(
@@ -330,40 +327,64 @@ impl<P: SchemeParams> PresigningData<P> {
                             &hat_s,
                         ),
                     );
-                let hat_cap_f =
-                    Ciphertext::new_with_randomizer_signed(&public_keys[i], &hat_beta, &hat_r);
 
                 hat_beta_vec.insert(j, hat_beta);
-                hat_r_vec.insert(j, hat_r);
                 hat_s_vec.insert(j, hat_s);
                 hat_cap_d_vec.insert(j, hat_cap_d);
+            }
+            hat_betas.push(hat_beta_vec.finalize().unwrap());
+            hat_ss.push(hat_s_vec.finalize().unwrap());
+            hat_cap_ds.push(hat_cap_d_vec.finalize().unwrap());
+        }
+
+        for i in 0..key_shares.len() {
+            let mut hat_r_vec = HoleVecAccum::new(num_parties, i);
+            let mut hat_cap_f_vec = HoleVecAccum::new(num_parties, i);
+
+            let x = key_shares[i].secret_share;
+            let k = ephemeral_scalar_shares[i];
+
+            for j in HoleRange::new(num_parties, i) {
+                let hat_beta = hat_betas[i].get(j).unwrap();
+                let hat_r = RandomizerMod::random(rng, &public_keys[i]).retrieve();
+
+                let hat_cap_f =
+                    Ciphertext::new_with_randomizer_signed(&public_keys[i], hat_beta, &hat_r);
+
+                hat_r_vec.insert(j, hat_r);
                 hat_cap_f_vec.insert(j, hat_cap_f);
             }
 
-            let hat_cap_d = hat_cap_d_vec.finalize().unwrap();
+            let mut hat_cap_d_received_vec = HoleVecAccum::new(num_parties, i);
+            for j in HoleRange::new(num_parties, i) {
+                hat_cap_d_received_vec.insert(j, hat_cap_ds[j].get(i).unwrap().clone());
+            }
+            let hat_cap_d_received = hat_cap_d_received_vec.finalize().unwrap();
+
+            let alpha_sum: Signed<_> = HoleRange::new(num_parties, i)
+                .map(|j| {
+                    P::signed_from_scalar(&key_shares[j].secret_share) * P::signed_from_scalar(&k)
+                        - hat_betas[j].get(i).unwrap()
+                })
+                .sum();
+
+            let beta_sum: Signed<_> = hat_betas[i].iter().sum();
+            let product_share_nonreduced =
+                P::signed_from_scalar(&x) * P::signed_from_scalar(&k) + alpha_sum + beta_sum;
 
             presigning.push(PresigningData {
                 nonce,
                 ephemeral_scalar_share: k,
-                product_share: product_shares[i],
-                hat_beta: hat_beta_vec.finalize().unwrap(),
+                product_share: P::scalar_from_signed(&product_share_nonreduced),
+                product_share_nonreduced,
+                hat_beta: hat_betas[i].clone(),
                 hat_r: hat_r_vec.finalize().unwrap(),
-                hat_s: hat_s_vec.finalize().unwrap(),
-                // Temporarily fill the field with invalid data
-                // because we need all node data to be created first
-                hat_cap_d_received: hat_cap_d.clone(),
-                hat_cap_d,
+                hat_s: hat_ss[i].clone(),
+                hat_cap_d_received,
+                hat_cap_d: hat_cap_ds[i].clone(),
                 hat_cap_f: hat_cap_f_vec.finalize().unwrap(),
                 cap_k: cap_k.clone().into_boxed_slice(),
             });
-        }
-
-        for i in 0..key_shares.len() {
-            let mut hat_cap_d_vec = HoleVecAccum::new(num_parties, i);
-            for j in HoleRange::new(num_parties, i) {
-                hat_cap_d_vec.insert(j, presigning[j].hat_cap_d.get(i).unwrap().clone());
-            }
-            presigning[i].hat_cap_d_received = hat_cap_d_vec.finalize().unwrap();
         }
 
         presigning.into()

--- a/synedrion/src/curve/arithmetic.rs
+++ b/synedrion/src/curve/arithmetic.rs
@@ -243,7 +243,7 @@ impl Neg for Scalar {
     }
 }
 
-impl<'a> Neg for &'a Scalar {
+impl Neg for &Scalar {
     type Output = Scalar;
     fn neg(self) -> Self::Output {
         Scalar(-self.0)
@@ -254,7 +254,7 @@ impl Add<Scalar> for Scalar {
     type Output = Scalar;
 
     fn add(self, other: Scalar) -> Scalar {
-        Scalar(self.0.add(other.0))
+        Scalar(self.0.add(&other.0))
     }
 }
 
@@ -270,7 +270,7 @@ impl Add<Point> for Point {
     type Output = Point;
 
     fn add(self, other: Point) -> Point {
-        Point(self.0.add(other.0))
+        Point(self.0.add(&(other.0)))
     }
 }
 
@@ -295,6 +295,14 @@ impl Sub<&Scalar> for &Scalar {
 
     fn sub(self, other: &Scalar) -> Scalar {
         Scalar(self.0.sub(&(other.0)))
+    }
+}
+
+impl Mul<Scalar> for Point {
+    type Output = Point;
+
+    fn mul(self, other: Scalar) -> Point {
+        Point(self.0.mul(&(other.0)))
     }
 }
 

--- a/synedrion/src/curve/arithmetic.rs
+++ b/synedrion/src/curve/arithmetic.rs
@@ -153,6 +153,12 @@ impl<'de> Deserialize<'de> for Scalar {
     }
 }
 
+impl Hashable for Scalar {
+    fn chain<C: Chain>(&self, digest: C) -> C {
+        digest.chain_constant_sized_bytes(&self.to_bytes().as_slice())
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Point(BackendPoint);
 
@@ -214,7 +220,7 @@ impl Hashable for Point {
     fn chain<C: Chain>(&self, digest: C) -> C {
         let arr = self.to_compressed_array();
         let arr_ref: &[u8] = arr.as_ref();
-        digest.chain(&arr_ref)
+        digest.chain_constant_sized_bytes(&arr_ref)
     }
 }
 

--- a/synedrion/src/paillier/keys.rs
+++ b/synedrion/src/paillier/keys.rs
@@ -276,6 +276,12 @@ impl<P: PaillierParams> Hashable for PublicKeyPaillier<P> {
     }
 }
 
+impl<P: PaillierParams> Hashable for PublicKeyPaillierPrecomputed<P> {
+    fn chain<C: Chain>(&self, digest: C) -> C {
+        digest.chain(&self.pk)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use rand_core::OsRng;

--- a/synedrion/src/paillier/params.rs
+++ b/synedrion/src/paillier/params.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::uint::{FromScalar, HasWide, UintLike, UintModLike};
+use crate::uint::{HasWide, UintLike, UintModLike};
 
 #[cfg(test)]
 use crate::uint::{U1024Mod, U2048Mod, U512Mod, U1024, U2048, U4096, U512};
@@ -16,7 +16,6 @@ pub trait PaillierParams: PartialEq + Eq + Clone + core::fmt::Debug + Send {
     type HalfUintMod: UintModLike<RawUint = Self::HalfUint>;
     /// An integer that fits the RSA modulus.
     type Uint: UintLike<ModUint = Self::UintMod>
-        + FromScalar
         + HasWide<Wide = Self::WideUint>
         + Serialize
         + for<'de> Deserialize<'de>;

--- a/synedrion/src/paillier/ring_pedersen.rs
+++ b/synedrion/src/paillier/ring_pedersen.rs
@@ -133,6 +133,12 @@ impl<P: PaillierParams> Hashable for RPParams<P> {
     }
 }
 
+impl<P: PaillierParams> Hashable for RPParamsMod<P> {
+    fn chain<C: Chain>(&self, digest: C) -> C {
+        digest.chain(&self.pk).chain(&self.base).chain(&self.power)
+    }
+}
+
 #[derive(PartialEq, Eq)]
 pub(crate) struct RPCommitmentMod<P: PaillierParams>(P::UintMod);
 

--- a/synedrion/src/threshold.rs
+++ b/synedrion/src/threshold.rs
@@ -170,7 +170,7 @@ impl<P: SchemeParams> ThresholdKeyShare<P> {
         let public_shares = share_idxs
             .iter()
             .map(|share_idx| {
-                &self.public_shares[share_idx] * &interpolation_coeff(share_idxs, share_idx)
+                self.public_shares[share_idx] * interpolation_coeff(share_idxs, share_idx)
             })
             .collect();
 

--- a/synedrion/src/tools/hashing.rs
+++ b/synedrion/src/tools/hashing.rs
@@ -120,6 +120,12 @@ impl Hashable for u32 {
     }
 }
 
+impl Hashable for u64 {
+    fn chain<C: Chain>(&self, digest: C) -> C {
+        digest.chain_constant_sized_bytes(&self.to_be_bytes())
+    }
+}
+
 impl Hashable for u8 {
     fn chain<C: Chain>(&self, digest: C) -> C {
         digest.chain_constant_sized_bytes(&self.to_be_bytes())

--- a/synedrion/src/uint.rs
+++ b/synedrion/src/uint.rs
@@ -4,8 +4,8 @@ mod signed;
 mod traits;
 
 pub(crate) use crypto_bigint::{
-    modular::Retrieve, subtle, CheckedAdd, CheckedMul, CheckedSub, Integer, Invert, NonZero,
-    PowBoundedExp, RandomMod, U1024, U2048, U4096, U512, U8192,
+    modular::Retrieve, subtle, CheckedAdd, CheckedMul, CheckedSub, Encoding, Integer, Invert,
+    NonZero, PowBoundedExp, RandomMod, Zero, U1024, U2048, U4096, U512, U8192,
 };
 pub(crate) use crypto_primes::RandomPrimeWithRng;
 
@@ -13,5 +13,5 @@ pub(crate) use bounded::Bounded;
 pub(crate) use jacobi::{JacobiSymbol, JacobiSymbolTrait};
 pub(crate) use signed::Signed;
 pub(crate) use traits::{
-    upcast_uint, FromScalar, HasWide, U1024Mod, U2048Mod, U4096Mod, U512Mod, UintLike, UintModLike,
+    upcast_uint, HasWide, U1024Mod, U2048Mod, U4096Mod, U512Mod, UintLike, UintModLike,
 };

--- a/synedrion/src/uint/bounded.rs
+++ b/synedrion/src/uint/bounded.rs
@@ -6,9 +6,8 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     subtle::{Choice, ConditionallySelectable, CtOption},
-    CheckedAdd, CheckedMul, FromScalar, HasWide, NonZero, Signed, UintLike,
+    CheckedAdd, CheckedMul, HasWide, NonZero, Signed, UintLike,
 };
-use crate::curve::{Scalar, ORDER};
 use crate::tools::hashing::{Chain, Hashable};
 use crate::tools::serde_bytes;
 
@@ -121,16 +120,6 @@ impl<T: UintLike + HasWide> Bounded<T> {
             value: result,
             bound: self.bound + rhs.bound,
         }
-    }
-}
-
-impl<T: UintLike + FromScalar> FromScalar for Bounded<T> {
-    fn from_scalar(value: &Scalar) -> Self {
-        const ORDER_BITS: usize = ORDER.bits_vartime();
-        Bounded::new(T::from_scalar(value), ORDER_BITS as u32).unwrap()
-    }
-    fn to_scalar(&self) -> Scalar {
-        self.value.to_scalar()
     }
 }
 

--- a/synedrion/src/uint/signed.rs
+++ b/synedrion/src/uint/signed.rs
@@ -8,9 +8,8 @@ use serde::{Deserialize, Serialize};
 use super::{
     bounded::PackedBounded,
     subtle::{Choice, ConditionallyNegatable, ConditionallySelectable, ConstantTimeEq, CtOption},
-    Bounded, CheckedAdd, CheckedMul, FromScalar, HasWide, Integer, NonZero, UintLike, UintModLike,
+    Bounded, CheckedAdd, CheckedMul, HasWide, Integer, NonZero, UintLike, UintModLike,
 };
-use crate::curve::{Scalar, ORDER};
 
 /// A packed representation for serializing Signed objects.
 /// Usually they have the bound much lower than the full size of the integer,
@@ -296,17 +295,6 @@ where
             bound: bound_bits as u32 + scale.bound(),
             value: scaled_positive_result.wrapping_sub(&scaled_bound),
         }
-    }
-}
-
-impl<T: UintLike + FromScalar> FromScalar for Signed<T> {
-    fn from_scalar(value: &Scalar) -> Self {
-        const ORDER_BITS: usize = ORDER.bits_vartime();
-        Signed::new_positive(T::from_scalar(value), ORDER_BITS as u32).unwrap()
-    }
-    fn to_scalar(&self) -> Scalar {
-        let abs_value = self.abs().to_scalar();
-        Scalar::conditional_select(&abs_value, &-abs_value, self.is_negative())
     }
 }
 

--- a/synedrion/src/uint/signed.rs
+++ b/synedrion/src/uint/signed.rs
@@ -359,6 +359,13 @@ impl<T: UintLike> Sub<Signed<T>> for Signed<T> {
     }
 }
 
+impl<T: UintLike> Sub<&Signed<T>> for Signed<T> {
+    type Output = Self;
+    fn sub(self, rhs: &Self) -> Self::Output {
+        self.checked_add(&-rhs).unwrap()
+    }
+}
+
 impl<T: UintLike> Mul<Signed<T>> for Signed<T> {
     type Output = Self;
     fn mul(self, rhs: Self) -> Self::Output {

--- a/synedrion/src/uint/signed.rs
+++ b/synedrion/src/uint/signed.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use super::{
     bounded::PackedBounded,
     subtle::{Choice, ConditionallyNegatable, ConditionallySelectable, ConstantTimeEq, CtOption},
-    Bounded, CheckedAdd, CheckedMul, HasWide, Integer, NonZero, UintLike, UintModLike,
+    Bounded, HasWide, Integer, NonZero, UintLike, UintModLike,
 };
 
 /// A packed representation for serializing Signed objects.
@@ -190,6 +190,46 @@ impl<T: UintLike> Signed<T> {
         let abs_mod = self.abs().to_mod(precomputed);
         T::ModUint::conditional_select(&abs_mod, &-abs_mod, self.is_negative())
     }
+
+    fn checked_add(&self, rhs: &Self) -> CtOption<Self> {
+        let bound = core::cmp::max(self.bound, rhs.bound) + 1;
+        let result = Self {
+            bound,
+            value: self.value.wrapping_add(&rhs.value),
+        };
+        let lhs_neg = self.is_negative();
+        let rhs_neg = rhs.is_negative();
+        let res_neg = result.is_negative();
+
+        // Cannot get overflow from adding values of different signs,
+        // and if for two values of the same sign the sign of the result remains the same
+        // it means there was no overflow.
+        CtOption::new(
+            result,
+            !(lhs_neg.ct_eq(&rhs_neg) & !lhs_neg.ct_eq(&res_neg)),
+        )
+    }
+
+    fn checked_mul(&self, rhs: &Self) -> CtOption<Self> {
+        let bound = self.bound + rhs.bound;
+        let lhs_neg = self.is_negative();
+        let rhs_neg = rhs.is_negative();
+        let lhs = T::conditional_select(&self.value, &self.value.neg(), lhs_neg);
+        let rhs = T::conditional_select(&rhs.value, &rhs.value.neg(), rhs_neg);
+        let result = lhs.checked_mul(&rhs);
+        let result_neg = lhs_neg ^ rhs_neg;
+        result.and_then(|val| {
+            let out_of_range = Choice::from((bound as usize >= <T as Integer>::BITS - 1) as u8);
+            let signed_val = T::conditional_select(&val, &val.neg(), result_neg);
+            CtOption::new(
+                Self {
+                    bound,
+                    value: signed_val,
+                },
+                out_of_range.not(),
+            )
+        })
+    }
 }
 
 impl<T: UintLike> Default for Signed<T> {
@@ -298,55 +338,16 @@ where
     }
 }
 
-impl<T: UintLike> CheckedAdd for Signed<T> {
-    type Output = Self;
-    fn checked_add(&self, rhs: Self) -> CtOption<Self> {
-        let bound = core::cmp::max(self.bound, rhs.bound) + 1;
-        let result = Self {
-            bound,
-            value: self.value.wrapping_add(&rhs.value),
-        };
-        let lhs_neg = self.is_negative();
-        let rhs_neg = rhs.is_negative();
-        let res_neg = result.is_negative();
-
-        // Cannot get overflow from adding values of different signs,
-        // and if for two values of the same sign the sign of the result remains the same
-        // it means there was no overflow.
-        CtOption::new(
-            result,
-            !(lhs_neg.ct_eq(&rhs_neg) & !lhs_neg.ct_eq(&res_neg)),
-        )
-    }
-}
-
-impl<T: UintLike> CheckedMul for Signed<T> {
-    type Output = Self;
-    fn checked_mul(&self, rhs: Self) -> CtOption<Self> {
-        let bound = self.bound + rhs.bound;
-        let lhs_neg = self.is_negative();
-        let rhs_neg = rhs.is_negative();
-        let lhs = T::conditional_select(&self.value, &self.value.neg(), lhs_neg);
-        let rhs = T::conditional_select(&rhs.value, &rhs.value.neg(), rhs_neg);
-        let result = lhs.checked_mul(&rhs);
-        let result_neg = lhs_neg ^ rhs_neg;
-        result.and_then(|val| {
-            let out_of_range = Choice::from((bound as usize >= <T as Integer>::BITS - 1) as u8);
-            let signed_val = T::conditional_select(&val, &val.neg(), result_neg);
-            CtOption::new(
-                Self {
-                    bound,
-                    value: signed_val,
-                },
-                out_of_range.not(),
-            )
-        })
-    }
-}
-
 impl<T: UintLike> Add<Signed<T>> for Signed<T> {
     type Output = Self;
     fn add(self, rhs: Self) -> Self::Output {
+        self.checked_add(&rhs).unwrap()
+    }
+}
+
+impl<T: UintLike> Add<&Signed<T>> for Signed<T> {
+    type Output = Self;
+    fn add(self, rhs: &Self) -> Self::Output {
         self.checked_add(rhs).unwrap()
     }
 }
@@ -354,20 +355,27 @@ impl<T: UintLike> Add<Signed<T>> for Signed<T> {
 impl<T: UintLike> Sub<Signed<T>> for Signed<T> {
     type Output = Self;
     fn sub(self, rhs: Self) -> Self::Output {
-        self.checked_add(-rhs).unwrap()
+        self.checked_add(&-rhs).unwrap()
     }
 }
 
 impl<T: UintLike> Mul<Signed<T>> for Signed<T> {
     type Output = Self;
     fn mul(self, rhs: Self) -> Self::Output {
+        self.checked_mul(&rhs).unwrap()
+    }
+}
+
+impl<T: UintLike> Mul<&Signed<T>> for Signed<T> {
+    type Output = Self;
+    fn mul(self, rhs: &Self) -> Self::Output {
         self.checked_mul(rhs).unwrap()
     }
 }
 
 impl<T: UintLike> core::iter::Sum for Signed<T> {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
-        iter.reduce(|x, y| x.checked_add(y).unwrap())
+        iter.reduce(|x, y| x.checked_add(&y).unwrap())
             .unwrap_or(Self::default())
     }
 }

--- a/synedrion/src/uint/traits.rs
+++ b/synedrion/src/uint/traits.rs
@@ -14,7 +14,6 @@ use crypto_primes::RandomPrimeWithRng;
 use digest::XofReader;
 
 use super::{bounded::Bounded, jacobi::JacobiSymbolTrait, signed::Signed};
-use crate::curve::Scalar;
 use crate::tools::hashing::{Chain, Hashable};
 
 pub(crate) const fn upcast_uint<const N1: usize, const N2: usize>(value: Uint<N1>) -> Uint<N2> {
@@ -367,38 +366,6 @@ impl HasWide for U4096 {
     }
     fn from_wide(value: Self::Wide) -> (Self, Self) {
         value.into()
-    }
-}
-
-// TODO (#63): this should be moved out of Uint layer.
-pub trait FromScalar {
-    fn from_scalar(value: &Scalar) -> Self;
-    fn to_scalar(&self) -> Scalar;
-}
-
-impl<T: UintLike> FromScalar for T {
-    fn from_scalar(value: &Scalar) -> Self {
-        let scalar_bytes = value.to_bytes();
-        let mut repr = Self::ZERO.to_be_bytes();
-
-        let uint_len = repr.as_ref().len();
-        let scalar_len = scalar_bytes.len();
-
-        debug_assert!(uint_len >= scalar_len);
-        repr.as_mut()[uint_len - scalar_len..].copy_from_slice(&scalar_bytes);
-        Self::from_be_bytes(repr)
-    }
-
-    fn to_scalar(&self) -> Scalar {
-        let p = NonZero::new(Self::from_scalar(&-Scalar::ONE).wrapping_add(&Self::ONE)).unwrap();
-        let r = self.rem(p);
-
-        let repr = r.to_be_bytes();
-        let uint_len = repr.as_ref().len();
-        let scalar_len = Scalar::repr_len();
-
-        // Can unwrap here since the value is within the Scalar range
-        Scalar::try_from_bytes(&repr.as_ref()[uint_len - scalar_len..]).unwrap()
     }
 }
 

--- a/synedrion/src/www02.rs
+++ b/synedrion/src/www02.rs
@@ -337,8 +337,8 @@ impl FinalizableToResult for Round1 {
         let vkey = bc_payloads
             .values()
             .map(|payload| {
-                &payload.public_polynomial.coeff0()
-                    * &interpolation_coeff(&old_share_idxs, &payload.old_share_idx)
+                payload.public_polynomial.coeff0()
+                    * interpolation_coeff(&old_share_idxs, &payload.old_share_idx)
             })
             .sum();
         if new_holder.context.verifying_key != vkey {


### PR DESCRIPTION
- Include challenges in all ZK proofs. While not strictly necessary, according to the authors of the paper, still adds a little more security and more debug info at the price of slightly larger message sizes. Also we were already doing it for some of the ZK proofs anyway.
- Adjust method visibility (don't use `pub(crate)` for the methods of a struct that's already `pub(crate)`)
- Bring some parameter names in sync with the paper
- Decouple curve scalars from big integers (fixes #63). Note that it adds some internal-use methods to `SchemeParams`; these should be hidden as a part of #74.
- TODO: add public values and commitments (if the ZK proof uses them) into the hash digest for challenge generation, as prescribed by Fig. 2
