### PR TITLE
Bundle public keys with Paillier ciphertexts

### DIFF
--- a/synedrion/benches/bench.rs
+++ b/synedrion/benches/bench.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use rand_core::OsRng;
 
-use synedrion::{cggmp21::benches, KeyShare, TestParams};
+use synedrion::{cggmp21::benches, KeyShare, PresigningData, TestParams};
 
 fn bench_happy_paths(c: &mut Criterion) {
     let mut group = c.benchmark_group("happy path");
@@ -13,8 +13,9 @@ fn bench_happy_paths(c: &mut Criterion) {
         b.iter(|| benches::key_init::<Params>(&mut OsRng, 2))
     });
 
+    let presigning_datas = PresigningData::new_centralized(&mut OsRng, &key_shares);
     group.bench_function("Signing, 2 parties", |b| {
-        b.iter(|| benches::signing::<Params>(&mut OsRng, &key_shares))
+        b.iter(|| benches::signing::<Params>(&mut OsRng, &key_shares, &presigning_datas))
     });
 
     group.sample_size(10);

--- a/synedrion/src/cggmp21/benches.rs
+++ b/synedrion/src/cggmp21/benches.rs
@@ -94,11 +94,13 @@ pub fn presigning<P: SchemeParams>(rng: &mut impl CryptoRngCore, key_shares: &[K
 }
 
 /// A sequential execution of the Presigning protocol for all parties.
-pub fn signing<P: SchemeParams>(rng: &mut impl CryptoRngCore, key_shares: &[KeyShare<P>]) {
+pub fn signing<P: SchemeParams>(
+    rng: &mut impl CryptoRngCore,
+    key_shares: &[KeyShare<P>],
+    presigning_datas: &[PresigningData<P>],
+) {
     let mut shared_randomness = [0u8; 32];
     rng.fill_bytes(&mut shared_randomness);
-
-    let presigning_datas = PresigningData::new_centralized(rng, key_shares);
 
     let message = Scalar::random(rng);
 

--- a/synedrion/src/cggmp21/protocols/presigning.rs
+++ b/synedrion/src/cggmp21/protocols/presigning.rs
@@ -537,10 +537,10 @@ impl<P: SchemeParams> DirectRound for Round2<P> {
         // where `q` is the curve order.
         // We will need this bound later, so we're asserting it.
         let alpha = alpha
-            .assert_bound_usize(core::cmp::max(2 * P::L_BOUND, P::LP_BOUND) + 1)
+            .assert_bit_bound_usize(core::cmp::max(2 * P::L_BOUND, P::LP_BOUND) + 1)
             .unwrap();
         let alpha_hat = alpha_hat
-            .assert_bound_usize(core::cmp::max(2 * P::L_BOUND, P::LP_BOUND) + 1)
+            .assert_bit_bound_usize(core::cmp::max(2 * P::L_BOUND, P::LP_BOUND) + 1)
             .unwrap();
 
         Ok(Round2Payload {

--- a/synedrion/src/cggmp21/protocols/presigning.rs
+++ b/synedrion/src/cggmp21/protocols/presigning.rs
@@ -380,19 +380,11 @@ impl<P: SchemeParams> DirectRound for Round2<P> {
 
         let d = self.k_ciphertexts[idx]
             .homomorphic_mul(&P::signed_from_scalar(&self.context.gamma))
-            .homomorphic_add(&CiphertextMod::new_with_randomizer_signed(
-                target_pk,
-                &-beta,
-                &s.retrieve(),
-            ));
+            + CiphertextMod::new_with_randomizer_signed(target_pk, &-beta, &s.retrieve());
 
         let d_hat = self.k_ciphertexts[idx]
             .homomorphic_mul(&P::signed_from_scalar(&self.context.key_share.secret_share))
-            .homomorphic_add(&CiphertextMod::new_with_randomizer_signed(
-                target_pk,
-                &-beta_hat,
-                &s_hat.retrieve(),
-            ));
+            + CiphertextMod::new_with_randomizer_signed(target_pk, &-beta_hat, &s_hat.retrieve());
         let f_hat = CiphertextMod::new_with_randomizer_signed(pk, &beta_hat, &r_hat.retrieve());
 
         let public_aux = &self.context.key_share.public_aux[idx];
@@ -917,8 +909,8 @@ impl<P: SchemeParams> FinalizableToResult for Round3<P> {
 
         for j in range {
             ciphertext = ciphertext
-                .homomorphic_add(self.cap_ds.get(j).unwrap())
-                .homomorphic_add(&self.round2_artifacts.get(j).unwrap().cap_f);
+                + self.cap_ds.get(j).unwrap()
+                + &self.round2_artifacts.get(j).unwrap().cap_f;
         }
 
         let rho = ciphertext.derive_randomizer(sk);

--- a/synedrion/src/cggmp21/protocols/presigning.rs
+++ b/synedrion/src/cggmp21/protocols/presigning.rs
@@ -378,12 +378,11 @@ impl<P: SchemeParams> DirectRound for Round2<P> {
 
         let cap_f = CiphertextMod::new_with_randomizer_signed(pk, &beta, &r.retrieve());
 
-        let d = self.k_ciphertexts[idx]
-            .homomorphic_mul(&P::signed_from_scalar(&self.context.gamma))
+        let d = &self.k_ciphertexts[idx] * P::signed_from_scalar(&self.context.gamma)
             + CiphertextMod::new_with_randomizer_signed(target_pk, &-beta, &s.retrieve());
 
-        let d_hat = self.k_ciphertexts[idx]
-            .homomorphic_mul(&P::signed_from_scalar(&self.context.key_share.secret_share))
+        let d_hat = &self.k_ciphertexts[idx]
+            * P::signed_from_scalar(&self.context.key_share.secret_share)
             + CiphertextMod::new_with_randomizer_signed(target_pk, &-beta_hat, &s_hat.retrieve());
         let f_hat = CiphertextMod::new_with_randomizer_signed(pk, &beta_hat, &r_hat.retrieve());
 
@@ -876,11 +875,9 @@ impl<P: SchemeParams> FinalizableToResult for Round3<P> {
         // Mul proof
 
         let rho = RandomizerMod::random(rng, pk);
-        let cap_h = self.g_ciphertexts[my_idx]
-            .homomorphic_mul_unsigned(&P::bounded_from_scalar(
-                &self.context.ephemeral_scalar_share,
-            ))
-            .mul_randomizer(&rho.retrieve());
+        let cap_h = (&self.g_ciphertexts[my_idx]
+            * P::bounded_from_scalar(&self.context.ephemeral_scalar_share))
+        .mul_randomizer(&rho.retrieve());
 
         let p_mul = MulProof::<P>::new(
             rng,

--- a/synedrion/src/cggmp21/protocols/signing.rs
+++ b/synedrion/src/cggmp21/protocols/signing.rs
@@ -262,18 +262,15 @@ impl<P: SchemeParams> FinalizableToResult for Round1<P> {
         let mut ciphertext = hat_cap_h.clone();
         for j in HoleRange::new(num_parties, my_idx) {
             ciphertext = ciphertext
-                .homomorphic_add(self.context.presigning.hat_cap_d_received.get(j).unwrap())
-                .homomorphic_add(self.context.presigning.hat_cap_f.get(j).unwrap());
+                + self.context.presigning.hat_cap_d_received.get(j).unwrap()
+                + self.context.presigning.hat_cap_f.get(j).unwrap();
         }
 
         let r = self.context.presigning.nonce.x_coordinate();
 
-        let ciphertext = ciphertext
-            .homomorphic_mul_unsigned(&P::bounded_from_scalar(&r))
-            .homomorphic_add(
-                &self.context.presigning.cap_k[my_idx]
-                    .homomorphic_mul_unsigned(&P::bounded_from_scalar(&self.context.message)),
-            );
+        let ciphertext = ciphertext.homomorphic_mul_unsigned(&P::bounded_from_scalar(&r))
+            + self.context.presigning.cap_k[my_idx]
+                .homomorphic_mul_unsigned(&P::bounded_from_scalar(&self.context.message));
 
         let rho = ciphertext.derive_randomizer(sk);
         // This is the same as `s_part` but if all the calculations were performed

--- a/synedrion/src/cggmp21/protocols/signing.rs
+++ b/synedrion/src/cggmp21/protocols/signing.rs
@@ -222,8 +222,8 @@ impl<P: SchemeParams> FinalizableToResult for Round1<P> {
 
         let rho = RandomizerMod::random(rng, pk);
         let hat_cap_h = self.context.presigning.cap_k[my_idx]
-            .homomorphic_mul_unsigned(pk, &P::bounded_from_scalar(&x))
-            .mul_randomizer(pk, &rho.retrieve());
+            .homomorphic_mul_unsigned(&P::bounded_from_scalar(&x))
+            .mul_randomizer(&rho.retrieve());
 
         let aux = (
             &self.shared_randomness,
@@ -262,21 +262,17 @@ impl<P: SchemeParams> FinalizableToResult for Round1<P> {
         let mut ciphertext = hat_cap_h.clone();
         for j in HoleRange::new(num_parties, my_idx) {
             ciphertext = ciphertext
-                .homomorphic_add(
-                    pk,
-                    self.context.presigning.hat_cap_d_received.get(j).unwrap(),
-                )
-                .homomorphic_add(pk, self.context.presigning.hat_cap_f.get(j).unwrap());
+                .homomorphic_add(self.context.presigning.hat_cap_d_received.get(j).unwrap())
+                .homomorphic_add(self.context.presigning.hat_cap_f.get(j).unwrap());
         }
 
         let r = self.context.presigning.nonce.x_coordinate();
 
         let ciphertext = ciphertext
-            .homomorphic_mul_unsigned(pk, &P::bounded_from_scalar(&r))
+            .homomorphic_mul_unsigned(&P::bounded_from_scalar(&r))
             .homomorphic_add(
-                pk,
                 &self.context.presigning.cap_k[my_idx]
-                    .homomorphic_mul_unsigned(pk, &P::bounded_from_scalar(&self.context.message)),
+                    .homomorphic_mul_unsigned(&P::bounded_from_scalar(&self.context.message)),
             );
 
         let rho = ciphertext.derive_randomizer(sk);

--- a/synedrion/src/cggmp21/protocols/signing.rs
+++ b/synedrion/src/cggmp21/protocols/signing.rs
@@ -221,8 +221,7 @@ impl<P: SchemeParams> FinalizableToResult for Round1<P> {
         let cap_x = self.context.key_share.public_shares[self.party_idx().as_usize()];
 
         let rho = RandomizerMod::random(rng, pk);
-        let hat_cap_h = self.context.presigning.cap_k[my_idx]
-            .homomorphic_mul_unsigned(&P::bounded_from_scalar(&x))
+        let hat_cap_h = (&self.context.presigning.cap_k[my_idx] * P::bounded_from_scalar(&x))
             .mul_randomizer(&rho.retrieve());
 
         let aux = (
@@ -268,9 +267,9 @@ impl<P: SchemeParams> FinalizableToResult for Round1<P> {
 
         let r = self.context.presigning.nonce.x_coordinate();
 
-        let ciphertext = ciphertext.homomorphic_mul_unsigned(&P::bounded_from_scalar(&r))
-            + self.context.presigning.cap_k[my_idx]
-                .homomorphic_mul_unsigned(&P::bounded_from_scalar(&self.context.message));
+        let ciphertext = ciphertext * P::bounded_from_scalar(&r)
+            + &self.context.presigning.cap_k[my_idx]
+                * P::bounded_from_scalar(&self.context.message);
 
         let rho = ciphertext.derive_randomizer(sk);
         // This is the same as `s_part` but if all the calculations were performed

--- a/synedrion/src/cggmp21/sigma/aff_g.rs
+++ b/synedrion/src/cggmp21/sigma/aff_g.rs
@@ -6,8 +6,8 @@ use serde::{Deserialize, Serialize};
 use super::super::SchemeParams;
 use crate::curve::Point;
 use crate::paillier::{
-    Ciphertext, PaillierParams, PublicKeyPaillierPrecomputed, RPCommitment, RPParamsMod,
-    Randomizer, RandomizerMod,
+    Ciphertext, CiphertextMod, PaillierParams, PublicKeyPaillierPrecomputed, RPCommitment,
+    RPParamsMod, Randomizer, RandomizerMod,
 };
 use crate::tools::hashing::{Chain, Hashable, XofHash};
 use crate::uint::Signed;
@@ -64,9 +64,9 @@ impl<P: SchemeParams> AffGProof<P> {
         rho_y: &RandomizerMod<P::Paillier>,
         pk0: &PublicKeyPaillierPrecomputed<P::Paillier>,
         pk1: &PublicKeyPaillierPrecomputed<P::Paillier>,
-        cap_c: &Ciphertext<P::Paillier>,
-        cap_d: &Ciphertext<P::Paillier>,
-        cap_y: &Ciphertext<P::Paillier>,
+        cap_c: &CiphertextMod<P::Paillier>,
+        cap_d: &CiphertextMod<P::Paillier>,
+        cap_y: &CiphertextMod<P::Paillier>,
         cap_x: &Point,
         setup: &RPParamsMod<P::Paillier>,
         aux: &impl Hashable,
@@ -99,12 +99,11 @@ impl<P: SchemeParams> AffGProof<P> {
         let delta = Signed::random_bounded_bits_scaled(rng, P::L_BOUND + P::EPS_BOUND, hat_cap_n);
         let mu = Signed::random_bounded_bits_scaled(rng, P::L_BOUND, hat_cap_n);
 
-        let cap_a = cap_c.homomorphic_mul(pk0, &alpha).homomorphic_add(
-            pk0,
-            &Ciphertext::new_with_randomizer_signed(pk0, &beta, &r_mod.retrieve()),
+        let cap_a = cap_c.homomorphic_mul(&alpha).homomorphic_add(
+            &CiphertextMod::new_with_randomizer_signed(pk0, &beta, &r_mod.retrieve()),
         );
         let cap_b_x = P::scalar_from_signed(&alpha).mul_by_generator();
-        let cap_b_y = Ciphertext::new_with_randomizer_signed(pk1, &beta, &r_y_mod.retrieve());
+        let cap_b_y = CiphertextMod::new_with_randomizer_signed(pk1, &beta, &r_y_mod.retrieve());
         let cap_e = setup.commit(&alpha, &gamma).retrieve();
         let cap_s = setup.commit(x, &m).retrieve();
         let cap_f = setup.commit(&beta, &delta).retrieve();
@@ -134,9 +133,9 @@ impl<P: SchemeParams> AffGProof<P> {
 
         Self {
             e,
-            cap_a,
+            cap_a: cap_a.retrieve(),
             cap_b_x,
-            cap_b_y,
+            cap_b_y: cap_b_y.retrieve(),
             cap_e,
             cap_s,
             cap_f,
@@ -155,9 +154,9 @@ impl<P: SchemeParams> AffGProof<P> {
         &self,
         pk0: &PublicKeyPaillierPrecomputed<P::Paillier>,
         pk1: &PublicKeyPaillierPrecomputed<P::Paillier>,
-        cap_c: &Ciphertext<P::Paillier>,
-        cap_d: &Ciphertext<P::Paillier>,
-        cap_y: &Ciphertext<P::Paillier>,
+        cap_c: &CiphertextMod<P::Paillier>,
+        cap_d: &CiphertextMod<P::Paillier>,
+        cap_y: &CiphertextMod<P::Paillier>,
         cap_x: &Point,
         setup: &RPParamsMod<P::Paillier>,
         aux: &impl Hashable,
@@ -184,12 +183,11 @@ impl<P: SchemeParams> AffGProof<P> {
 
         // C^{z_1} (1 + N_0)^{z_2} \omega^{N_0} = A D^e \mod N_0^2
         // => C (*) z_1 (+) encrypt_0(z_2, \omega) = A (+) D (*) e
-        if cap_c.homomorphic_mul(pk0, &self.z1).homomorphic_add(
-            pk0,
-            &Ciphertext::new_with_randomizer_signed(pk0, &self.z2, &self.omega),
+        if cap_c.homomorphic_mul(&self.z1).homomorphic_add(
+            &CiphertextMod::new_with_randomizer_signed(pk0, &self.z2, &self.omega),
         ) != cap_d
-            .homomorphic_mul(pk0, &e)
-            .homomorphic_add(pk0, &self.cap_a)
+            .homomorphic_mul(&e)
+            .homomorphic_add(&self.cap_a.to_mod(pk0))
         {
             return false;
         }
@@ -206,10 +204,10 @@ impl<P: SchemeParams> AffGProof<P> {
         // Original: `Y^e`. Modified `Y^{-e}`.
         // (1 + N_1)^{z_2} \omega_y^{N_1} = B_y Y^(-e) \mod N_1^2
         // => encrypt_1(z_2, \omega_y) = B_y (+) Y (*) (-e)
-        if Ciphertext::new_with_randomizer_signed(pk1, &self.z2, &self.omega_y)
+        if CiphertextMod::new_with_randomizer_signed(pk1, &self.z2, &self.omega_y)
             != cap_y
-                .homomorphic_mul(pk1, &-e)
-                .homomorphic_add(pk1, &self.cap_b_y)
+                .homomorphic_mul(&-e)
+                .homomorphic_add(&self.cap_b_y.to_mod(pk1))
         {
             return false;
         }
@@ -238,7 +236,7 @@ mod tests {
 
     use super::AffGProof;
     use crate::cggmp21::{SchemeParams, TestParams};
-    use crate::paillier::{Ciphertext, RPParamsMod, RandomizerMod, SecretKeyPaillier};
+    use crate::paillier::{CiphertextMod, RPParamsMod, RandomizerMod, SecretKeyPaillier};
     use crate::uint::Signed;
 
     #[test]
@@ -263,13 +261,17 @@ mod tests {
         let rho = RandomizerMod::random(&mut OsRng, pk0);
         let rho_y = RandomizerMod::random(&mut OsRng, pk1);
         let secret = Signed::random(&mut OsRng);
-        let cap_c = Ciphertext::new_signed(&mut OsRng, pk0, &secret);
+        let cap_c = CiphertextMod::new_signed(&mut OsRng, pk0, &secret);
 
-        let cap_d = cap_c.homomorphic_mul(pk0, &x).homomorphic_add(
-            pk0,
-            &Ciphertext::new_with_randomizer_signed(pk0, &-y, &rho.retrieve()),
-        );
-        let cap_y = Ciphertext::new_with_randomizer_signed(pk1, &y, &rho_y.retrieve());
+        let cap_d =
+            cap_c
+                .homomorphic_mul(&x)
+                .homomorphic_add(&CiphertextMod::new_with_randomizer_signed(
+                    pk0,
+                    &-y,
+                    &rho.retrieve(),
+                ));
+        let cap_y = CiphertextMod::new_with_randomizer_signed(pk1, &y, &rho_y.retrieve());
         let cap_x = Params::scalar_from_signed(&x).mul_by_generator();
 
         let proof = AffGProof::<Params>::new(

--- a/synedrion/src/cggmp21/sigma/aff_g.rs
+++ b/synedrion/src/cggmp21/sigma/aff_g.rs
@@ -105,7 +105,7 @@ impl<P: SchemeParams> AffGProof<P> {
         let delta = Signed::random_bounded_bits_scaled(rng, P::L_BOUND + P::EPS_BOUND, hat_cap_n);
         let mu = Signed::random_bounded_bits_scaled(rng, P::L_BOUND, hat_cap_n);
 
-        let cap_a = cap_c.homomorphic_mul(&alpha)
+        let cap_a = cap_c * alpha
             + CiphertextMod::new_with_randomizer_signed(pk0, &beta, &r_mod.retrieve());
         let cap_b_x = P::scalar_from_signed(&alpha).mul_by_generator();
         let cap_b_y = CiphertextMod::new_with_randomizer_signed(pk1, &beta, &r_y_mod.retrieve());
@@ -192,9 +192,8 @@ impl<P: SchemeParams> AffGProof<P> {
 
         // C^{z_1} (1 + N_0)^{z_2} \omega^{N_0} = A D^e \mod N_0^2
         // => C (*) z_1 (+) encrypt_0(z_2, \omega) = A (+) D (*) e
-        if cap_c.homomorphic_mul(&self.z1)
-            + CiphertextMod::new_with_randomizer_signed(pk0, &self.z2, &self.omega)
-            != cap_d.homomorphic_mul(&e) + self.cap_a.to_mod(pk0)
+        if cap_c * self.z1 + CiphertextMod::new_with_randomizer_signed(pk0, &self.z2, &self.omega)
+            != cap_d * e + self.cap_a.to_mod(pk0)
         {
             return false;
         }
@@ -212,7 +211,7 @@ impl<P: SchemeParams> AffGProof<P> {
         // (1 + N_1)^{z_2} \omega_y^{N_1} = B_y Y^(-e) \mod N_1^2
         // => encrypt_1(z_2, \omega_y) = B_y (+) Y (*) (-e)
         if CiphertextMod::new_with_randomizer_signed(pk1, &self.z2, &self.omega_y)
-            != cap_y.homomorphic_mul(&-e) + self.cap_b_y.to_mod(pk1)
+            != cap_y * (-e) + self.cap_b_y.to_mod(pk1)
         {
             return false;
         }
@@ -268,8 +267,8 @@ mod tests {
         let secret = Signed::random(&mut OsRng);
         let cap_c = CiphertextMod::new_signed(&mut OsRng, pk0, &secret);
 
-        let cap_d = cap_c.homomorphic_mul(&x)
-            + CiphertextMod::new_with_randomizer_signed(pk0, &-y, &rho.retrieve());
+        let cap_d =
+            &cap_c * x + CiphertextMod::new_with_randomizer_signed(pk0, &-y, &rho.retrieve());
         let cap_y = CiphertextMod::new_with_randomizer_signed(pk1, &y, &rho_y.retrieve());
         let cap_x = Params::scalar_from_signed(&x).mul_by_generator();
 

--- a/synedrion/src/cggmp21/sigma/aff_g.rs
+++ b/synedrion/src/cggmp21/sigma/aff_g.rs
@@ -105,9 +105,8 @@ impl<P: SchemeParams> AffGProof<P> {
         let delta = Signed::random_bounded_bits_scaled(rng, P::L_BOUND + P::EPS_BOUND, hat_cap_n);
         let mu = Signed::random_bounded_bits_scaled(rng, P::L_BOUND, hat_cap_n);
 
-        let cap_a = cap_c.homomorphic_mul(&alpha).homomorphic_add(
-            &CiphertextMod::new_with_randomizer_signed(pk0, &beta, &r_mod.retrieve()),
-        );
+        let cap_a = cap_c.homomorphic_mul(&alpha)
+            + CiphertextMod::new_with_randomizer_signed(pk0, &beta, &r_mod.retrieve());
         let cap_b_x = P::scalar_from_signed(&alpha).mul_by_generator();
         let cap_b_y = CiphertextMod::new_with_randomizer_signed(pk1, &beta, &r_y_mod.retrieve());
         let cap_e = setup.commit(&alpha, &gamma).retrieve();
@@ -193,11 +192,9 @@ impl<P: SchemeParams> AffGProof<P> {
 
         // C^{z_1} (1 + N_0)^{z_2} \omega^{N_0} = A D^e \mod N_0^2
         // => C (*) z_1 (+) encrypt_0(z_2, \omega) = A (+) D (*) e
-        if cap_c.homomorphic_mul(&self.z1).homomorphic_add(
-            &CiphertextMod::new_with_randomizer_signed(pk0, &self.z2, &self.omega),
-        ) != cap_d
-            .homomorphic_mul(&e)
-            .homomorphic_add(&self.cap_a.to_mod(pk0))
+        if cap_c.homomorphic_mul(&self.z1)
+            + CiphertextMod::new_with_randomizer_signed(pk0, &self.z2, &self.omega)
+            != cap_d.homomorphic_mul(&e) + self.cap_a.to_mod(pk0)
         {
             return false;
         }
@@ -215,9 +212,7 @@ impl<P: SchemeParams> AffGProof<P> {
         // (1 + N_1)^{z_2} \omega_y^{N_1} = B_y Y^(-e) \mod N_1^2
         // => encrypt_1(z_2, \omega_y) = B_y (+) Y (*) (-e)
         if CiphertextMod::new_with_randomizer_signed(pk1, &self.z2, &self.omega_y)
-            != cap_y
-                .homomorphic_mul(&-e)
-                .homomorphic_add(&self.cap_b_y.to_mod(pk1))
+            != cap_y.homomorphic_mul(&-e) + self.cap_b_y.to_mod(pk1)
         {
             return false;
         }
@@ -273,14 +268,8 @@ mod tests {
         let secret = Signed::random(&mut OsRng);
         let cap_c = CiphertextMod::new_signed(&mut OsRng, pk0, &secret);
 
-        let cap_d =
-            cap_c
-                .homomorphic_mul(&x)
-                .homomorphic_add(&CiphertextMod::new_with_randomizer_signed(
-                    pk0,
-                    &-y,
-                    &rho.retrieve(),
-                ));
+        let cap_d = cap_c.homomorphic_mul(&x)
+            + CiphertextMod::new_with_randomizer_signed(pk0, &-y, &rho.retrieve());
         let cap_y = CiphertextMod::new_with_randomizer_signed(pk1, &y, &rho_y.retrieve());
         let cap_x = Params::scalar_from_signed(&x).mul_by_generator();
 

--- a/synedrion/src/cggmp21/sigma/aff_g.rs
+++ b/synedrion/src/cggmp21/sigma/aff_g.rs
@@ -71,6 +71,12 @@ impl<P: SchemeParams> AffGProof<P> {
         setup: &RPParamsMod<P::Paillier>,
         aux: &impl Hashable,
     ) -> Self {
+        x.assert_bound(P::L_BOUND);
+        y.assert_bound(P::LP_BOUND);
+        assert!(cap_c.public_key() == pk0);
+        assert!(cap_d.public_key() == pk0);
+        assert!(cap_y.public_key() == pk1);
+
         let mut reader = XofHash::new_with_dst(HASH_TAG)
             .chain(pk0)
             .chain(pk1)
@@ -161,6 +167,10 @@ impl<P: SchemeParams> AffGProof<P> {
         setup: &RPParamsMod<P::Paillier>,
         aux: &impl Hashable,
     ) -> bool {
+        assert!(cap_c.public_key() == pk0);
+        assert!(cap_d.public_key() == pk0);
+        assert!(cap_y.public_key() == pk1);
+
         let mut reader = XofHash::new_with_dst(HASH_TAG)
             .chain(pk0)
             .chain(pk1)

--- a/synedrion/src/cggmp21/sigma/dec.rs
+++ b/synedrion/src/cggmp21/sigma/dec.rs
@@ -121,10 +121,7 @@ impl<P: SchemeParams> DecProof<P> {
 
         // enc(z_1, \omega) == A (+) C (*) e
         if CiphertextMod::new_with_randomizer_wide(pk0, &self.z1, &self.omega)
-            != self
-                .cap_a
-                .to_mod(pk0)
-                .homomorphic_add(&cap_c.homomorphic_mul(&e))
+            != self.cap_a.to_mod(pk0) + cap_c.homomorphic_mul(&e)
         {
             return false;
         }

--- a/synedrion/src/cggmp21/sigma/dec.rs
+++ b/synedrion/src/cggmp21/sigma/dec.rs
@@ -121,7 +121,7 @@ impl<P: SchemeParams> DecProof<P> {
 
         // enc(z_1, \omega) == A (+) C (*) e
         if CiphertextMod::new_with_randomizer_wide(pk0, &self.z1, &self.omega)
-            != self.cap_a.to_mod(pk0) + cap_c.homomorphic_mul(&e)
+            != self.cap_a.to_mod(pk0) + cap_c * e
         {
             return false;
         }

--- a/synedrion/src/cggmp21/sigma/dec.rs
+++ b/synedrion/src/cggmp21/sigma/dec.rs
@@ -52,6 +52,8 @@ impl<P: SchemeParams> DecProof<P> {
         setup: &RPParamsMod<P::Paillier>,
         aux: &impl Hashable,
     ) -> Self {
+        assert_eq!(cap_c.public_key(), pk0);
+
         let mut reader = XofHash::new_with_dst(HASH_TAG)
             .chain(pk0)
             .chain(x)
@@ -100,6 +102,8 @@ impl<P: SchemeParams> DecProof<P> {
         setup: &RPParamsMod<P::Paillier>,
         aux: &impl Hashable,
     ) -> bool {
+        assert_eq!(cap_c.public_key(), pk0);
+
         let mut reader = XofHash::new_with_dst(HASH_TAG)
             .chain(pk0)
             .chain(x)

--- a/synedrion/src/cggmp21/sigma/enc.rs
+++ b/synedrion/src/cggmp21/sigma/enc.rs
@@ -46,6 +46,9 @@ impl<P: SchemeParams> EncProof<P> {
         setup: &RPParamsMod<P::Paillier>,
         aux: &impl Hashable,
     ) -> Self {
+        k.assert_bound(P::L_BOUND);
+        assert_eq!(cap_k.public_key(), pk0);
+
         let mut reader = XofHash::new_with_dst(HASH_TAG)
             .chain(pk0)
             .chain(cap_k)
@@ -91,6 +94,8 @@ impl<P: SchemeParams> EncProof<P> {
         setup: &RPParamsMod<P::Paillier>,
         aux: &impl Hashable,
     ) -> bool {
+        assert_eq!(cap_k.public_key(), pk0);
+
         let mut reader = XofHash::new_with_dst(HASH_TAG)
             .chain(pk0)
             .chain(cap_k)

--- a/synedrion/src/cggmp21/sigma/enc.rs
+++ b/synedrion/src/cggmp21/sigma/enc.rs
@@ -117,7 +117,7 @@ impl<P: SchemeParams> EncProof<P> {
 
         // enc_0(z1, z2) == A (+) K (*) e
         let c = CiphertextMod::new_with_randomizer_signed(pk0, &self.z1, &self.z2);
-        if c != self.cap_a.to_mod(pk0) + cap_k.homomorphic_mul(&e) {
+        if c != self.cap_a.to_mod(pk0) + cap_k * e {
             return false;
         }
 

--- a/synedrion/src/cggmp21/sigma/enc.rs
+++ b/synedrion/src/cggmp21/sigma/enc.rs
@@ -117,11 +117,7 @@ impl<P: SchemeParams> EncProof<P> {
 
         // enc_0(z1, z2) == A (+) K (*) e
         let c = CiphertextMod::new_with_randomizer_signed(pk0, &self.z1, &self.z2);
-        if c != self
-            .cap_a
-            .to_mod(pk0)
-            .homomorphic_add(&cap_k.homomorphic_mul(&e))
-        {
+        if c != self.cap_a.to_mod(pk0) + cap_k.homomorphic_mul(&e) {
             return false;
         }
 

--- a/synedrion/src/cggmp21/sigma/log_star.rs
+++ b/synedrion/src/cggmp21/sigma/log_star.rs
@@ -126,7 +126,7 @@ impl<P: SchemeParams> LogStarProof<P> {
 
         // enc_0(z1, z2) == A (+) C (*) e
         let c = CiphertextMod::new_with_randomizer_signed(pk0, &self.z1, &self.z2);
-        if c != self.cap_a.to_mod(pk0) + cap_c.homomorphic_mul(&e) {
+        if c != self.cap_a.to_mod(pk0) + cap_c * e {
             return false;
         }
 

--- a/synedrion/src/cggmp21/sigma/log_star.rs
+++ b/synedrion/src/cggmp21/sigma/log_star.rs
@@ -126,11 +126,7 @@ impl<P: SchemeParams> LogStarProof<P> {
 
         // enc_0(z1, z2) == A (+) C (*) e
         let c = CiphertextMod::new_with_randomizer_signed(pk0, &self.z1, &self.z2);
-        if c != self
-            .cap_a
-            .to_mod(pk0)
-            .homomorphic_add(&cap_c.homomorphic_mul(&e))
-        {
+        if c != self.cap_a.to_mod(pk0) + cap_c.homomorphic_mul(&e) {
             return false;
         }
 

--- a/synedrion/src/cggmp21/sigma/log_star.rs
+++ b/synedrion/src/cggmp21/sigma/log_star.rs
@@ -53,6 +53,9 @@ impl<P: SchemeParams> LogStarProof<P> {
         setup: &RPParamsMod<P::Paillier>,
         aux: &impl Hashable,
     ) -> Self {
+        x.assert_bound(P::L_BOUND);
+        assert_eq!(cap_c.public_key(), pk0);
+
         let mut reader = XofHash::new_with_dst(HASH_TAG)
             .chain(pk0)
             .chain(cap_c)
@@ -103,6 +106,8 @@ impl<P: SchemeParams> LogStarProof<P> {
         setup: &RPParamsMod<P::Paillier>,
         aux: &impl Hashable,
     ) -> bool {
+        assert_eq!(cap_c.public_key(), pk0);
+
         let mut reader = XofHash::new_with_dst(HASH_TAG)
             .chain(pk0)
             .chain(cap_c)

--- a/synedrion/src/cggmp21/sigma/mul.rs
+++ b/synedrion/src/cggmp21/sigma/mul.rs
@@ -5,7 +5,8 @@ use serde::{Deserialize, Serialize};
 
 use super::super::SchemeParams;
 use crate::paillier::{
-    Ciphertext, PaillierParams, PublicKeyPaillierPrecomputed, Randomizer, RandomizerMod,
+    Ciphertext, CiphertextMod, PaillierParams, PublicKeyPaillierPrecomputed, Randomizer,
+    RandomizerMod,
 };
 use crate::tools::hashing::{Chain, Hashable, XofHash};
 use crate::uint::{Bounded, Retrieve, Signed};
@@ -46,9 +47,9 @@ impl<P: SchemeParams> MulProof<P> {
         rho_x: &RandomizerMod<P::Paillier>,
         rho: &RandomizerMod<P::Paillier>,
         pk: &PublicKeyPaillierPrecomputed<P::Paillier>,
-        cap_x: &Ciphertext<P::Paillier>,
-        cap_y: &Ciphertext<P::Paillier>,
-        cap_c: &Ciphertext<P::Paillier>,
+        cap_x: &CiphertextMod<P::Paillier>,
+        cap_y: &CiphertextMod<P::Paillier>,
+        cap_c: &CiphertextMod<P::Paillier>,
         aux: &impl Hashable,
     ) -> Self {
         let mut reader = XofHash::new_with_dst(HASH_TAG)
@@ -74,10 +75,8 @@ impl<P: SchemeParams> MulProof<P> {
         let r = r_mod.retrieve();
         let s = s_mod.retrieve();
 
-        let cap_a = cap_y
-            .homomorphic_mul_unsigned(pk, &alpha)
-            .mul_randomizer(pk, &r);
-        let cap_b = Ciphertext::new_with_randomizer(pk, alpha.as_ref(), &s);
+        let cap_a = cap_y.homomorphic_mul_unsigned(&alpha).mul_randomizer(&r);
+        let cap_b = CiphertextMod::new_with_randomizer(pk, alpha.as_ref(), &s);
 
         let z = alpha.into_wide().into_signed().unwrap() + e.mul_wide(x);
         let u = (r_mod * rho.pow_signed_vartime(&e)).retrieve();
@@ -85,8 +84,8 @@ impl<P: SchemeParams> MulProof<P> {
 
         Self {
             e,
-            cap_a,
-            cap_b,
+            cap_a: cap_a.retrieve(),
+            cap_b: cap_b.retrieve(),
             z,
             u,
             v,
@@ -96,9 +95,9 @@ impl<P: SchemeParams> MulProof<P> {
     pub fn verify(
         &self,
         pk: &PublicKeyPaillierPrecomputed<P::Paillier>,
-        cap_x: &Ciphertext<P::Paillier>,
-        cap_y: &Ciphertext<P::Paillier>,
-        cap_c: &Ciphertext<P::Paillier>,
+        cap_x: &CiphertextMod<P::Paillier>,
+        cap_y: &CiphertextMod<P::Paillier>,
+        cap_c: &CiphertextMod<P::Paillier>,
         aux: &impl Hashable,
     ) -> bool {
         let mut reader = XofHash::new_with_dst(HASH_TAG)
@@ -117,22 +116,22 @@ impl<P: SchemeParams> MulProof<P> {
         }
 
         // Y^z u^N = A * C^e \mod N^2
-        if cap_y
-            .homomorphic_mul_wide(pk, &self.z)
-            .mul_randomizer(pk, &self.u)
+        if cap_y.homomorphic_mul_wide(&self.z).mul_randomizer(&self.u)
             != self
                 .cap_a
-                .homomorphic_add(pk, &cap_c.homomorphic_mul(pk, &e))
+                .to_mod(pk)
+                .homomorphic_add(&cap_c.homomorphic_mul(&e))
         {
             return false;
         }
 
         // enc(z, v) == B * X^e \mod N^2
         // (Note: typo in the paper, it uses `c` and not `v` here)
-        if Ciphertext::new_with_randomizer_wide(pk, &self.z, &self.v)
+        if CiphertextMod::new_with_randomizer_wide(pk, &self.z, &self.v)
             != self
                 .cap_b
-                .homomorphic_add(pk, &cap_x.homomorphic_mul(pk, &e))
+                .to_mod(pk)
+                .homomorphic_add(&cap_x.homomorphic_mul(&e))
         {
             return false;
         }
@@ -147,7 +146,7 @@ mod tests {
 
     use super::MulProof;
     use crate::cggmp21::{SchemeParams, TestParams};
-    use crate::paillier::{Ciphertext, RandomizerMod, SecretKeyPaillier};
+    use crate::paillier::{CiphertextMod, RandomizerMod, SecretKeyPaillier};
     use crate::uint::Signed;
 
     #[test]
@@ -165,11 +164,9 @@ mod tests {
         let rho_x = RandomizerMod::random(&mut OsRng, pk);
         let rho = RandomizerMod::random(&mut OsRng, pk);
 
-        let cap_x = Ciphertext::new_with_randomizer_signed(pk, &x, &rho_x.retrieve());
-        let cap_y = Ciphertext::new_signed(&mut OsRng, pk, &y);
-        let cap_c = cap_y
-            .homomorphic_mul(pk, &x)
-            .mul_randomizer(pk, &rho.retrieve());
+        let cap_x = CiphertextMod::new_with_randomizer_signed(pk, &x, &rho_x.retrieve());
+        let cap_y = CiphertextMod::new_signed(&mut OsRng, pk, &y);
+        let cap_c = cap_y.homomorphic_mul(&x).mul_randomizer(&rho.retrieve());
 
         let proof = MulProof::<Params>::new(
             &mut OsRng, &x, &rho_x, &rho, pk, &cap_x, &cap_y, &cap_c, &aux,

--- a/synedrion/src/cggmp21/sigma/mul.rs
+++ b/synedrion/src/cggmp21/sigma/mul.rs
@@ -79,7 +79,7 @@ impl<P: SchemeParams> MulProof<P> {
         let r = r_mod.retrieve();
         let s = s_mod.retrieve();
 
-        let cap_a = cap_y.homomorphic_mul_unsigned(&alpha).mul_randomizer(&r);
+        let cap_a = (cap_y * alpha).mul_randomizer(&r);
         let cap_b = CiphertextMod::new_with_randomizer(pk, alpha.as_ref(), &s);
 
         let z = alpha.into_wide().into_signed().unwrap() + e.mul_wide(x);
@@ -125,7 +125,7 @@ impl<P: SchemeParams> MulProof<P> {
 
         // Y^z u^N = A * C^e \mod N^2
         if cap_y.homomorphic_mul_wide(&self.z).mul_randomizer(&self.u)
-            != self.cap_a.to_mod(pk) + cap_c.homomorphic_mul(&e)
+            != self.cap_a.to_mod(pk) + cap_c * e
         {
             return false;
         }
@@ -133,7 +133,7 @@ impl<P: SchemeParams> MulProof<P> {
         // enc(z, v) == B * X^e \mod N^2
         // (Note: typo in the paper, it uses `c` and not `v` here)
         if CiphertextMod::new_with_randomizer_wide(pk, &self.z, &self.v)
-            != self.cap_b.to_mod(pk) + cap_x.homomorphic_mul(&e)
+            != self.cap_b.to_mod(pk) + cap_x * e
         {
             return false;
         }
@@ -168,7 +168,7 @@ mod tests {
 
         let cap_x = CiphertextMod::new_with_randomizer_signed(pk, &x, &rho_x.retrieve());
         let cap_y = CiphertextMod::new_signed(&mut OsRng, pk, &y);
-        let cap_c = cap_y.homomorphic_mul(&x).mul_randomizer(&rho.retrieve());
+        let cap_c = (&cap_y * x).mul_randomizer(&rho.retrieve());
 
         let proof = MulProof::<Params>::new(
             &mut OsRng, &x, &rho_x, &rho, pk, &cap_x, &cap_y, &cap_c, &aux,

--- a/synedrion/src/cggmp21/sigma/mul.rs
+++ b/synedrion/src/cggmp21/sigma/mul.rs
@@ -125,10 +125,7 @@ impl<P: SchemeParams> MulProof<P> {
 
         // Y^z u^N = A * C^e \mod N^2
         if cap_y.homomorphic_mul_wide(&self.z).mul_randomizer(&self.u)
-            != self
-                .cap_a
-                .to_mod(pk)
-                .homomorphic_add(&cap_c.homomorphic_mul(&e))
+            != self.cap_a.to_mod(pk) + cap_c.homomorphic_mul(&e)
         {
             return false;
         }
@@ -136,10 +133,7 @@ impl<P: SchemeParams> MulProof<P> {
         // enc(z, v) == B * X^e \mod N^2
         // (Note: typo in the paper, it uses `c` and not `v` here)
         if CiphertextMod::new_with_randomizer_wide(pk, &self.z, &self.v)
-            != self
-                .cap_b
-                .to_mod(pk)
-                .homomorphic_add(&cap_x.homomorphic_mul(&e))
+            != self.cap_b.to_mod(pk) + cap_x.homomorphic_mul(&e)
         {
             return false;
         }

--- a/synedrion/src/cggmp21/sigma/mul.rs
+++ b/synedrion/src/cggmp21/sigma/mul.rs
@@ -52,6 +52,10 @@ impl<P: SchemeParams> MulProof<P> {
         cap_c: &CiphertextMod<P::Paillier>,
         aux: &impl Hashable,
     ) -> Self {
+        assert_eq!(cap_x.public_key(), pk);
+        assert_eq!(cap_y.public_key(), pk);
+        assert_eq!(cap_c.public_key(), pk);
+
         let mut reader = XofHash::new_with_dst(HASH_TAG)
             .chain(pk)
             .chain(cap_x)
@@ -100,6 +104,10 @@ impl<P: SchemeParams> MulProof<P> {
         cap_c: &CiphertextMod<P::Paillier>,
         aux: &impl Hashable,
     ) -> bool {
+        assert_eq!(cap_x.public_key(), pk);
+        assert_eq!(cap_y.public_key(), pk);
+        assert_eq!(cap_c.public_key(), pk);
+
         let mut reader = XofHash::new_with_dst(HASH_TAG)
             .chain(pk)
             .chain(cap_x)

--- a/synedrion/src/cggmp21/sigma/mul_star.rs
+++ b/synedrion/src/cggmp21/sigma/mul_star.rs
@@ -6,8 +6,8 @@ use serde::{Deserialize, Serialize};
 use super::super::SchemeParams;
 use crate::curve::Point;
 use crate::paillier::{
-    Ciphertext, PaillierParams, PublicKeyPaillierPrecomputed, RPCommitment, RPParamsMod,
-    Randomizer, RandomizerMod,
+    Ciphertext, CiphertextMod, PaillierParams, PublicKeyPaillierPrecomputed, RPCommitment,
+    RPParamsMod, Randomizer, RandomizerMod,
 };
 use crate::tools::hashing::{Chain, Hashable, XofHash};
 use crate::uint::Signed;
@@ -47,8 +47,8 @@ impl<P: SchemeParams> MulStarProof<P> {
         x: &Signed<<P::Paillier as PaillierParams>::Uint>,
         rho: &RandomizerMod<P::Paillier>,
         pk0: &PublicKeyPaillierPrecomputed<P::Paillier>,
-        cap_c: &Ciphertext<P::Paillier>,
-        cap_d: &Ciphertext<P::Paillier>,
+        cap_c: &CiphertextMod<P::Paillier>,
+        cap_d: &CiphertextMod<P::Paillier>,
         cap_x: &Point,
         setup: &RPParamsMod<P::Paillier>,
         aux: &impl Hashable,
@@ -79,10 +79,8 @@ impl<P: SchemeParams> MulStarProof<P> {
         let gamma = Signed::random_bounded_bits_scaled(rng, P::L_BOUND + P::EPS_BOUND, hat_cap_n);
         let m = Signed::random_bounded_bits_scaled(rng, P::L_BOUND, hat_cap_n);
 
-        let cap_a = cap_c
-            .homomorphic_mul(pk0, &alpha)
-            .mul_randomizer(pk0, &r.retrieve());
-        let cap_b_x = Point::GENERATOR * P::scalar_from_signed(&alpha);
+        let cap_a = cap_c.homomorphic_mul(&alpha).mul_randomizer(&r.retrieve());
+        let cap_b_x = P::scalar_from_signed(&alpha).mul_by_generator();
         let cap_e = setup.commit(&alpha, &gamma).retrieve();
         let cap_s = setup.commit(x, &m).retrieve();
 
@@ -92,7 +90,7 @@ impl<P: SchemeParams> MulStarProof<P> {
 
         Self {
             e,
-            cap_a,
+            cap_a: cap_a.retrieve(),
             cap_b_x,
             cap_e,
             cap_s,
@@ -107,8 +105,8 @@ impl<P: SchemeParams> MulStarProof<P> {
     pub fn verify(
         &self,
         pk0: &PublicKeyPaillierPrecomputed<P::Paillier>,
-        cap_c: &Ciphertext<P::Paillier>,
-        cap_d: &Ciphertext<P::Paillier>,
+        cap_c: &CiphertextMod<P::Paillier>,
+        cap_d: &CiphertextMod<P::Paillier>,
         cap_x: &Point,
         setup: &RPParamsMod<P::Paillier>,
         aux: &impl Hashable,
@@ -132,18 +130,17 @@ impl<P: SchemeParams> MulStarProof<P> {
         let aux_pk = setup.public_key();
 
         // C (*) z_1 * \omega^{N_0} == A (+) D (*) e
-        if cap_c
-            .homomorphic_mul(pk0, &self.z1)
-            .mul_randomizer(pk0, &self.omega)
+        if cap_c.homomorphic_mul(&self.z1).mul_randomizer(&self.omega)
             != self
                 .cap_a
-                .homomorphic_add(pk0, &cap_d.homomorphic_mul(pk0, &e))
+                .to_mod(pk0)
+                .homomorphic_add(&cap_d.homomorphic_mul(&e))
         {
             return false;
         }
 
         // g^{z_1} == B_x X^e
-        if Point::GENERATOR * P::scalar_from_signed(&self.z1)
+        if P::scalar_from_signed(&self.z1).mul_by_generator()
             != self.cap_b_x + cap_x * &P::scalar_from_signed(&e)
         {
             return false;
@@ -166,8 +163,7 @@ mod tests {
 
     use super::MulStarProof;
     use crate::cggmp21::{SchemeParams, TestParams};
-    use crate::curve::Point;
-    use crate::paillier::{Ciphertext, RPParamsMod, RandomizerMod, SecretKeyPaillier};
+    use crate::paillier::{CiphertextMod, RPParamsMod, RandomizerMod, SecretKeyPaillier};
     use crate::uint::Signed;
 
     #[test]
@@ -186,11 +182,9 @@ mod tests {
         let x = Signed::random_bounded_bits(&mut OsRng, Params::L_BOUND);
         let secret = Signed::random_bounded_bits(&mut OsRng, Params::L_BOUND);
         let rho = RandomizerMod::random(&mut OsRng, pk);
-        let cap_c = Ciphertext::new_signed(&mut OsRng, pk, &secret);
-        let cap_d = cap_c
-            .homomorphic_mul(pk, &x)
-            .mul_randomizer(pk, &rho.retrieve());
-        let cap_x = Point::GENERATOR * Params::scalar_from_signed(&x);
+        let cap_c = CiphertextMod::new_signed(&mut OsRng, pk, &secret);
+        let cap_d = cap_c.homomorphic_mul(&x).mul_randomizer(&rho.retrieve());
+        let cap_x = Params::scalar_from_signed(&x).mul_by_generator();
 
         let proof = MulStarProof::<Params>::new(
             &mut OsRng, &x, &rho, pk, &cap_c, &cap_d, &cap_x, &setup, &aux,

--- a/synedrion/src/cggmp21/sigma/mul_star.rs
+++ b/synedrion/src/cggmp21/sigma/mul_star.rs
@@ -60,6 +60,10 @@ impl<P: SchemeParams> MulStarProof<P> {
         - $\beta$ used to create $A$ is not mentioned anywhere else - a typo, it is effectively == 0
         */
 
+        x.assert_bound(P::L_BOUND);
+        assert_eq!(cap_c.public_key(), pk0);
+        assert_eq!(cap_d.public_key(), pk0);
+
         let mut reader = XofHash::new_with_dst(HASH_TAG)
             .chain(pk0)
             .chain(cap_c)
@@ -111,6 +115,9 @@ impl<P: SchemeParams> MulStarProof<P> {
         setup: &RPParamsMod<P::Paillier>,
         aux: &impl Hashable,
     ) -> bool {
+        assert_eq!(cap_c.public_key(), pk0);
+        assert_eq!(cap_d.public_key(), pk0);
+
         let mut reader = XofHash::new_with_dst(HASH_TAG)
             .chain(pk0)
             .chain(cap_c)

--- a/synedrion/src/cggmp21/sigma/mul_star.rs
+++ b/synedrion/src/cggmp21/sigma/mul_star.rs
@@ -83,7 +83,7 @@ impl<P: SchemeParams> MulStarProof<P> {
         let gamma = Signed::random_bounded_bits_scaled(rng, P::L_BOUND + P::EPS_BOUND, hat_cap_n);
         let m = Signed::random_bounded_bits_scaled(rng, P::L_BOUND, hat_cap_n);
 
-        let cap_a = cap_c.homomorphic_mul(&alpha).mul_randomizer(&r.retrieve());
+        let cap_a = (cap_c * alpha).mul_randomizer(&r.retrieve());
         let cap_b_x = P::scalar_from_signed(&alpha).mul_by_generator();
         let cap_e = setup.commit(&alpha, &gamma).retrieve();
         let cap_s = setup.commit(x, &m).retrieve();
@@ -137,9 +137,7 @@ impl<P: SchemeParams> MulStarProof<P> {
         let aux_pk = setup.public_key();
 
         // C (*) z_1 * \omega^{N_0} == A (+) D (*) e
-        if cap_c.homomorphic_mul(&self.z1).mul_randomizer(&self.omega)
-            != self.cap_a.to_mod(pk0) + cap_d.homomorphic_mul(&e)
-        {
+        if (cap_c * self.z1).mul_randomizer(&self.omega) != self.cap_a.to_mod(pk0) + cap_d * e {
             return false;
         }
 
@@ -187,7 +185,7 @@ mod tests {
         let secret = Signed::random_bounded_bits(&mut OsRng, Params::L_BOUND);
         let rho = RandomizerMod::random(&mut OsRng, pk);
         let cap_c = CiphertextMod::new_signed(&mut OsRng, pk, &secret);
-        let cap_d = cap_c.homomorphic_mul(&x).mul_randomizer(&rho.retrieve());
+        let cap_d = (&cap_c * x).mul_randomizer(&rho.retrieve());
         let cap_x = Params::scalar_from_signed(&x).mul_by_generator();
 
         let proof = MulStarProof::<Params>::new(

--- a/synedrion/src/cggmp21/sigma/mul_star.rs
+++ b/synedrion/src/cggmp21/sigma/mul_star.rs
@@ -138,10 +138,7 @@ impl<P: SchemeParams> MulStarProof<P> {
 
         // C (*) z_1 * \omega^{N_0} == A (+) D (*) e
         if cap_c.homomorphic_mul(&self.z1).mul_randomizer(&self.omega)
-            != self
-                .cap_a
-                .to_mod(pk0)
-                .homomorphic_add(&cap_d.homomorphic_mul(&e))
+            != self.cap_a.to_mod(pk0) + cap_d.homomorphic_mul(&e)
         {
             return false;
         }

--- a/synedrion/src/common.rs
+++ b/synedrion/src/common.rs
@@ -317,7 +317,7 @@ impl<P: SchemeParams> PresigningData<P> {
             for j in HoleRange::new(num_parties, i) {
                 let hat_beta = Signed::random_bounded_bits(rng, P::LP_BOUND);
                 let hat_s = RandomizerMod::random(rng, &public_keys[j]).retrieve();
-                let hat_cap_d = cap_k[j].homomorphic_mul(&P::signed_from_scalar(&x))
+                let hat_cap_d = &cap_k[j] * P::signed_from_scalar(&x)
                     + CiphertextMod::new_with_randomizer_signed(
                         &public_keys[j],
                         &-hat_beta,

--- a/synedrion/src/common.rs
+++ b/synedrion/src/common.rs
@@ -317,13 +317,12 @@ impl<P: SchemeParams> PresigningData<P> {
             for j in HoleRange::new(num_parties, i) {
                 let hat_beta = Signed::random_bounded_bits(rng, P::LP_BOUND);
                 let hat_s = RandomizerMod::random(rng, &public_keys[j]).retrieve();
-                let hat_cap_d = cap_k[j]
-                    .homomorphic_mul(&P::signed_from_scalar(&x))
-                    .homomorphic_add(&CiphertextMod::new_with_randomizer_signed(
+                let hat_cap_d = cap_k[j].homomorphic_mul(&P::signed_from_scalar(&x))
+                    + CiphertextMod::new_with_randomizer_signed(
                         &public_keys[j],
                         &-hat_beta,
                         &hat_s,
-                    ));
+                    );
 
                 hat_beta_vec.insert(j, hat_beta);
                 hat_s_vec.insert(j, hat_s);

--- a/synedrion/src/common.rs
+++ b/synedrion/src/common.rs
@@ -281,7 +281,7 @@ impl<P: SchemeParams> KeySharePrecomputed<P> {
 impl<P: SchemeParams> PresigningData<P> {
     /// Creates a consistent set of presigning data for testing purposes.
     #[cfg(any(test, feature = "bench-internals"))]
-    pub(crate) fn new_centralized(
+    pub fn new_centralized(
         rng: &mut impl CryptoRngCore,
         key_shares: &[KeyShare<P>],
     ) -> Box<[Self]> {

--- a/synedrion/src/common.rs
+++ b/synedrion/src/common.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use crate::cggmp21::SchemeParams;
 use crate::curve::{Point, Scalar};
 use crate::paillier::{
-    Ciphertext, PaillierParams, PublicKeyPaillier, PublicKeyPaillierPrecomputed, RPParams,
+    CiphertextMod, PaillierParams, PublicKeyPaillier, PublicKeyPaillierPrecomputed, RPParams,
     RPParamsMod, Randomizer, SecretKeyPaillier, SecretKeyPaillierPrecomputed,
 };
 use crate::rounds::PartyIdx;
@@ -125,12 +125,12 @@ pub struct PresigningData<P: SchemeParams> {
     pub(crate) hat_beta: HoleVec<Signed<<P::Paillier as PaillierParams>::Uint>>,
     pub(crate) hat_r: HoleVec<Randomizer<P::Paillier>>,
     pub(crate) hat_s: HoleVec<Randomizer<P::Paillier>>,
-    pub(crate) cap_k: Box<[Ciphertext<P::Paillier>]>,
+    pub(crate) cap_k: Box<[CiphertextMod<P::Paillier>]>,
     /// Received $\hat{D}$, that is $\hat{D}_{i,j}$, $j != i$, where $i$ is this party's index.
-    pub(crate) hat_cap_d_received: HoleVec<Ciphertext<P::Paillier>>,
+    pub(crate) hat_cap_d_received: HoleVec<CiphertextMod<P::Paillier>>,
     /// Sent $\hat{D}$, that is $\hat{D}_{j,i}$, $j != i$, where $i$ is this party's index.
-    pub(crate) hat_cap_d: HoleVec<Ciphertext<P::Paillier>>,
-    pub(crate) hat_cap_f: HoleVec<Ciphertext<P::Paillier>>,
+    pub(crate) hat_cap_d: HoleVec<CiphertextMod<P::Paillier>>,
+    pub(crate) hat_cap_f: HoleVec<CiphertextMod<P::Paillier>>,
 }
 
 impl<P: SchemeParams> KeyShare<P> {
@@ -299,7 +299,7 @@ impl<P: SchemeParams> PresigningData<P> {
         let cap_k = ephemeral_scalar_shares
             .iter()
             .enumerate()
-            .map(|(i, k)| Ciphertext::new(rng, &public_keys[i], &P::uint_from_scalar(k)))
+            .map(|(i, k)| CiphertextMod::new(rng, &public_keys[i], &P::uint_from_scalar(k)))
             .collect::<Vec<_>>();
 
         let mut presigning = Vec::new();
@@ -312,21 +312,18 @@ impl<P: SchemeParams> PresigningData<P> {
 
             let mut hat_beta_vec = HoleVecAccum::new(num_parties, i);
             let mut hat_s_vec = HoleVecAccum::new(num_parties, i);
-            let mut hat_cap_d_vec = HoleVecAccum::<Ciphertext<P::Paillier>>::new(num_parties, i);
+            let mut hat_cap_d_vec = HoleVecAccum::<CiphertextMod<P::Paillier>>::new(num_parties, i);
 
             for j in HoleRange::new(num_parties, i) {
                 let hat_beta = Signed::random_bounded_bits(rng, P::LP_BOUND);
                 let hat_s = RandomizerMod::random(rng, &public_keys[j]).retrieve();
                 let hat_cap_d = cap_k[j]
-                    .homomorphic_mul(&public_keys[j], &P::signed_from_scalar(&x))
-                    .homomorphic_add(
+                    .homomorphic_mul(&P::signed_from_scalar(&x))
+                    .homomorphic_add(&CiphertextMod::new_with_randomizer_signed(
                         &public_keys[j],
-                        &Ciphertext::new_with_randomizer_signed(
-                            &public_keys[j],
-                            &-hat_beta,
-                            &hat_s,
-                        ),
-                    );
+                        &-hat_beta,
+                        &hat_s,
+                    ));
 
                 hat_beta_vec.insert(j, hat_beta);
                 hat_s_vec.insert(j, hat_s);
@@ -349,7 +346,7 @@ impl<P: SchemeParams> PresigningData<P> {
                 let hat_r = RandomizerMod::random(rng, &public_keys[i]).retrieve();
 
                 let hat_cap_f =
-                    Ciphertext::new_with_randomizer_signed(&public_keys[i], hat_beta, &hat_r);
+                    CiphertextMod::new_with_randomizer_signed(&public_keys[i], hat_beta, &hat_r);
 
                 hat_r_vec.insert(j, hat_r);
                 hat_cap_f_vec.insert(j, hat_cap_f);

--- a/synedrion/src/lib.rs
+++ b/synedrion/src/lib.rs
@@ -47,7 +47,7 @@ pub use cggmp21::{
     PresigningProof, PresigningResult, ProductionParams, SchemeParams, SigningProof, SigningResult,
     TestParams,
 };
-pub use common::{KeyShare, KeyShareChange};
+pub use common::{KeyShare, KeyShareChange, PresigningData};
 pub use constructors::{
     make_interactive_signing_session, make_key_gen_session, make_key_refresh_session,
     PrehashedMessage,

--- a/synedrion/src/paillier.rs
+++ b/synedrion/src/paillier.rs
@@ -3,7 +3,7 @@ mod keys;
 mod params;
 mod ring_pedersen;
 
-pub(crate) use encryption::{Ciphertext, Randomizer, RandomizerMod};
+pub(crate) use encryption::{Ciphertext, CiphertextMod, Randomizer, RandomizerMod};
 pub(crate) use keys::{
     PublicKeyPaillier, PublicKeyPaillierPrecomputed, SecretKeyPaillier,
     SecretKeyPaillierPrecomputed,

--- a/synedrion/src/paillier/encryption.rs
+++ b/synedrion/src/paillier/encryption.rs
@@ -105,6 +105,10 @@ pub(crate) struct CiphertextMod<P: PaillierParams> {
 }
 
 impl<P: PaillierParams> CiphertextMod<P> {
+    pub fn public_key(&self) -> &PublicKeyPaillierPrecomputed<P> {
+        &self.pk
+    }
+
     /// Encrypts the plaintext with the provided randomizer.
     fn new_with_randomizer_inner(
         pk: &PublicKeyPaillierPrecomputed<P>,
@@ -329,7 +333,7 @@ impl<P: PaillierParams> Hashable for Ciphertext<P> {
 
 impl<P: PaillierParams> Hashable for CiphertextMod<P> {
     fn chain<C: Chain>(&self, digest: C) -> C {
-        digest.chain(&self.pk).chain(&self.ciphertext)
+        digest.chain(&self.ciphertext)
     }
 }
 

--- a/synedrion/src/paillier/keys.rs
+++ b/synedrion/src/paillier/keys.rs
@@ -224,7 +224,7 @@ impl<P: PaillierParams> PublicKeyPaillier<P> {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct PublicKeyPaillierPrecomputed<P: PaillierParams> {
     pk: PublicKeyPaillier<P>,
     precomputed_modulus: <P::UintMod as UintModLike>::Precomputed,
@@ -269,6 +269,14 @@ impl<P: PaillierParams> PublicKeyPaillierPrecomputed<P> {
         }
     }
 }
+
+impl<P: PaillierParams> PartialEq for PublicKeyPaillierPrecomputed<P> {
+    fn eq(&self, other: &Self) -> bool {
+        self.pk.eq(&other.pk)
+    }
+}
+
+impl<P: PaillierParams> Eq for PublicKeyPaillierPrecomputed<P> {}
 
 impl<P: PaillierParams> Hashable for PublicKeyPaillier<P> {
     fn chain<C: Chain>(&self, digest: C) -> C {

--- a/synedrion/src/tools/collections.rs
+++ b/synedrion/src/tools/collections.rs
@@ -189,6 +189,16 @@ impl<T> HoleVec<T> {
             hole_at: self.hole_at,
         }
     }
+
+    pub fn map_enumerate<F, V>(self, f: F) -> HoleVec<V>
+    where
+        F: FnMut((usize, &T)) -> V,
+    {
+        HoleVec {
+            elems: self.enumerate().map(f).collect(),
+            hole_at: self.hole_at,
+        }
+    }
 }
 
 impl<T, V> HoleVec<(T, V)> {

--- a/synedrion/src/uint/signed.rs
+++ b/synedrion/src/uint/signed.rs
@@ -58,8 +58,17 @@ impl<T: UintLike> Signed<T> {
         self.bound
     }
 
-    pub fn assert_bound_usize(self, bound: usize) -> Option<Self> {
-        if self.abs().bits() <= bound {
+    // Asserts that the value lies in the interval `[-2^bound, 2^bound]`.
+    // Panics if it is not the case.
+    pub fn assert_bound(self, bound: usize) {
+        assert!(self.abs() <= T::ONE.shl_vartime(bound));
+    }
+
+    // Asserts that the value has bound less or equal to `bound`
+    // (or, in other words, the value lies in the interval `(-(2^bound-1), 2^bound-1)`).
+    // Returns the value with the bound set to `bound`.
+    pub fn assert_bit_bound_usize(self, bound: usize) -> Option<Self> {
+        if self.abs().bits_vartime() <= bound {
             Some(Self {
                 value: self.value,
                 bound: bound as u32,


### PR DESCRIPTION
- Add `CiphertextMod` that includes the public key used to created it. Fixes #59 
- Add sanity checks in proof constructors - check that the scalar values are in the required range, and ciphertexts have consistent public keys. Fixes #64

Note that we could avoid passing the actual public keys in the proof constructors since they are already contained in ciphertexts. But:
- we already have them available, and it allows to catch some errors early;
- since the public key in the ciphertext is not hashed when creating the challenge, we need to add them to the hash explicitly, and it just makes it easier to eyeball the structure: the list of public inputs is exactly the list of method parameters, and is exactly the items passed to the hash.