### PR TITLE
Fixes for the audit week 1

### DIFF
--- a/synedrion/src/cggmp21/params.rs
+++ b/synedrion/src/cggmp21/params.rs
@@ -1,5 +1,4 @@
-use crate::curve::Scalar;
-use crate::curve::{Point, ORDER};
+use crate::curve::{Curve, Scalar, ORDER};
 use crate::paillier::PaillierParams;
 use crate::tools::hashing::{Chain, HashableType};
 use crate::uint::{
@@ -160,7 +159,7 @@ pub trait SchemeParams: Clone + Send + PartialEq + Eq + core::fmt::Debug + 'stat
 
 impl<P: SchemeParams> HashableType for P {
     fn chain_type<C: Chain>(digest: C) -> C {
-        digest.chain(&ORDER).chain(&Point::GENERATOR)
+        digest.chain_type::<Curve>()
     }
 }
 

--- a/synedrion/src/cggmp21/params.rs
+++ b/synedrion/src/cggmp21/params.rs
@@ -1,6 +1,7 @@
 use crate::curve::Scalar;
-use crate::curve::ORDER;
+use crate::curve::{Point, ORDER};
 use crate::paillier::PaillierParams;
+use crate::tools::hashing::{Chain, HashableType};
 use crate::uint::{
     subtle::ConditionallySelectable, upcast_uint, Bounded, Encoding, NonZero, Signed, U1024Mod,
     U2048Mod, U4096Mod, U512Mod, Zero, U1024, U2048, U4096, U512, U8192,
@@ -154,6 +155,12 @@ pub trait SchemeParams: Clone + Send + PartialEq + Eq + core::fmt::Debug + 'stat
     ) -> Scalar {
         let abs_value = Self::scalar_from_wide_uint(&value.abs());
         Scalar::conditional_select(&abs_value, &-abs_value, value.is_negative())
+    }
+}
+
+impl<P: SchemeParams> HashableType for P {
+    fn chain_type<C: Chain>(digest: C) -> C {
+        digest.chain(&ORDER).chain(&Point::GENERATOR)
     }
 }
 

--- a/synedrion/src/cggmp21/protocols/key_init.rs
+++ b/synedrion/src/cggmp21/protocols/key_init.rs
@@ -400,6 +400,7 @@ impl<P: SchemeParams> FinalizableToResult for Round3<P> {
         Ok(KeyShareSeed {
             secret_share: self.context.x,
             public_shares: all_cap_x,
+            init_id: self.rid,
         })
     }
 }

--- a/synedrion/src/cggmp21/sigma/aff_g.rs
+++ b/synedrion/src/cggmp21/sigma/aff_g.rs
@@ -190,6 +190,16 @@ impl<P: SchemeParams> AffGProof<P> {
 
         let aux_pk = setup.public_key();
 
+        // Range checks
+
+        if !self.z1.in_range_bits(P::L_BOUND + P::EPS_BOUND) {
+            return false;
+        }
+
+        if !self.z2.in_range_bits(P::LP_BOUND + P::EPS_BOUND) {
+            return false;
+        }
+
         // C^{z_1} (1 + N_0)^{z_2} \omega^{N_0} = A D^e \mod N_0^2
         // => C (*) z_1 (+) encrypt_0(z_2, \omega) = A (+) D (*) e
         if cap_c * self.z1 + CiphertextMod::new_with_randomizer_signed(pk0, &self.z2, &self.omega)

--- a/synedrion/src/cggmp21/sigma/log_star.rs
+++ b/synedrion/src/cggmp21/sigma/log_star.rs
@@ -124,6 +124,11 @@ impl<P: SchemeParams> LogStarProof<P> {
             return false;
         }
 
+        // Range check
+        if !self.z1.in_range_bits(P::L_BOUND + P::EPS_BOUND) {
+            return false;
+        }
+
         // enc_0(z1, z2) == A (+) C (*) e
         let c = CiphertextMod::new_with_randomizer_signed(pk0, &self.z1, &self.z2);
         if c != self.cap_a.to_mod(pk0) + cap_c * e {

--- a/synedrion/src/cggmp21/sigma/mod_.rs
+++ b/synedrion/src/cggmp21/sigma/mod_.rs
@@ -2,13 +2,15 @@
 
 use alloc::vec::Vec;
 
-use rand_core::CryptoRngCore;
+use rand_core::{CryptoRngCore, OsRng};
 use serde::{Deserialize, Serialize};
 
 use super::super::SchemeParams;
 use crate::paillier::{PaillierParams, PublicKeyPaillierPrecomputed, SecretKeyPaillierPrecomputed};
 use crate::tools::hashing::{Chain, Hashable, XofHash};
-use crate::uint::{JacobiSymbol, JacobiSymbolTrait, RandomMod, Retrieve, UintLike, UintModLike};
+use crate::uint::{
+    JacobiSymbol, JacobiSymbolTrait, RandomMod, RandomPrimeWithRng, Retrieve, UintLike, UintModLike,
+};
 
 const HASH_TAG: &[u8] = b"P_mod";
 
@@ -144,6 +146,15 @@ impl<P: SchemeParams> ModProof<P> {
     ) -> bool {
         let challenge = ModChallenge::new(pk, aux);
         if challenge != self.challenge {
+            return false;
+        }
+
+        // Note: I think we can get away with using the default RNG here
+        // since the result is RNG-independent (or at least supposed to be).
+        // It is possible to pass the external RNG similarly to how it's done for `new()`,
+        // but it would require quite a bit of changes because an external RNG is not accessible
+        // at the callsite.
+        if pk.modulus().is_prime_with_rng(&mut OsRng) {
             return false;
         }
 

--- a/synedrion/src/cggmp21/sigma/mod_.rs
+++ b/synedrion/src/cggmp21/sigma/mod_.rs
@@ -149,11 +149,15 @@ impl<P: SchemeParams> ModProof<P> {
             return false;
         }
 
+        // The paper requires checking that `N` is odd here,
+        // but it is already an invariant of `PublicKeyPaillierPrecomputed`.
+
         // Note: I think we can get away with using the default RNG here
         // since the result is RNG-independent (or at least supposed to be).
         // It is possible to pass the external RNG similarly to how it's done for `new()`,
         // but it would require quite a bit of changes because an external RNG is not accessible
         // at the callsite.
+        // TODO (#105): consider if we should keep using the default RNG here.
         if pk.modulus().is_prime_with_rng(&mut OsRng) {
             return false;
         }

--- a/synedrion/src/cggmp21/sigma/mul_star.rs
+++ b/synedrion/src/cggmp21/sigma/mul_star.rs
@@ -136,6 +136,11 @@ impl<P: SchemeParams> MulStarProof<P> {
 
         let aux_pk = setup.public_key();
 
+        // Range check
+        if !self.z1.in_range_bits(P::L_BOUND + P::EPS_BOUND) {
+            return false;
+        }
+
         // C (*) z_1 * \omega^{N_0} == A (+) D (*) e
         if (cap_c * self.z1).mul_randomizer(&self.omega) != self.cap_a.to_mod(pk0) + cap_d * e {
             return false;

--- a/synedrion/src/cggmp21/sigma/sch.rs
+++ b/synedrion/src/cggmp21/sigma/sch.rs
@@ -79,7 +79,7 @@ impl SchProof {
         aux: &impl Hashable,
     ) -> Self {
         let challenge = SchChallenge::new(cap_x, commitment, aux);
-        let proof = proof_secret.0 + &challenge.0 * x;
+        let proof = proof_secret.0 + challenge.0 * x;
         Self { challenge, proof }
     }
 

--- a/synedrion/src/common.rs
+++ b/synedrion/src/common.rs
@@ -92,6 +92,9 @@ pub(crate) struct KeySharePrecomputed<P: SchemeParams> {
     pub(crate) public_shares: Box<[Point]>,
     pub(crate) secret_aux: SecretAuxInfoPrecomputed<P>,
     pub(crate) public_aux: Box<[PublicAuxInfoPrecomputed<P>]>,
+    #[allow(dead_code)]
+    pub(crate) init_id: BitVec,
+    pub(crate) share_set_id: HashOutput,
 }
 
 #[derive(Clone)]
@@ -271,6 +274,8 @@ impl<P: SchemeParams> KeyShare<P> {
                     }
                 })
                 .collect(),
+            init_id: self.init_id.clone(),
+            share_set_id: self.share_set_id,
         }
     }
 

--- a/synedrion/src/common.rs
+++ b/synedrion/src/common.rs
@@ -14,7 +14,11 @@ use crate::paillier::{
     RPParamsMod, Randomizer, SecretKeyPaillier, SecretKeyPaillierPrecomputed,
 };
 use crate::rounds::PartyIdx;
-use crate::tools::collections::HoleVec;
+use crate::tools::{
+    bitvec::BitVec,
+    collections::HoleVec,
+    hashing::{Chain, Hash, HashOutput, Hashable},
+};
 use crate::uint::Signed;
 
 #[cfg(any(test, feature = "bench-internals"))]
@@ -32,6 +36,9 @@ pub struct KeyShareSeed {
     pub(crate) secret_share: Scalar, // `x_i`
     /// Public key shares of all nodes (including this one).
     pub(crate) public_shares: Box<[Point]>, // `X_j`
+    /// A random identifier, the same for all holders of the shares of this set,
+    /// generated along with the shares.
+    pub(crate) init_id: BitVec, // $rid$ in the paper
 }
 
 /// The full key share with auxiliary parameters.
@@ -48,6 +55,13 @@ pub struct KeyShare<P: SchemeParams> {
     pub(crate) public_shares: Box<[Point]>,
     pub(crate) secret_aux: SecretAuxInfo<P>,
     pub(crate) public_aux: Box<[PublicAuxInfo<P>]>,
+    /// A random identifier, the same for all holders of the shares of this set,
+    /// preserved after refresh.
+    pub(crate) init_id: BitVec,
+    /// A random identifier, the same for all holders of the shares of this set,
+    /// changed after refresh.
+    // Takes place of $ssid$ in the paper when used in hashes/proofs.
+    pub(crate) share_set_id: HashOutput,
 }
 
 // TODO (#77): Debug can be derived automatically here if `el_gamal_sk` is wrapped in its own struct,
@@ -134,6 +148,19 @@ pub struct PresigningData<P: SchemeParams> {
 }
 
 impl<P: SchemeParams> KeyShare<P> {
+    pub(crate) fn make_share_set_id(
+        init_id: &BitVec,
+        public_shares: &[Point],
+        public_aux: &[PublicAuxInfo<P>],
+    ) -> HashOutput {
+        Hash::new_with_dst(b"ShareSetID")
+            .chain_type::<P>()
+            .chain(init_id)
+            .chain_slice(public_shares)
+            .chain_slice(public_aux)
+            .finalize()
+    }
+
     /// Creates a key share out of the seed (obtained from the KeyGen protocol)
     /// and the share change (obtained from the KeyRefresh+Auxiliary protocol).
     pub(crate) fn new(seed: KeyShareSeed, change: KeyShareChange<P>) -> Self {
@@ -144,13 +171,19 @@ impl<P: SchemeParams> KeyShare<P> {
             .iter()
             .zip(change.public_share_changes.into_vec())
             .map(|(public_share, public_share_change)| public_share + &public_share_change)
-            .collect();
+            .collect::<Box<_>>();
+
+        let share_set_id =
+            Self::make_share_set_id(&seed.init_id, &public_shares, &change.public_aux);
+
         Self {
             index: change.index,
             secret_share,
             public_shares,
             secret_aux: change.secret_aux,
             public_aux: change.public_aux,
+            init_id: seed.init_id,
+            share_set_id,
         }
     }
 
@@ -174,6 +207,9 @@ impl<P: SchemeParams> KeyShare<P> {
 
         let (secret_aux, public_aux) = make_aux_info(rng, num_parties);
 
+        let init_id = BitVec::random(rng, P::SECURITY_PARAMETER);
+        let share_set_id = Self::make_share_set_id(&init_id, &public_shares, &public_aux);
+
         secret_aux
             .into_vec()
             .into_iter()
@@ -184,6 +220,8 @@ impl<P: SchemeParams> KeyShare<P> {
                 public_shares: public_shares.clone(),
                 secret_aux,
                 public_aux: public_aux.clone(),
+                init_id: init_id.clone(),
+                share_set_id,
             })
             .collect()
     }
@@ -198,13 +236,17 @@ impl<P: SchemeParams> KeyShare<P> {
             .iter()
             .zip(change.public_share_changes.into_vec())
             .map(|(public_share, public_share_change)| public_share + &public_share_change)
-            .collect();
+            .collect::<Box<_>>();
+        let share_set_id =
+            Self::make_share_set_id(&self.init_id, &public_shares, &change.public_aux);
         Self {
             index: change.index,
             secret_share,
             public_shares,
             secret_aux: change.secret_aux,
             public_aux: change.public_aux,
+            init_id: self.init_id,
+            share_set_id,
         }
     }
 
@@ -460,6 +502,15 @@ pub(crate) fn make_aux_info<P: SchemeParams>(
         .collect();
 
     (secret_aux, public_aux)
+}
+
+impl<P: SchemeParams> Hashable for PublicAuxInfo<P> {
+    fn chain<C: Chain>(&self, digest: C) -> C {
+        digest
+            .chain(&self.el_gamal_pk)
+            .chain(&self.paillier_pk)
+            .chain(&self.rp_params)
+    }
 }
 
 #[cfg(test)]

--- a/synedrion/src/curve.rs
+++ b/synedrion/src/curve.rs
@@ -9,4 +9,4 @@ mod ecdsa;
 pub(crate) use arithmetic::ORDER;
 
 pub use self::ecdsa::RecoverableSignature;
-pub(crate) use arithmetic::{Point, Scalar};
+pub(crate) use arithmetic::{Curve, Point, Scalar};

--- a/synedrion/src/curve/arithmetic.rs
+++ b/synedrion/src/curve/arithmetic.rs
@@ -56,7 +56,7 @@ impl Scalar {
     }
 
     pub fn mul_by_generator(&self) -> Point {
-        &Point::GENERATOR * self
+        Point::GENERATOR * self
     }
 
     pub fn invert(&self) -> CtOption<Self> {
@@ -286,6 +286,14 @@ impl Mul<Scalar> for Point {
     }
 }
 
+impl Mul<&Scalar> for Point {
+    type Output = Point;
+
+    fn mul(self, other: &Scalar) -> Point {
+        Point(self.0.mul(&(other.0)))
+    }
+}
+
 impl Mul<&Scalar> for &Point {
     type Output = Point;
 
@@ -298,6 +306,14 @@ impl Mul<Scalar> for Scalar {
     type Output = Scalar;
 
     fn mul(self, other: Scalar) -> Scalar {
+        Scalar(self.0.mul(&(other.0)))
+    }
+}
+
+impl Mul<&Scalar> for Scalar {
+    type Output = Scalar;
+
+    fn mul(self, other: &Scalar) -> Scalar {
         Scalar(self.0.mul(&(other.0)))
     }
 }

--- a/synedrion/src/curve/arithmetic.rs
+++ b/synedrion/src/curve/arithmetic.rs
@@ -52,18 +52,6 @@ impl Scalar {
         &Point::GENERATOR * self
     }
 
-    pub fn pow(&self, exp: usize) -> Self {
-        let mut result = Self::ONE;
-        for _ in 0..exp {
-            result = &result * self;
-        }
-        result
-    }
-
-    pub fn negate(&self) -> Self {
-        Self(self.0.negate())
-    }
-
     pub fn invert(&self) -> CtOption<Self> {
         self.0.invert().map(Self)
     }
@@ -224,12 +212,6 @@ impl Hashable for Point {
     }
 }
 
-impl Default for Point {
-    fn default() -> Self {
-        Point::IDENTITY
-    }
-}
-
 impl From<u32> for Scalar {
     fn from(val: u32) -> Self {
         Self(BackendScalar::from(val))
@@ -249,26 +231,11 @@ impl Neg for Scalar {
     }
 }
 
-impl Neg for &Scalar {
-    type Output = Scalar;
-    fn neg(self) -> Self::Output {
-        Scalar(-self.0)
-    }
-}
-
 impl Add<Scalar> for Scalar {
     type Output = Scalar;
 
     fn add(self, other: Scalar) -> Scalar {
         Scalar(self.0.add(&other.0))
-    }
-}
-
-impl Add<&Scalar> for &Scalar {
-    type Output = Scalar;
-
-    fn add(self, other: &Scalar) -> Scalar {
-        Scalar(self.0.add(&(other.0)))
     }
 }
 
@@ -351,12 +318,6 @@ impl<'a> core::iter::Sum<&'a Self> for Scalar {
 impl core::iter::Product for Scalar {
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.reduce(core::ops::Mul::mul).unwrap_or(Self::ONE)
-    }
-}
-
-impl<'a> core::iter::Product<&'a Self> for Scalar {
-    fn product<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
-        iter.cloned().product()
     }
 }
 

--- a/synedrion/src/curve/arithmetic.rs
+++ b/synedrion/src/curve/arithmetic.rs
@@ -14,7 +14,7 @@ use k256::elliptic_curve::{
     point::AffineCoordinates,
     sec1::{EncodedPoint, FromEncodedPoint, ModulusSize, ToEncodedPoint},
     subtle::{Choice, ConditionallySelectable, CtOption},
-    Curve,
+    Curve as _,
     Field,
     FieldBytesSize,
     NonZeroScalar,
@@ -23,15 +23,22 @@ use k256::{ecdsa::VerifyingKey, Secp256k1};
 use rand_core::CryptoRngCore;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::tools::hashing::{Chain, Hashable};
+use crate::tools::hashing::{Chain, Hashable, HashableType};
 use crate::tools::serde_bytes;
 
+pub(crate) type Curve = Secp256k1;
 pub(crate) type BackendScalar = k256::Scalar;
 pub(crate) type BackendPoint = k256::ProjectivePoint;
 pub(crate) type CompressedPointSize =
     <FieldBytesSize<Secp256k1> as ModulusSize>::CompressedPointSize;
 
 pub(crate) const ORDER: U256 = Secp256k1::ORDER;
+
+impl HashableType for Curve {
+    fn chain_type<C: Chain>(digest: C) -> C {
+        digest.chain(&ORDER).chain(&Point::GENERATOR)
+    }
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default, PartialOrd, Ord)]
 pub struct Scalar(BackendScalar);

--- a/synedrion/src/paillier/keys.rs
+++ b/synedrion/src/paillier/keys.rs
@@ -204,7 +204,7 @@ impl<P: PaillierParams> SecretKeyPaillierPrecomputed<P> {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct PublicKeyPaillier<P: PaillierParams> {
-    modulus: P::Uint, // $N$
+    modulus: P::Uint, // TODO (#104): wrap it in `crypto_bigint::Odd`
 }
 
 impl<P: PaillierParams> PublicKeyPaillier<P> {
@@ -213,6 +213,8 @@ impl<P: PaillierParams> PublicKeyPaillier<P> {
     }
 
     pub fn to_precomputed(&self) -> PublicKeyPaillierPrecomputed<P> {
+        // Note that this ensures that `self.modulus` is odd,
+        // otherwise creating the Montgomery parameters fails.
         let precomputed_modulus = P::UintMod::new_precomputed(&NonZero::new(self.modulus).unwrap());
         let precomputed_modulus_squared =
             P::WideUintMod::new_precomputed(&NonZero::new(self.modulus.square_wide()).unwrap());

--- a/synedrion/src/threshold.rs
+++ b/synedrion/src/threshold.rs
@@ -1,5 +1,7 @@
 use alloc::boxed::Box;
 use alloc::collections::BTreeMap;
+use alloc::vec::Vec;
+use core::marker::PhantomData;
 
 use k256::ecdsa::VerifyingKey;
 use rand_core::CryptoRngCore;
@@ -9,19 +11,25 @@ use crate::cggmp21::SchemeParams;
 use crate::common::{make_aux_info, KeyShare, PublicAuxInfo, SecretAuxInfo};
 use crate::curve::{Point, Scalar};
 use crate::rounds::PartyIdx;
-use crate::tools::sss::{
-    interpolation_coeff, shamir_evaluation_points, shamir_join_points, shamir_split, ShareIdx,
+use crate::tools::{
+    bitvec::BitVec,
+    hashing::HashOutput,
+    sss::{
+        interpolation_coeff, shamir_evaluation_points, shamir_join_points, shamir_split, ShareIdx,
+    },
 };
 
 #[derive(Clone)]
-pub struct ThresholdKeyShareSeed {
+pub struct ThresholdKeyShareSeed<P: SchemeParams> {
     pub(crate) index: ShareIdx,
     pub(crate) threshold: u32,
     pub(crate) secret_share: Scalar,
     pub(crate) public_shares: BTreeMap<ShareIdx, Point>,
+    pub(crate) init_id: BitVec,
+    pub(crate) phantom: PhantomData<P>,
 }
 
-impl ThresholdKeyShareSeed {
+impl<P: SchemeParams> ThresholdKeyShareSeed<P> {
     pub fn index(&self) -> ShareIdx {
         self.index
     }
@@ -51,12 +59,16 @@ impl ThresholdKeyShareSeed {
             .map(|(idx, share)| (*idx, share.mul_by_generator()))
             .collect::<BTreeMap<_, _>>();
 
+        let init_id = BitVec::random(rng, P::SECURITY_PARAMETER);
+
         (0..num_parties)
             .map(|idx| Self {
                 index: share_idxs[idx],
                 threshold: threshold as u32,
                 secret_share: secret_shares[&share_idxs[idx]],
                 public_shares: public_shares.clone(),
+                init_id: init_id.clone(),
+                phantom: PhantomData,
             })
             .collect()
     }
@@ -90,6 +102,8 @@ pub struct ThresholdKeyShare<P: SchemeParams> {
     pub(crate) public_shares: BTreeMap<ShareIdx, Point>,
     pub(crate) secret_aux: SecretAuxInfo<P>,
     pub(crate) public_aux: BTreeMap<ShareIdx, PublicAuxInfo<P>>,
+    pub(crate) init_id: BitVec,
+    pub(crate) share_set_id: HashOutput,
 }
 
 impl<P: SchemeParams> ThresholdKeyShare<P> {
@@ -124,6 +138,18 @@ impl<P: SchemeParams> ThresholdKeyShare<P> {
             .map(|(idx, public)| (share_idxs[idx], public))
             .collect::<BTreeMap<_, _>>();
 
+        let init_id = BitVec::random(rng, P::SECURITY_PARAMETER);
+
+        // TODO (#20): this will probably be changed as we integrate
+        // the threshold structures into the rest of the library better.
+        // Making `make_share_set_id()` take an iterator creates a bunch of ugly conversions
+        // and typing problems, so we just make some copies to create a slice it can take.
+        let public_shares_vec = public_shares.values().cloned().collect::<Vec<_>>();
+        let public_aux_vec = public_aux.values().cloned().collect::<Vec<_>>();
+
+        let share_set_id =
+            KeyShare::make_share_set_id(&init_id, &public_shares_vec, &public_aux_vec);
+
         secret_aux
             .into_vec()
             .into_iter()
@@ -135,6 +161,8 @@ impl<P: SchemeParams> ThresholdKeyShare<P> {
                 public_shares: public_shares.clone(),
                 secret_aux,
                 public_aux: public_aux.clone(),
+                init_id: init_id.clone(),
+                share_set_id,
             })
             .collect()
     }
@@ -185,6 +213,8 @@ impl<P: SchemeParams> ThresholdKeyShare<P> {
             public_shares,
             secret_aux: self.secret_aux.clone(),
             public_aux,
+            init_id: self.init_id.clone(),
+            share_set_id: self.share_set_id,
         }
     }
 }

--- a/synedrion/src/tools/hashing.rs
+++ b/synedrion/src/tools/hashing.rs
@@ -39,6 +39,10 @@ pub trait Chain: Sized {
     fn chain<T: Hashable>(self, hashable: &T) -> Self {
         hashable.chain(self)
     }
+
+    fn chain_type<T: HashableType>(self) -> Self {
+        T::chain_type(self)
+    }
 }
 
 pub(crate) type BackendDigest = Sha256;
@@ -104,6 +108,11 @@ impl XofHash {
     pub fn finalize_to_reader(self) -> Shake256Reader {
         self.0.finalize_xof()
     }
+}
+
+/// A trait allowing hashing of types without having access to their instances.
+pub trait HashableType {
+    fn chain_type<C: Chain>(digest: C) -> C;
 }
 
 /// A trait allowing complex objects to give access to their contents for hashing purposes

--- a/synedrion/src/tools/hashing.rs
+++ b/synedrion/src/tools/hashing.rs
@@ -43,6 +43,16 @@ pub trait Chain: Sized {
     fn chain_type<T: HashableType>(self) -> Self {
         T::chain_type(self)
     }
+
+    fn chain_slice<T: Hashable>(self, hashable: &[T]) -> Self {
+        // Hashing the length too to prevent collisions.
+        let len = hashable.len() as u32;
+        let mut digest = self.chain(&len);
+        for elem in hashable {
+            digest = digest.chain(elem);
+        }
+        digest
+    }
 }
 
 pub(crate) type BackendDigest = Sha256;
@@ -181,13 +191,7 @@ impl<T1: Hashable, T2: Hashable, T3: Hashable> Hashable for (&T1, &T2, &T3) {
 
 impl<T: Hashable> Hashable for Vec<T> {
     fn chain<C: Chain>(&self, digest: C) -> C {
-        // Hashing the vector length too to prevent collisions.
-        let len = self.len() as u32;
-        let mut digest = digest.chain(&len);
-        for elem in self {
-            digest = digest.chain(elem);
-        }
-        digest
+        digest.chain_slice(self)
     }
 }
 

--- a/synedrion/src/tools/hashing.rs
+++ b/synedrion/src/tools/hashing.rs
@@ -32,7 +32,7 @@ pub trait Chain: Sized {
     fn chain_bytes(self, bytes: &(impl AsRef<[u8]> + ?Sized)) -> Self {
         // Hash the length too to prevent hash conflicts. (e.g. H(AB|CD) == H(ABC|D)).
         // Not strictly necessary for fixed-size arrays, but it's easier to just always do it.
-        let len = (bytes.as_ref().len() as u32).to_be_bytes();
+        let len = (bytes.as_ref().len() as u64).to_be_bytes();
         self.chain_raw_bytes(&len).chain_raw_bytes(bytes.as_ref())
     }
 
@@ -46,7 +46,7 @@ pub trait Chain: Sized {
 
     fn chain_slice<T: Hashable>(self, hashable: &[T]) -> Self {
         // Hashing the length too to prevent collisions.
-        let len = hashable.len() as u32;
+        let len = hashable.len() as u64;
         let mut digest = self.chain(&len);
         for elem in hashable {
             digest = digest.chain(elem);
@@ -198,7 +198,7 @@ impl<T: Hashable> Hashable for Vec<T> {
 impl<K: Hashable, V: Hashable> Hashable for BTreeMap<K, V> {
     fn chain<C: Chain>(&self, digest: C) -> C {
         // Hashing the map length too to prevent collisions.
-        let len = self.len() as u32;
+        let len = self.len() as u64;
         let mut digest = digest.chain(&len);
         // The iteration is ordered (by keys)
         for (key, value) in self {

--- a/synedrion/src/uint/bounded.rs
+++ b/synedrion/src/uint/bounded.rs
@@ -13,7 +13,7 @@ use crate::tools::serde_bytes;
 
 /// A packed representation for serializing Bounded objects.
 /// Usually they have the bound much lower than the full size of the integer,
-/// so thiw way we avoid serializing a bunch of zeros.
+/// so this way we avoid serializing a bunch of zeros.
 #[derive(Serialize, Deserialize)]
 pub(crate) struct PackedBounded {
     bound: u32,

--- a/synedrion/src/uint/signed.rs
+++ b/synedrion/src/uint/signed.rs
@@ -13,7 +13,7 @@ use super::{
 
 /// A packed representation for serializing Signed objects.
 /// Usually they have the bound much lower than the full size of the integer,
-/// so thiw way we avoid serializing a bunch of zeros.
+/// so this way we avoid serializing a bunch of zeros.
 #[derive(Serialize, Deserialize)]
 struct PackedSigned {
     is_negative: bool,


### PR DESCRIPTION
- Add the missing range checks in aff-g, log*, and mul* proofs
- Add a check for the RSA modulus being a composite in the mod proof
- Add the missing primality check in the mod proof
- Hash in curve parameters and the number of parties in KeyInit and KeyRefresh; hash in curve parameters and share set IDs in Presigning and Signing  (updates #3, but not sure if closes it)
- Remove some unused curve arithmetic methods
- Optimize polynomial evaluation