### PR TITLE
Add commitment to the hash when calculating non-interactive challenges

### DIFF
--- a/synedrion/src/paillier/encryption.rs
+++ b/synedrion/src/paillier/encryption.rs
@@ -390,12 +390,6 @@ impl<P: PaillierParams> Hashable for Ciphertext<P> {
     }
 }
 
-impl<P: PaillierParams> Hashable for CiphertextMod<P> {
-    fn chain<C: Chain>(&self, digest: C) -> C {
-        digest.chain(&self.ciphertext)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use rand_core::OsRng;

--- a/synedrion/src/paillier/ring_pedersen.rs
+++ b/synedrion/src/paillier/ring_pedersen.rs
@@ -135,7 +135,7 @@ impl<P: PaillierParams> Hashable for RPParams<P> {
 
 impl<P: PaillierParams> Hashable for RPParamsMod<P> {
     fn chain<C: Chain>(&self, digest: C) -> C {
-        digest.chain(&self.pk).chain(&self.base).chain(&self.power)
+        digest.chain(&self.retrieve())
     }
 }
 
@@ -173,5 +173,11 @@ pub(crate) struct RPCommitment<P: PaillierParams>(P::Uint);
 impl<P: PaillierParams> RPCommitment<P> {
     pub fn to_mod(&self, pk: &PublicKeyPaillierPrecomputed<P>) -> RPCommitmentMod<P> {
         RPCommitmentMod(self.0.to_mod(pk.precomputed_modulus()))
+    }
+}
+
+impl<P: PaillierParams> Hashable for RPCommitment<P> {
+    fn chain<C: Chain>(&self, digest: C) -> C {
+        digest.chain(&self.0)
     }
 }

--- a/synedrion/src/uint/signed.rs
+++ b/synedrion/src/uint/signed.rs
@@ -14,6 +14,8 @@ use super::{
     Bounded, CheckedAdd, HasWide, Integer, NonZero, RandomMod, UintLike, UintModLike,
 };
 
+use crate::tools::hashing::{Chain, Hashable};
+
 /// A packed representation for serializing Signed objects.
 /// Usually they have the bound much lower than the full size of the integer,
 /// so this way we avoid serializing a bunch of zeros.
@@ -54,6 +56,12 @@ pub struct Signed<T: UintLike> {
     /// bound on the bit size of the absolute value
     bound: u32,
     value: T,
+}
+
+impl<T: UintLike> Hashable for Signed<T> {
+    fn chain<C: Chain>(&self, digest: C) -> C {
+        digest.chain(&self.bound).chain(&self.value)
+    }
 }
 
 impl<T: UintLike> Signed<T> {

--- a/synedrion/src/uint/traits.rs
+++ b/synedrion/src/uint/traits.rs
@@ -196,7 +196,6 @@ pub trait UintModLike:
     + for<'a> Mul<&'a Self, Output = Self>
     + subtle::ConditionallyNegatable
     + subtle::ConditionallySelectable
-    + Hashable
 {
     /// The corresponding regular integer type.
     type RawUint: UintLike<ModUint = Self>;
@@ -292,19 +291,6 @@ pub trait UintModLike:
         result
     }
     fn square(&self) -> Self;
-}
-
-impl<const L: usize> Hashable for DynResidue<L> {
-    fn chain<C: Chain>(&self, digest: C) -> C {
-        let mut digest = digest;
-        // Montgomery form is a bijection, so we can just hash it directly
-        // without converting back.
-        let montgomery_form = self.as_montgomery();
-        for word in montgomery_form.as_words() {
-            digest = digest.chain(word);
-        }
-        digest
-    }
 }
 
 impl<const L: usize> UintModLike for DynResidue<L>


### PR DESCRIPTION
The paper requires this (see Fig. 2). Not doing that opens easy ways of forging valid-looking proofs. 

Also removing `Hashable` from `CiphertextMod` and `RPCommitmentMod` (and from `UintMod`), to make the retrievals explicit, in case we want to optimize them in future (perhaps some retrievals can be avoided). Keeping `Hashable` for `RPParamsMod`, but making it produce the same hash as the one for `RPParams`. 