### PR TITLE
Merge direct and broadcast messages

### DIFF
--- a/synedrion/src/cggmp21/protocols/presigning.rs
+++ b/synedrion/src/cggmp21/protocols/presigning.rs
@@ -16,9 +16,8 @@ use crate::common::{KeyShare, KeySharePrecomputed, PresigningData};
 use crate::curve::{Point, Scalar};
 use crate::paillier::{Ciphertext, CiphertextMod, PaillierParams, Randomizer, RandomizerMod};
 use crate::rounds::{
-    all_parties_except, try_to_holevec, BaseRound, BroadcastRound, DirectRound, Finalizable,
-    FinalizableToNextRound, FinalizableToResult, FinalizationRequirement, FinalizeError,
-    FirstRound, InitError, PartyIdx, ProtocolResult, ReceiveError, ToNextRound, ToResult,
+    all_parties_except, try_to_holevec, FinalizableToNextRound, FinalizableToResult, FinalizeError,
+    FirstRound, InitError, PartyIdx, ProtocolResult, ReceiveError, Round, ToNextRound, ToResult,
 };
 use crate::tools::{
     collections::{HoleRange, HoleVec},
@@ -113,7 +112,25 @@ impl<P: SchemeParams> FirstRound for Round1<P> {
     }
 }
 
-impl<P: SchemeParams> BaseRound for Round1<P> {
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(bound(serialize = "Ciphertext<P::Paillier>: Serialize,
+    EncProof<P>: Serialize"))]
+#[serde(bound(deserialize = "Ciphertext<P::Paillier>: for<'x> Deserialize<'x>,
+    EncProof<P>: for<'x> Deserialize<'x>"))]
+pub struct Round1Message<P: SchemeParams> {
+    // TODO: only these two need to be echoed
+    cap_k: Ciphertext<P::Paillier>,
+    cap_g: Ciphertext<P::Paillier>,
+    // This one doesn't need to be echoed
+    psi0: EncProof<P>,
+}
+
+pub struct Round1Payload<P: SchemeParams> {
+    cap_k: Ciphertext<P::Paillier>,
+    cap_g: Ciphertext<P::Paillier>,
+}
+
+impl<P: SchemeParams> Round for Round1<P> {
     type Type = ToNextRound;
     type Result = PresigningResult<P>;
     const ROUND_NUM: u8 = 1;
@@ -126,64 +143,20 @@ impl<P: SchemeParams> BaseRound for Round1<P> {
     fn party_idx(&self) -> PartyIdx {
         self.context.key_share.party_index()
     }
-}
 
-#[derive(Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "Ciphertext<P>: Serialize"))]
-#[serde(bound(deserialize = "Ciphertext<P>: for<'x> Deserialize<'x>"))]
-pub struct Round1Bcast<P: PaillierParams> {
-    cap_k: Ciphertext<P>,
-    cap_g: Ciphertext<P>,
-}
-
-impl<P: SchemeParams> BroadcastRound for Round1<P> {
-    const REQUIRES_CONSENSUS: bool = true;
-    type Message = Round1Bcast<P::Paillier>;
-    type Payload = Round1Bcast<P::Paillier>;
-
-    fn broadcast_destinations(&self) -> Option<Vec<PartyIdx>> {
-        Some(all_parties_except(
-            self.context.key_share.num_parties(),
-            self.context.key_share.party_index(),
-        ))
-    }
-
-    fn make_broadcast(&self, _rng: &mut impl CryptoRngCore) -> Result<Self::Message, String> {
-        Ok(Round1Bcast {
-            cap_k: self.cap_k.retrieve(),
-            cap_g: self.cap_g.retrieve(),
-        })
-    }
-
-    fn verify_broadcast(
-        &self,
-        _from: PartyIdx,
-        msg: Self::Message,
-    ) -> Result<Self::Payload, ReceiveError<Self::Result>> {
-        Ok(msg)
-    }
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "EncProof<P>: Serialize"))]
-#[serde(bound(deserialize = "EncProof<P>: for<'x> Deserialize<'x>"))]
-pub struct Round1Direct<P: SchemeParams> {
-    psi0: EncProof<P>,
-}
-
-impl<P: SchemeParams> DirectRound for Round1<P> {
-    type Message = Round1Direct<P>;
-    type Payload = Round1Direct<P>;
+    const REQUIRES_ECHO: bool = true;
+    type Message = Round1Message<P>;
+    type Payload = Round1Payload<P>;
     type Artifact = ();
 
-    fn direct_message_destinations(&self) -> Option<Vec<PartyIdx>> {
-        Some(all_parties_except(
+    fn message_destinations(&self) -> Vec<PartyIdx> {
+        all_parties_except(
             self.context.key_share.num_parties(),
             self.context.key_share.party_index(),
-        ))
+        )
     }
 
-    fn make_direct_message(
+    fn make_message(
         &self,
         rng: &mut impl CryptoRngCore,
         destination: PartyIdx,
@@ -198,23 +171,43 @@ impl<P: SchemeParams> DirectRound for Round1<P> {
             &self.context.key_share.public_aux[destination.as_usize()].rp_params,
             &aux,
         );
-        Ok((Round1Direct { psi0 }, ()))
+
+        Ok((
+            Round1Message {
+                cap_k: self.cap_k.retrieve(),
+                cap_g: self.cap_g.retrieve(),
+                psi0,
+            },
+            (),
+        ))
     }
 
-    fn verify_direct_message(
+    fn verify_message(
         &self,
-        _from: PartyIdx,
+        from: PartyIdx,
         msg: Self::Message,
     ) -> Result<Self::Payload, ReceiveError<Self::Result>> {
-        // We cannot verify it here since the broadcast with the necessary public data
-        // is sent asynchronously. Have to wait until finalization.
-        Ok(msg)
-    }
-}
+        let aux = (&self.context.ssid_hash, &self.party_idx());
 
-impl<P: SchemeParams> Finalizable for Round1<P> {
-    fn requirement() -> FinalizationRequirement {
-        FinalizationRequirement::AllBroadcastsAndDms
+        let public_aux = &self.context.key_share.public_aux[self.party_idx().as_usize()];
+
+        let from_pk = &self.context.key_share.public_aux[from.as_usize()].paillier_pk;
+
+        if !msg.psi0.verify(
+            from_pk,
+            &msg.cap_k.to_mod(from_pk),
+            &public_aux.rp_params,
+            &aux,
+        ) {
+            return Err(ReceiveError::Provable(PresigningError::Round1(
+                "Failed to verify EncProof".into(),
+            )));
+        }
+
+        Ok(Round1Payload {
+            cap_k: msg.cap_k,
+            cap_g: msg.cap_g,
+        })
     }
 }
 
@@ -223,29 +216,14 @@ impl<P: SchemeParams> FinalizableToNextRound for Round1<P> {
     fn finalize_to_next_round(
         self,
         _rng: &mut impl CryptoRngCore,
-        bc_payloads: BTreeMap<PartyIdx, <Self as BroadcastRound>::Payload>,
-        dm_payloads: BTreeMap<PartyIdx, <Self as DirectRound>::Payload>,
-        _dm_artifacts: BTreeMap<PartyIdx, <Self as DirectRound>::Artifact>,
+        payloads: BTreeMap<PartyIdx, <Self as Round>::Payload>,
+        _artifacts: BTreeMap<PartyIdx, <Self as Round>::Artifact>,
     ) -> Result<Self::NextRound, FinalizeError<Self::Result>> {
-        let ciphertexts = try_to_holevec(
-            bc_payloads,
-            self.context.key_share.num_parties(),
-            self.context.key_share.party_index(),
-        )
-        .unwrap();
-        let proofs = try_to_holevec(
-            dm_payloads,
-            self.context.key_share.num_parties(),
-            self.context.key_share.party_index(),
-        )
-        .unwrap();
+        let payloads = try_to_holevec(payloads, self.num_parties(), self.party_idx()).unwrap();
 
-        let aux = (
-            &self.context.ssid_hash,
-            &self.context.key_share.party_index(),
-        );
-
-        let (others_cap_k, others_cap_g) = ciphertexts.map(|data| (data.cap_k, data.cap_g)).unzip();
+        let (others_cap_k, others_cap_g) = payloads
+            .map(|payload| (payload.cap_k, payload.cap_g))
+            .unzip();
 
         let others_cap_k = others_cap_k.map_enumerate(|(i, ciphertext)| {
             ciphertext.to_mod(&self.context.key_share.public_aux[i].paillier_pk)
@@ -253,23 +231,6 @@ impl<P: SchemeParams> FinalizableToNextRound for Round1<P> {
         let others_cap_g = others_cap_g.map_enumerate(|(i, ciphertext)| {
             ciphertext.to_mod(&self.context.key_share.public_aux[i].paillier_pk)
         });
-
-        let public_aux =
-            &self.context.key_share.public_aux[self.context.key_share.party_index().as_usize()];
-
-        for ((from, cap_k), proof) in others_cap_k.enumerate().zip(proofs.iter()) {
-            if !proof.psi0.verify(
-                &self.context.key_share.public_aux[from].paillier_pk,
-                cap_k,
-                &public_aux.rp_params,
-                &aux,
-            ) {
-                return Err(FinalizeError::Provable {
-                    party: PartyIdx::from_usize(from),
-                    error: PresigningError::Round1("Failed to verify EncProof".into()),
-                });
-            }
-        }
 
         let all_cap_k = others_cap_k.into_vec(self.cap_k);
         let all_cap_g = others_cap_g.into_vec(self.cap_g);
@@ -287,26 +248,6 @@ pub struct Round2<P: SchemeParams> {
     all_cap_g: Vec<CiphertextMod<P::Paillier>>,
 }
 
-impl<P: SchemeParams> BaseRound for Round2<P> {
-    type Type = ToNextRound;
-    type Result = PresigningResult<P>;
-    const ROUND_NUM: u8 = 2;
-    const NEXT_ROUND_NUM: Option<u8> = Some(3);
-
-    fn num_parties(&self) -> usize {
-        self.context.key_share.num_parties()
-    }
-
-    fn party_idx(&self) -> PartyIdx {
-        self.context.key_share.party_index()
-    }
-}
-
-impl<P: SchemeParams> BroadcastRound for Round2<P> {
-    type Message = ();
-    type Payload = ();
-}
-
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(bound(serialize = "Ciphertext<P::Paillier>: Serialize,
     AffGProof<P>: Serialize,
@@ -314,7 +255,7 @@ impl<P: SchemeParams> BroadcastRound for Round2<P> {
 #[serde(bound(deserialize = "Ciphertext<P::Paillier>: for<'x> Deserialize<'x>,
     AffGProof<P>: for<'x> Deserialize<'x>,
     LogStarProof<P>: for<'x> Deserialize<'x>"))]
-pub struct Round2Direct<P: SchemeParams> {
+pub struct Round2Message<P: SchemeParams> {
     cap_gamma: Point,
     cap_d: Ciphertext<P::Paillier>,
     hat_cap_d: Ciphertext<P::Paillier>,
@@ -347,19 +288,32 @@ pub struct Round2Payload<P: SchemeParams> {
     hat_cap_d: CiphertextMod<P::Paillier>,
 }
 
-impl<P: SchemeParams> DirectRound for Round2<P> {
-    type Message = Round2Direct<P>;
+impl<P: SchemeParams> Round for Round2<P> {
+    type Type = ToNextRound;
+    type Result = PresigningResult<P>;
+    const ROUND_NUM: u8 = 2;
+    const NEXT_ROUND_NUM: Option<u8> = Some(3);
+
+    fn num_parties(&self) -> usize {
+        self.context.key_share.num_parties()
+    }
+
+    fn party_idx(&self) -> PartyIdx {
+        self.context.key_share.party_index()
+    }
+
+    type Message = Round2Message<P>;
     type Payload = Round2Payload<P>;
     type Artifact = Round2Artifact<P>;
 
-    fn direct_message_destinations(&self) -> Option<Vec<PartyIdx>> {
-        Some(all_parties_except(
+    fn message_destinations(&self) -> Vec<PartyIdx> {
+        all_parties_except(
             self.context.key_share.num_parties(),
             self.context.key_share.party_index(),
-        ))
+        )
     }
 
-    fn make_direct_message(
+    fn make_message(
         &self,
         rng: &mut impl CryptoRngCore,
         destination: PartyIdx,
@@ -438,7 +392,7 @@ impl<P: SchemeParams> DirectRound for Round2<P> {
             &aux,
         );
 
-        let msg = Round2Direct {
+        let msg = Round2Message {
             cap_gamma,
             cap_d: cap_d.retrieve(),
             cap_f: cap_f.retrieve(),
@@ -465,7 +419,7 @@ impl<P: SchemeParams> DirectRound for Round2<P> {
         Ok((msg, artifact))
     }
 
-    fn verify_direct_message(
+    fn verify_message(
         &self,
         from: PartyIdx,
         msg: Self::Message,
@@ -549,35 +503,18 @@ impl<P: SchemeParams> DirectRound for Round2<P> {
     }
 }
 
-impl<P: SchemeParams> Finalizable for Round2<P> {
-    fn requirement() -> FinalizationRequirement {
-        FinalizationRequirement::AllDms
-    }
-}
-
 impl<P: SchemeParams> FinalizableToNextRound for Round2<P> {
     type NextRound = Round3<P>;
     fn finalize_to_next_round(
         self,
         _rng: &mut impl CryptoRngCore,
-        _bc_payloads: BTreeMap<PartyIdx, <Self as BroadcastRound>::Payload>,
-        dm_payloads: BTreeMap<PartyIdx, <Self as DirectRound>::Payload>,
-        dm_artifacts: BTreeMap<PartyIdx, <Self as DirectRound>::Artifact>,
+        payloads: BTreeMap<PartyIdx, <Self as Round>::Payload>,
+        artifacts: BTreeMap<PartyIdx, <Self as Round>::Artifact>,
     ) -> Result<Self::NextRound, FinalizeError<Self::Result>> {
-        let dm_payloads = try_to_holevec(
-            dm_payloads,
-            self.context.key_share.num_parties(),
-            self.context.key_share.party_index(),
-        )
-        .unwrap();
-        let dm_artifacts = try_to_holevec(
-            dm_artifacts,
-            self.context.key_share.num_parties(),
-            self.context.key_share.party_index(),
-        )
-        .unwrap();
+        let payloads = try_to_holevec(payloads, self.num_parties(), self.party_idx()).unwrap();
+        let artifacts = try_to_holevec(artifacts, self.num_parties(), self.party_idx()).unwrap();
 
-        let cap_gamma = dm_payloads
+        let cap_gamma = payloads
             .iter()
             .map(|payload| payload.cap_gamma)
             .sum::<Point>()
@@ -585,22 +522,22 @@ impl<P: SchemeParams> FinalizableToNextRound for Round2<P> {
 
         let cap_delta = cap_gamma * self.context.k;
 
-        let alpha_sum: Signed<_> = dm_payloads.iter().map(|p| p.alpha).sum();
-        let beta_sum: Signed<_> = dm_artifacts.iter().map(|p| p.beta).sum();
+        let alpha_sum: Signed<_> = payloads.iter().map(|p| p.alpha).sum();
+        let beta_sum: Signed<_> = artifacts.iter().map(|p| p.beta).sum();
         let delta = P::signed_from_scalar(&self.context.gamma)
             * P::signed_from_scalar(&self.context.k)
             + alpha_sum
             + beta_sum;
 
-        let hat_alpha_sum: Signed<_> = dm_payloads.iter().map(|payload| payload.hat_alpha).sum();
-        let hat_beta_sum: Signed<_> = dm_artifacts.iter().map(|artifact| artifact.hat_beta).sum();
+        let hat_alpha_sum: Signed<_> = payloads.iter().map(|payload| payload.hat_alpha).sum();
+        let hat_beta_sum: Signed<_> = artifacts.iter().map(|artifact| artifact.hat_beta).sum();
         let chi = P::signed_from_scalar(&self.context.key_share.secret_share)
             * P::signed_from_scalar(&self.context.k)
             + hat_alpha_sum
             + hat_beta_sum;
 
-        let cap_ds = dm_payloads.map_ref(|payload| payload.cap_d.clone());
-        let hat_cap_d = dm_payloads.map_ref(|payload| payload.hat_cap_d.clone());
+        let cap_ds = payloads.map_ref(|payload| payload.cap_d.clone());
+        let hat_cap_d = payloads.map_ref(|payload| payload.hat_cap_d.clone());
 
         Ok(Round3 {
             context: self.context,
@@ -612,18 +549,9 @@ impl<P: SchemeParams> FinalizableToNextRound for Round2<P> {
             all_cap_g: self.all_cap_g,
             cap_ds,
             hat_cap_d,
-            round2_artifacts: dm_artifacts,
+            round2_artifacts: artifacts,
         })
     }
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "LogStarProof<P>: Serialize"))]
-#[serde(bound(deserialize = "LogStarProof<P>: for<'x> Deserialize<'x>"))]
-pub struct Round3Direct<P: SchemeParams> {
-    delta: Scalar,
-    cap_delta: Point,
-    psi_pprime: LogStarProof<P>,
 }
 
 pub struct Round3<P: SchemeParams> {
@@ -639,7 +567,21 @@ pub struct Round3<P: SchemeParams> {
     round2_artifacts: HoleVec<Round2Artifact<P>>,
 }
 
-impl<P: SchemeParams> BaseRound for Round3<P> {
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(bound(serialize = "LogStarProof<P>: Serialize"))]
+#[serde(bound(deserialize = "LogStarProof<P>: for<'x> Deserialize<'x>"))]
+pub struct Round3Message<P: SchemeParams> {
+    delta: Scalar,
+    cap_delta: Point,
+    psi_pprime: LogStarProof<P>,
+}
+
+pub struct Round3Payload {
+    delta: Scalar,
+    cap_delta: Point,
+}
+
+impl<P: SchemeParams> Round for Round3<P> {
     type Type = ToResult;
     type Result = PresigningResult<P>;
     const ROUND_NUM: u8 = 3;
@@ -652,31 +594,19 @@ impl<P: SchemeParams> BaseRound for Round3<P> {
     fn party_idx(&self) -> PartyIdx {
         self.context.key_share.party_index()
     }
-}
 
-pub struct Round3Payload {
-    delta: Scalar,
-    cap_delta: Point,
-}
-
-impl<P: SchemeParams> BroadcastRound for Round3<P> {
-    type Message = ();
-    type Payload = ();
-}
-
-impl<P: SchemeParams> DirectRound for Round3<P> {
-    type Message = Round3Direct<P>;
+    type Message = Round3Message<P>;
     type Payload = Round3Payload;
     type Artifact = ();
 
-    fn direct_message_destinations(&self) -> Option<Vec<PartyIdx>> {
-        Some(all_parties_except(
+    fn message_destinations(&self) -> Vec<PartyIdx> {
+        all_parties_except(
             self.context.key_share.num_parties(),
             self.context.key_share.party_index(),
-        ))
+        )
     }
 
-    fn make_direct_message(
+    fn make_message(
         &self,
         rng: &mut impl CryptoRngCore,
         destination: PartyIdx,
@@ -702,7 +632,7 @@ impl<P: SchemeParams> DirectRound for Round3<P> {
             rp,
             &aux,
         );
-        let message = Round3Direct {
+        let message = Round3Message {
             delta: P::scalar_from_signed(&self.delta),
             cap_delta: self.cap_delta,
             psi_pprime,
@@ -711,7 +641,7 @@ impl<P: SchemeParams> DirectRound for Round3<P> {
         Ok((message, ()))
     }
 
-    fn verify_direct_message(
+    fn verify_message(
         &self,
         from: PartyIdx,
         msg: Self::Message,
@@ -751,27 +681,20 @@ pub struct PresigningProof<P: SchemeParams> {
     dec_proofs: Vec<(PartyIdx, DecProof<P>)>,
 }
 
-impl<P: SchemeParams> Finalizable for Round3<P> {
-    fn requirement() -> FinalizationRequirement {
-        FinalizationRequirement::AllDms
-    }
-}
-
 impl<P: SchemeParams> FinalizableToResult for Round3<P> {
     fn finalize_to_result(
         self,
         rng: &mut impl CryptoRngCore,
-        _bc_payloads: BTreeMap<PartyIdx, <Self as BroadcastRound>::Payload>,
-        dm_payloads: BTreeMap<PartyIdx, <Self as DirectRound>::Payload>,
-        _dm_artifacts: BTreeMap<PartyIdx, <Self as DirectRound>::Artifact>,
+        payloads: BTreeMap<PartyIdx, <Self as Round>::Payload>,
+        _artifacts: BTreeMap<PartyIdx, <Self as Round>::Artifact>,
     ) -> Result<<Self::Result as ProtocolResult>::Success, FinalizeError<Self::Result>> {
-        let dm_payloads = try_to_holevec(
-            dm_payloads,
+        let payloads = try_to_holevec(
+            payloads,
             self.context.key_share.num_parties(),
             self.context.key_share.party_index(),
         )
         .unwrap();
-        let (deltas, cap_deltas) = dm_payloads
+        let (deltas, cap_deltas) = payloads
             .map(|payload| (payload.delta, payload.cap_delta))
             .unzip();
 

--- a/synedrion/src/cggmp21/protocols/signing.rs
+++ b/synedrion/src/cggmp21/protocols/signing.rs
@@ -16,9 +16,8 @@ use crate::common::{KeySharePrecomputed, PresigningData};
 use crate::curve::{RecoverableSignature, Scalar};
 use crate::paillier::RandomizerMod;
 use crate::rounds::{
-    all_parties_except, try_to_holevec, BaseRound, BroadcastRound, DirectRound, Finalizable,
-    FinalizableToResult, FinalizationRequirement, FinalizeError, FirstRound, InitError, PartyIdx,
-    ProtocolResult, ReceiveError, ToResult,
+    all_parties_except, try_to_holevec, FinalizableToResult, FinalizeError, FirstRound, InitError,
+    PartyIdx, ProtocolResult, ReceiveError, Round, ToResult,
 };
 use crate::tools::{
     collections::HoleRange,
@@ -91,7 +90,16 @@ impl<P: SchemeParams> FirstRound for Round1<P> {
     }
 }
 
-impl<P: SchemeParams> BaseRound for Round1<P> {
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Round1Message {
+    sigma: Scalar,
+}
+
+pub struct Round1Payload {
+    sigma: Scalar,
+}
+
+impl<P: SchemeParams> Round for Round1<P> {
     type Type = ToResult;
     type Result = SigningResult<P>;
     const ROUND_NUM: u8 = 1;
@@ -104,29 +112,23 @@ impl<P: SchemeParams> BaseRound for Round1<P> {
     fn party_idx(&self) -> PartyIdx {
         self.party_idx
     }
-}
 
-#[derive(Clone, Serialize, Deserialize)]
-pub struct Round1Bcast {
-    sigma: Scalar,
-}
-
-pub struct Round1Payload {
-    sigma: Scalar,
-}
-
-impl<P: SchemeParams> BroadcastRound for Round1<P> {
-    const REQUIRES_CONSENSUS: bool = false;
-    type Message = Round1Bcast;
+    type Message = Round1Message;
     type Payload = Round1Payload;
-    fn broadcast_destinations(&self) -> Option<Vec<PartyIdx>> {
-        Some(all_parties_except(self.num_parties(), self.party_idx()))
+    type Artifact = ();
+
+    fn message_destinations(&self) -> Vec<PartyIdx> {
+        all_parties_except(self.num_parties(), self.party_idx())
     }
-    fn make_broadcast(&self, _rng: &mut impl CryptoRngCore) -> Result<Self::Message, String> {
-        Ok(Round1Bcast { sigma: self.sigma })
+    fn make_message(
+        &self,
+        _rng: &mut impl CryptoRngCore,
+        _destination: PartyIdx,
+    ) -> Result<(Self::Message, Self::Artifact), String> {
+        Ok((Round1Message { sigma: self.sigma }, ()))
     }
 
-    fn verify_broadcast(
+    fn verify_message(
         &self,
         _from: PartyIdx,
         msg: Self::Message,
@@ -135,27 +137,14 @@ impl<P: SchemeParams> BroadcastRound for Round1<P> {
     }
 }
 
-impl<P: SchemeParams> DirectRound for Round1<P> {
-    type Message = ();
-    type Payload = ();
-    type Artifact = ();
-}
-
-impl<P: SchemeParams> Finalizable for Round1<P> {
-    fn requirement() -> FinalizationRequirement {
-        FinalizationRequirement::AllBroadcasts
-    }
-}
-
 impl<P: SchemeParams> FinalizableToResult for Round1<P> {
     fn finalize_to_result(
         self,
         rng: &mut impl CryptoRngCore,
-        bc_payloads: BTreeMap<PartyIdx, <Self as BroadcastRound>::Payload>,
-        _dm_payloads: BTreeMap<PartyIdx, <Self as DirectRound>::Payload>,
-        _dm_artifacts: BTreeMap<PartyIdx, <Self as DirectRound>::Artifact>,
+        payloads: BTreeMap<PartyIdx, <Self as Round>::Payload>,
+        _artifacts: BTreeMap<PartyIdx, <Self as Round>::Artifact>,
     ) -> Result<<Self::Result as ProtocolResult>::Success, FinalizeError<Self::Result>> {
-        let payloads = try_to_holevec(bc_payloads, self.num_parties, self.party_idx).unwrap();
+        let payloads = try_to_holevec(payloads, self.num_parties, self.party_idx).unwrap();
         let others_sigma = payloads.map(|payload| payload.sigma);
         let assembled_sigma = others_sigma.iter().sum::<Scalar>() + self.sigma;
 

--- a/synedrion/src/rounds.rs
+++ b/synedrion/src/rounds.rs
@@ -6,8 +6,8 @@ pub(crate) mod test_utils;
 
 pub use generic::ProtocolResult;
 pub(crate) use generic::{
-    all_parties_except, try_to_holevec, BaseRound, BroadcastRound, DirectRound, Finalizable,
-    FinalizableToNextRound, FinalizableToResult, FinalizationRequirement, FinalizeError,
-    FirstRound, InitError, PartyIdx, ReceiveError, Round, ToNextRound, ToResult,
+    all_parties_except, try_to_holevec, FinalizableToNextRound, FinalizableToResult,
+    FinalizationRequirement, FinalizeError, FirstRound, InitError, PartyIdx, ReceiveError, Round,
+    ToNextRound, ToResult,
 };
 pub(crate) use wrappers::{wrap_finalize_error, wrap_receive_error, ResultWrapper, RoundWrapper};

--- a/synedrion/src/rounds/test_utils.rs
+++ b/synedrion/src/rounds/test_utils.rs
@@ -6,9 +6,7 @@ use alloc::vec::Vec;
 use itertools::izip;
 use rand_core::CryptoRngCore;
 
-use super::generic::{
-    BroadcastRound, DirectRound, FinalizableToNextRound, FinalizableToResult, ProtocolResult, Round,
-};
+use super::generic::{FinalizableToNextRound, FinalizableToResult, ProtocolResult, Round};
 use super::{FinalizeError, PartyIdx};
 
 #[derive(Debug)]
@@ -19,9 +17,8 @@ pub(crate) enum StepError {
 
 pub(crate) struct AssembledRound<R: Round> {
     round: R,
-    bc_payloads: BTreeMap<PartyIdx, <R as BroadcastRound>::Payload>,
-    dm_payloads: BTreeMap<PartyIdx, <R as DirectRound>::Payload>,
-    dm_artifacts: BTreeMap<PartyIdx, <R as DirectRound>::Artifact>,
+    payloads: BTreeMap<PartyIdx, <R as Round>::Payload>,
+    artifacts: BTreeMap<PartyIdx, <R as Round>::Artifact>,
 }
 
 pub(crate) fn step_round<R>(
@@ -30,83 +27,55 @@ pub(crate) fn step_round<R>(
 ) -> Result<Vec<AssembledRound<R>>, StepError>
 where
     R: Round,
-    <R as BroadcastRound>::Message: Clone,
+    <R as Round>::Message: Clone,
 {
     // Collect outgoing messages
 
-    let mut dm_artifact_accums = (0..rounds.len())
+    let mut artifact_accums = (0..rounds.len())
         .map(|_| BTreeMap::new())
         .collect::<Vec<_>>();
 
     // `to, from, message`
-    let mut direct_messages = Vec::<(PartyIdx, PartyIdx, <R as DirectRound>::Message)>::new();
-    let mut broadcasts = Vec::<(PartyIdx, PartyIdx, <R as BroadcastRound>::Message)>::new();
+    let mut messages = Vec::<(PartyIdx, PartyIdx, <R as Round>::Message)>::new();
 
     for (idx_from, round) in rounds.iter().enumerate() {
         let idx_from = PartyIdx::from_usize(idx_from);
 
-        if let Some(destinations) = round.direct_message_destinations() {
-            for idx_to in destinations {
-                let (message, artifact) = round.make_direct_message(rng, idx_to).unwrap();
-                direct_messages.push((idx_to, idx_from, message));
-                assert!(dm_artifact_accums[idx_from.as_usize()]
-                    .insert(idx_to, artifact)
-                    .is_none());
-            }
-        }
-
-        if let Some(destinations) = round.broadcast_destinations() {
-            let message = round.make_broadcast(rng).unwrap();
-            for idx_to in destinations {
-                broadcasts.push((idx_to, idx_from, message.clone()));
-            }
+        let destinations = round.message_destinations();
+        for idx_to in destinations {
+            let (message, artifact) = round.make_message(rng, idx_to).unwrap();
+            messages.push((idx_to, idx_from, message));
+            assert!(artifact_accums[idx_from.as_usize()]
+                .insert(idx_to, artifact)
+                .is_none());
         }
     }
 
-    // Deliver direct messages
+    // Deliver messages
 
-    let mut dm_payload_accums = (0..rounds.len())
+    let mut payload_accums = (0..rounds.len())
         .map(|_| BTreeMap::new())
         .collect::<Vec<_>>();
-    for (idx_to, idx_from, message) in direct_messages.into_iter() {
+    for (idx_to, idx_from, message) in messages.into_iter() {
         let round = &rounds[idx_to.as_usize()];
         let payload = round
-            .verify_direct_message(idx_from, message)
+            .verify_message(idx_from, message)
             .map_err(|err| StepError::Receive(format!("{:?}", err)))?;
-        dm_payload_accums[idx_to.as_usize()].insert(idx_from, payload);
-    }
-
-    // Deliver broadcasts
-
-    let mut bc_payload_accums = (0..rounds.len())
-        .map(|_| BTreeMap::new())
-        .collect::<Vec<_>>();
-    for (idx_to, idx_from, message) in broadcasts.into_iter() {
-        let round = &rounds[idx_to.as_usize()];
-        let payload = round
-            .verify_broadcast(idx_from, message)
-            .map_err(|err| StepError::Receive(format!("{:?}", err)))?;
-        bc_payload_accums[idx_to.as_usize()].insert(idx_from, payload);
+        payload_accums[idx_to.as_usize()].insert(idx_from, payload);
     }
 
     // Assemble
 
     let mut assembled = Vec::new();
-    for (round, bc_payloads, dm_payloads, dm_artifacts) in izip!(
-        rounds,
-        bc_payload_accums,
-        dm_payload_accums,
-        dm_artifact_accums
-    ) {
-        if !round.can_finalize(bc_payloads.keys(), dm_payloads.keys(), dm_artifacts.keys()) {
+    for (round, payloads, artifacts) in izip!(rounds, payload_accums, artifact_accums) {
+        if !round.can_finalize(payloads.keys(), artifacts.keys()) {
             return Err(StepError::AccumFinalize);
         };
 
         assembled.push(AssembledRound {
             round,
-            bc_payloads,
-            dm_payloads,
-            dm_artifacts,
+            payloads,
+            artifacts,
         });
     }
     Ok(assembled)
@@ -120,9 +89,8 @@ pub(crate) fn step_next_round<R: FinalizableToNextRound>(
     for assembled_round in assembled_rounds.into_iter() {
         let next_round = assembled_round.round.finalize_to_next_round(
             rng,
-            assembled_round.bc_payloads,
-            assembled_round.dm_payloads,
-            assembled_round.dm_artifacts,
+            assembled_round.payloads,
+            assembled_round.artifacts,
         )?;
         results.push(next_round);
     }
@@ -137,9 +105,8 @@ pub(crate) fn step_result<R: FinalizableToResult>(
     for assembled_round in assembled_rounds.into_iter() {
         let result = assembled_round.round.finalize_to_result(
             rng,
-            assembled_round.bc_payloads,
-            assembled_round.dm_payloads,
-            assembled_round.dm_artifacts,
+            assembled_round.payloads,
+            assembled_round.artifacts,
         )?;
         results.push(result);
     }

--- a/synedrion/src/sessions/broadcast.rs
+++ b/synedrion/src/sessions/broadcast.rs
@@ -78,7 +78,7 @@ where
 
             let echoed_bc = bc_map.get(idx).ok_or(ConsensusError::MissingBroadcast)?;
 
-            if broadcast.as_unverified() != echoed_bc {
+            if !broadcast.as_unverified().is_same_as(echoed_bc) {
                 return Err(ConsensusError::ConflictingBroadcasts);
             }
         }

--- a/synedrion/src/sessions/signed_message.rs
+++ b/synedrion/src/sessions/signed_message.rs
@@ -42,20 +42,17 @@ fn message_hash(
 /// Protocol message type.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, PartialEq)]
 pub enum MessageType {
-    /// Direct messaging part of the round.
-    Direct,
-    /// Broadcasting part of the round.
-    Broadcast,
-    /// A service message for broadcasting consensus.
-    BroadcastConsensus,
+    /// Regular messaging part of the round.
+    Normal,
+    /// A service message for echo-broadcast.
+    Echo,
 }
 
 impl Hashable for MessageType {
     fn chain<C: Chain>(&self, digest: C) -> C {
         let value: u8 = match self {
-            Self::Direct => 0,
-            Self::Broadcast => 1,
-            Self::BroadcastConsensus => 2,
+            Self::Normal => 0,
+            Self::Echo => 1,
         };
         digest.chain(&value)
     }
@@ -105,6 +102,14 @@ impl<Sig> SignedMessage<Sig> {
     /// The message type.
     pub fn message_type(&self) -> MessageType {
         self.message_type
+    }
+
+    /// Compares the "significant" part of the messages (that is, everything but signatures)
+    pub fn is_same_as(&self, other: &Self) -> bool {
+        self.session_id == other.session_id
+            && self.round == other.round
+            && self.message_type == other.message_type
+            && self.payload == other.payload
     }
 }
 

--- a/synedrion/src/sessions/type_erased.rs
+++ b/synedrion/src/sessions/type_erased.rs
@@ -15,8 +15,8 @@ use serde::{Deserialize, Serialize};
 
 use super::error::LocalError;
 use crate::rounds::{
-    self, BroadcastRound, DirectRound, FinalizableToNextRound, FinalizableToResult, PartyIdx,
-    ProtocolResult, Round, ToNextRound, ToResult,
+    self, FinalizableToNextRound, FinalizableToResult, PartyIdx, ProtocolResult, Round,
+    ToNextRound, ToResult,
 };
 
 pub(crate) fn serialize_message(message: &impl Serialize) -> Result<Box<[u8]>, LocalError> {
@@ -85,37 +85,27 @@ impl<'a> rand_core::RngCore for BoxedRng<'a> {
     }
 }
 
-pub(crate) struct DynBcPayload(Box<dyn Any + Send>);
+pub(crate) struct DynPayload(Box<dyn Any + Send>);
 
-pub(crate) struct DynDmPayload(Box<dyn Any + Send>);
-
-pub(crate) struct DynDmArtifact(Box<dyn Any + Send>);
+pub(crate) struct DynArtifact(pub(crate) Box<dyn Any + Send>);
 
 /// An object-safe trait wrapping `Round`.
 pub(crate) trait DynRound<Res: ProtocolResult>: Send {
     fn round_num(&self) -> u8;
     fn next_round_num(&self) -> Option<u8>;
 
-    fn broadcast_destinations(&self) -> Option<Vec<PartyIdx>>;
-    fn make_broadcast(&self, rng: &mut dyn CryptoRngCore) -> Result<Box<[u8]>, LocalError>;
-    fn requires_broadcast_consensus(&self) -> bool;
-    fn direct_message_destinations(&self) -> Option<Vec<PartyIdx>>;
-    fn make_direct_message(
+    fn requires_echo(&self) -> bool;
+    fn message_destinations(&self) -> Vec<PartyIdx>;
+    fn make_message(
         &self,
         rng: &mut dyn CryptoRngCore,
         destination: PartyIdx,
-    ) -> Result<(Box<[u8]>, DynDmArtifact), LocalError>;
-
-    fn verify_broadcast(
+    ) -> Result<(Box<[u8]>, DynArtifact), LocalError>;
+    fn verify_message(
         &self,
         from: PartyIdx,
         message: &[u8],
-    ) -> Result<DynBcPayload, ReceiveError<Res>>;
-    fn verify_direct_message(
-        &self,
-        from: PartyIdx,
-        message: &[u8],
-    ) -> Result<DynDmPayload, ReceiveError<Res>>;
+    ) -> Result<DynPayload, ReceiveError<Res>>;
     fn can_finalize(&self, accum: &DynRoundAccum) -> bool;
     fn missing_payloads(&self, accum: &DynRoundAccum) -> BTreeSet<PartyIdx>;
 }
@@ -123,9 +113,8 @@ pub(crate) trait DynRound<Res: ProtocolResult>: Send {
 impl<R> DynRound<R::Result> for R
 where
     R: Round + Send,
-    <R as BroadcastRound>::Payload: 'static + Send,
-    <R as DirectRound>::Payload: 'static + Send,
-    <R as DirectRound>::Artifact: 'static + Send,
+    <R as Round>::Payload: 'static + Send,
+    <R as Round>::Artifact: 'static + Send,
 {
     fn round_num(&self) -> u8 {
         R::ROUND_NUM
@@ -135,186 +124,117 @@ where
         R::NEXT_ROUND_NUM
     }
 
-    fn verify_broadcast(
-        &self,
-        from: PartyIdx,
-        message: &[u8],
-    ) -> Result<DynBcPayload, ReceiveError<R::Result>> {
-        let typed_message: <R as BroadcastRound>::Message = match deserialize_message(message) {
-            Ok(message) => message,
-            Err(err) => return Err(ReceiveError::CannotDeserialize(err)),
-        };
-
-        let payload = self
-            .verify_broadcast(from, typed_message)
-            .map_err(ReceiveError::Protocol)?;
-
-        Ok(DynBcPayload(Box::new(payload)))
+    fn message_destinations(&self) -> Vec<PartyIdx> {
+        self.message_destinations()
     }
 
-    fn verify_direct_message(
-        &self,
-        from: PartyIdx,
-        message: &[u8],
-    ) -> Result<DynDmPayload, ReceiveError<R::Result>> {
-        let typed_message: <R as DirectRound>::Message = match deserialize_message(message) {
-            Ok(message) => message,
-            Err(err) => return Err(ReceiveError::CannotDeserialize(err)),
-        };
-
-        let payload = self
-            .verify_direct_message(from, typed_message)
-            .map_err(ReceiveError::Protocol)?;
-
-        Ok(DynDmPayload(Box::new(payload)))
-    }
-
-    fn broadcast_destinations(&self) -> Option<Vec<PartyIdx>> {
-        self.broadcast_destinations()
-    }
-
-    fn make_broadcast(&self, rng: &mut dyn CryptoRngCore) -> Result<Box<[u8]>, LocalError> {
-        let mut boxed_rng = BoxedRng(rng);
-        let serialized = self
-            .make_broadcast(&mut boxed_rng)
-            .map_err(|err| LocalError(format!("Failed to make a broadcast message: {err:?}")))?;
-        serialize_message(&serialized)
-    }
-
-    fn requires_broadcast_consensus(&self) -> bool {
-        <R as BroadcastRound>::REQUIRES_CONSENSUS
-    }
-
-    fn direct_message_destinations(&self) -> Option<Vec<PartyIdx>> {
-        self.direct_message_destinations()
-    }
-
-    fn make_direct_message(
+    fn make_message(
         &self,
         rng: &mut dyn CryptoRngCore,
         destination: PartyIdx,
-    ) -> Result<(Box<[u8]>, DynDmArtifact), LocalError> {
+    ) -> Result<(Box<[u8]>, DynArtifact), LocalError> {
         let mut boxed_rng = BoxedRng(rng);
         let (typed_message, typed_artifact) = self
-            .make_direct_message(&mut boxed_rng, destination)
-            .map_err(|err| LocalError(format!("Failed to make a direct message: {err:?}")))?;
+            .make_message(&mut boxed_rng, destination)
+            .map_err(|err| LocalError(format!("Failed to make a message: {err:?}")))?;
         let message = serialize_message(&typed_message)?;
-        Ok((message, DynDmArtifact(Box::new(typed_artifact))))
+        Ok((message, DynArtifact(Box::new(typed_artifact))))
+    }
+
+    fn verify_message(
+        &self,
+        from: PartyIdx,
+        message: &[u8],
+    ) -> Result<DynPayload, ReceiveError<R::Result>> {
+        let typed_message: <R as Round>::Message = match deserialize_message(message) {
+            Ok(message) => message,
+            Err(err) => return Err(ReceiveError::CannotDeserialize(err)),
+        };
+
+        let payload = self
+            .verify_message(from, typed_message)
+            .map_err(ReceiveError::Protocol)?;
+
+        Ok(DynPayload(Box::new(payload)))
+    }
+
+    fn requires_echo(&self) -> bool {
+        <R as Round>::REQUIRES_ECHO
     }
 
     fn can_finalize(&self, accum: &DynRoundAccum) -> bool {
-        self.can_finalize(
-            accum.bc_payloads.keys(),
-            accum.dm_payloads.keys(),
-            accum.dm_artifacts.keys(),
-        )
+        self.can_finalize(accum.payloads.keys(), accum.artifacts.keys())
     }
 
     fn missing_payloads(&self, accum: &DynRoundAccum) -> BTreeSet<PartyIdx> {
-        self.missing_payloads(
-            accum.bc_payloads.keys(),
-            accum.dm_payloads.keys(),
-            accum.dm_artifacts.keys(),
-        )
+        self.missing_payloads(accum.payloads.keys(), accum.artifacts.keys())
     }
 }
 
 pub(crate) struct DynRoundAccum {
-    bc_payloads: BTreeMap<PartyIdx, DynBcPayload>,
-    dm_payloads: BTreeMap<PartyIdx, DynDmPayload>,
-    dm_artifacts: BTreeMap<PartyIdx, DynDmArtifact>,
+    payloads: BTreeMap<PartyIdx, DynPayload>,
+    artifacts: BTreeMap<PartyIdx, DynArtifact>,
 }
 
 struct RoundAccum<R: Round> {
-    bc_payloads: BTreeMap<PartyIdx, <R as BroadcastRound>::Payload>,
-    dm_payloads: BTreeMap<PartyIdx, <R as DirectRound>::Payload>,
-    dm_artifacts: BTreeMap<PartyIdx, <R as DirectRound>::Artifact>,
+    payloads: BTreeMap<PartyIdx, <R as Round>::Payload>,
+    artifacts: BTreeMap<PartyIdx, <R as Round>::Artifact>,
 }
 
 impl DynRoundAccum {
     pub fn new() -> Self {
         Self {
-            bc_payloads: BTreeMap::new(),
-            dm_payloads: BTreeMap::new(),
-            dm_artifacts: BTreeMap::new(),
+            payloads: BTreeMap::new(),
+            artifacts: BTreeMap::new(),
         }
     }
 
-    pub fn contains(&self, from: PartyIdx, broadcast: bool) -> bool {
-        if broadcast {
-            self.bc_payloads.contains_key(&from)
-        } else {
-            self.dm_payloads.contains_key(&from)
-        }
+    pub fn contains(&self, from: PartyIdx) -> bool {
+        self.payloads.contains_key(&from)
     }
 
-    pub fn add_bc_payload(
+    pub fn add_payload(
         &mut self,
         from: PartyIdx,
-        payload: DynBcPayload,
+        payload: DynPayload,
     ) -> Result<(), AccumAddError> {
-        if self.bc_payloads.contains_key(&from) {
+        if self.payloads.contains_key(&from) {
             return Err(AccumAddError::SlotTaken);
         }
-        self.bc_payloads.insert(from, payload);
+        self.payloads.insert(from, payload);
         Ok(())
     }
 
-    pub fn add_dm_payload(
-        &mut self,
-        from: PartyIdx,
-        payload: DynDmPayload,
-    ) -> Result<(), AccumAddError> {
-        if self.dm_payloads.contains_key(&from) {
-            return Err(AccumAddError::SlotTaken);
-        }
-        self.dm_payloads.insert(from, payload);
-        Ok(())
-    }
-
-    pub fn add_dm_artifact(
+    pub fn add_artifact(
         &mut self,
         destination: PartyIdx,
-        artifact: DynDmArtifact,
+        artifact: DynArtifact,
     ) -> Result<(), AccumAddError> {
-        if self.dm_artifacts.contains_key(&destination) {
+        if self.artifacts.contains_key(&destination) {
             return Err(AccumAddError::SlotTaken);
         }
-        self.dm_artifacts.insert(destination, artifact);
+        self.artifacts.insert(destination, artifact);
         Ok(())
     }
 
     fn finalize<R: Round>(self) -> Result<RoundAccum<R>, AccumFinalizeError>
     where
-        <R as BroadcastRound>::Payload: 'static,
-        <R as DirectRound>::Payload: 'static,
-        <R as DirectRound>::Artifact: 'static,
+        <R as Round>::Payload: 'static,
+        <R as Round>::Artifact: 'static,
     {
-        let bc_payloads = self
-            .bc_payloads
+        let payloads = self
+            .payloads
             .into_iter()
-            .map(|(idx, elem)| {
-                downcast::<<R as BroadcastRound>::Payload>(elem.0).map(|elem| (idx, elem))
-            })
+            .map(|(idx, elem)| downcast::<<R as Round>::Payload>(elem.0).map(|elem| (idx, elem)))
             .collect::<Result<BTreeMap<_, _>, _>>()?;
-        let dm_payloads = self
-            .dm_payloads
+        let artifacts = self
+            .artifacts
             .into_iter()
-            .map(|(idx, elem)| {
-                downcast::<<R as DirectRound>::Payload>(elem.0).map(|elem| (idx, elem))
-            })
-            .collect::<Result<BTreeMap<_, _>, _>>()?;
-        let dm_artifacts = self
-            .dm_artifacts
-            .into_iter()
-            .map(|(idx, elem)| {
-                downcast::<<R as DirectRound>::Artifact>(elem.0).map(|elem| (idx, elem))
-            })
+            .map(|(idx, elem)| downcast::<<R as Round>::Artifact>(elem.0).map(|elem| (idx, elem)))
             .collect::<Result<BTreeMap<_, _>, _>>()?;
         Ok(RoundAccum {
-            bc_payloads,
-            dm_payloads,
-            dm_artifacts,
+            payloads,
+            artifacts,
         })
     }
 }
@@ -359,9 +279,8 @@ const _: () = {
     impl<R> DynFinalizable<R::Result> for R
     where
         R: Round + Send + 'static,
-        <R as BroadcastRound>::Payload: Send,
-        <R as DirectRound>::Payload: Send,
-        <R as DirectRound>::Artifact: Send,
+        <R as Round>::Payload: Send,
+        <R as Round>::Artifact: Send,
         Self: _DynFinalizable<R::Result, R::Type>,
     {
         fn finalize(
@@ -387,12 +306,7 @@ const _: () = {
             let mut boxed_rng = BoxedRng(rng);
             let typed_accum = accum.finalize::<R>().map_err(FinalizeError::Accumulator)?;
             let result = (*self)
-                .finalize_to_result(
-                    &mut boxed_rng,
-                    typed_accum.bc_payloads,
-                    typed_accum.dm_payloads,
-                    typed_accum.dm_artifacts,
-                )
+                .finalize_to_result(&mut boxed_rng, typed_accum.payloads, typed_accum.artifacts)
                 .map_err(FinalizeError::Protocol)?;
             Ok(FinalizeOutcome::Success(result))
         }
@@ -411,12 +325,7 @@ const _: () = {
             let mut boxed_rng = BoxedRng(rng);
             let typed_accum = accum.finalize::<R>().map_err(FinalizeError::Accumulator)?;
             let next_round = (*self)
-                .finalize_to_next_round(
-                    &mut boxed_rng,
-                    typed_accum.bc_payloads,
-                    typed_accum.dm_payloads,
-                    typed_accum.dm_artifacts,
-                )
+                .finalize_to_next_round(&mut boxed_rng, typed_accum.payloads, typed_accum.artifacts)
                 .map_err(FinalizeError::Protocol)?;
             Ok(FinalizeOutcome::AnotherRound(Box::new(next_round)))
         }

--- a/synedrion/src/www02.rs
+++ b/synedrion/src/www02.rs
@@ -16,9 +16,8 @@ use serde::{Deserialize, Serialize};
 use crate::cggmp21::SchemeParams;
 use crate::curve::{Point, Scalar};
 use crate::rounds::{
-    BaseRound, BroadcastRound, DirectRound, Finalizable, FinalizableToResult,
-    FinalizationRequirement, FinalizeError, FirstRound, InitError, PartyIdx, ProtocolResult,
-    ReceiveError, ToResult,
+    FinalizableToResult, FinalizationRequirement, FinalizeError, FirstRound, InitError, PartyIdx,
+    ProtocolResult, ReceiveError, Round, ToResult,
 };
 use crate::threshold::ThresholdKeyShareSeed;
 use crate::tools::{
@@ -139,7 +138,21 @@ impl<P: SchemeParams> FirstRound for Round1<P> {
     }
 }
 
-impl<P: SchemeParams> BaseRound for Round1<P> {
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Round1Message {
+    subshare: Scalar,
+    // TODO: this should be echoed
+    public_polynomial: PublicPolynomial,
+    old_share_idx: ShareIdx,
+}
+
+pub struct Round1Payload {
+    subshare: Scalar,
+    public_polynomial: PublicPolynomial,
+    old_share_idx: ShareIdx,
+}
+
+impl<P: SchemeParams> Round for Round1<P> {
     type Type = ToResult;
     type Result = KeyResharingResult<P>;
     const ROUND_NUM: u8 = 1;
@@ -152,32 +165,20 @@ impl<P: SchemeParams> BaseRound for Round1<P> {
     fn party_idx(&self) -> PartyIdx {
         self.party_idx
     }
-}
 
-pub struct Round1DirectPayload {
-    subshare: Scalar,
-    public_subshare: Point,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Round1Direct {
-    subshare: Scalar,
-}
-
-impl<P: SchemeParams> DirectRound for Round1<P> {
-    type Message = Round1Direct;
-    type Payload = Round1DirectPayload;
+    type Message = Round1Message;
+    type Payload = Round1Payload;
     type Artifact = ();
 
-    fn direct_message_destinations(&self) -> Option<Vec<PartyIdx>> {
+    fn message_destinations(&self) -> Vec<PartyIdx> {
         if self.old_holder.is_some() {
-            Some(self.new_share_idxs.keys().cloned().collect())
+            self.new_share_idxs.keys().cloned().collect()
         } else {
-            None
+            Vec::new()
         }
     }
 
-    fn make_direct_message(
+    fn make_message(
         &self,
         _rng: &mut impl CryptoRngCore,
         destination: PartyIdx,
@@ -186,13 +187,20 @@ impl<P: SchemeParams> DirectRound for Round1<P> {
             let subshare = old_holder
                 .polynomial
                 .evaluate(&self.new_share_idxs[&destination]);
-            Ok((Round1Direct { subshare }, ()))
+            Ok((
+                Round1Message {
+                    subshare,
+                    public_polynomial: old_holder.public_polynomial.clone(),
+                    old_share_idx: old_holder.inputs.key_share_seed.index(),
+                },
+                (),
+            ))
         } else {
-            Err("This node does not send direct messages in this round".into())
+            Err("This node does not send messages in this round".into())
         }
     }
 
-    fn verify_direct_message(
+    fn verify_message(
         &self,
         from: PartyIdx,
         msg: Self::Message,
@@ -204,94 +212,40 @@ impl<P: SchemeParams> DirectRound for Round1<P> {
                 .iter()
                 .any(|party_idx| party_idx == &from)
             {
-                return Ok(Round1DirectPayload {
-                    subshare: msg.subshare,
-                    public_subshare: msg.subshare.mul_by_generator(),
-                });
-            }
-        }
-        Err(ReceiveError::Provable(KeyResharingError::UnexpectedSender))
-    }
-}
-
-pub struct Round1BcastPayload {
-    public_polynomial: PublicPolynomial,
-    public_subshare: Point,
-    old_share_idx: ShareIdx,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Round1Bcast {
-    public_polynomial: PublicPolynomial,
-    old_share_idx: ShareIdx,
-}
-
-impl<P: SchemeParams> BroadcastRound for Round1<P> {
-    const REQUIRES_CONSENSUS: bool = true;
-    type Message = Round1Bcast;
-    type Payload = Round1BcastPayload;
-
-    fn broadcast_destinations(&self) -> Option<Vec<PartyIdx>> {
-        if self.old_holder.is_some() {
-            Some(self.new_share_idxs.keys().cloned().collect())
-        } else {
-            None
-        }
-    }
-
-    fn make_broadcast(&self, _rng: &mut impl CryptoRngCore) -> Result<Self::Message, String> {
-        if let Some(old_holder) = self.old_holder.as_ref() {
-            Ok(Round1Bcast {
-                public_polynomial: old_holder.public_polynomial.clone(),
-                old_share_idx: old_holder.inputs.key_share_seed.index(),
-            })
-        } else {
-            Err("This node does not send broadcast messages in this round".into())
-        }
-    }
-
-    fn verify_broadcast(
-        &self,
-        from: PartyIdx,
-        msg: Self::Message,
-    ) -> Result<Self::Payload, ReceiveError<Self::Result>> {
-        if let Some(new_holder) = self.new_holder.as_ref() {
-            if new_holder
-                .inputs
-                .old_holders
-                .iter()
-                .any(|party_idx| party_idx == &from)
-            {
-                let public_subshare = msg
+                let public_subshare_from_poly = msg
                     .public_polynomial
                     .evaluate(&self.new_share_idxs[&self.party_idx()]);
-                return Ok(Round1BcastPayload {
+                let public_subshare_from_private = msg.subshare.mul_by_generator();
+
+                // Check that the public polynomial sent in the broadcast corresponds to the secret share
+                // sent in the direct message.
+                if public_subshare_from_poly != public_subshare_from_private {
+                    return Err(ReceiveError::Provable(KeyResharingError::SubshareMismatch));
+                }
+
+                return Ok(Round1Payload {
+                    subshare: msg.subshare,
                     public_polynomial: msg.public_polynomial,
-                    public_subshare,
                     old_share_idx: msg.old_share_idx,
                 });
             }
         }
         Err(ReceiveError::Provable(KeyResharingError::UnexpectedSender))
     }
-}
 
-impl<P: SchemeParams> Finalizable for Round1<P> {
-    fn requirement() -> FinalizationRequirement {
+    fn finalization_requirement() -> FinalizationRequirement {
         FinalizationRequirement::Custom
     }
 
     fn can_finalize<'a>(
         &self,
-        bc_payloads: impl Iterator<Item = &'a PartyIdx>,
-        dm_payloads: impl Iterator<Item = &'a PartyIdx>,
-        _dm_artifacts: impl Iterator<Item = &'a PartyIdx>,
+        payloads: impl Iterator<Item = &'a PartyIdx>,
+        _artifacts: impl Iterator<Item = &'a PartyIdx>,
     ) -> bool {
         if let Some(new_holder) = self.new_holder.as_ref() {
-            let bc_set = bc_payloads.cloned().collect::<BTreeSet<_>>();
-            let dm_set = dm_payloads.cloned().collect::<BTreeSet<_>>();
+            let set = payloads.cloned().collect::<BTreeSet<_>>();
             let threshold = new_holder.inputs.old_threshold;
-            bc_set.len() >= threshold && dm_set.len() >= threshold
+            set.len() >= threshold
         } else {
             true
         }
@@ -299,19 +253,17 @@ impl<P: SchemeParams> Finalizable for Round1<P> {
 
     fn missing_payloads<'a>(
         &self,
-        bc_payloads: impl Iterator<Item = &'a PartyIdx>,
-        dm_payloads: impl Iterator<Item = &'a PartyIdx>,
-        _dm_artifacts: impl Iterator<Item = &'a PartyIdx>,
+        payloads: impl Iterator<Item = &'a PartyIdx>,
+        _artifacts: impl Iterator<Item = &'a PartyIdx>,
     ) -> BTreeSet<PartyIdx> {
         if let Some(new_holder) = self.new_holder.as_ref() {
-            let bc_set = bc_payloads.cloned().collect::<BTreeSet<_>>();
-            let dm_set = dm_payloads.cloned().collect::<BTreeSet<_>>();
+            let set = payloads.cloned().collect::<BTreeSet<_>>();
             new_holder
                 .inputs
                 .old_holders
                 .iter()
                 .cloned()
-                .filter(|idx| !bc_set.contains(idx) || !dm_set.contains(idx))
+                .filter(|idx| !set.contains(idx))
                 .collect()
         } else {
             BTreeSet::new()
@@ -323,9 +275,8 @@ impl<P: SchemeParams> FinalizableToResult for Round1<P> {
     fn finalize_to_result(
         self,
         _rng: &mut impl CryptoRngCore,
-        bc_payloads: BTreeMap<PartyIdx, <Self as BroadcastRound>::Payload>,
-        dm_payloads: BTreeMap<PartyIdx, <Self as DirectRound>::Payload>,
-        _dm_artifacts: BTreeMap<PartyIdx, <Self as DirectRound>::Artifact>,
+        payloads: BTreeMap<PartyIdx, <Self as Round>::Payload>,
+        _artifacts: BTreeMap<PartyIdx, <Self as Round>::Artifact>,
     ) -> Result<<Self::Result as ProtocolResult>::Success, FinalizeError<Self::Result>> {
         // If this party is not a new holder, exit.
         let new_holder = match self.new_holder.as_ref() {
@@ -335,24 +286,13 @@ impl<P: SchemeParams> FinalizableToResult for Round1<P> {
 
         let share_idx = self.new_share_idxs[&self.party_idx()];
 
-        // Check that the public polynomial sent in the broadcast corresponds to the secret share
-        // sent in the direct message.
-        for party_idx in new_holder.inputs.old_holders.iter() {
-            if dm_payloads[&party_idx].public_subshare != bc_payloads[&party_idx].public_subshare {
-                return Err(FinalizeError::Provable {
-                    party: *party_idx,
-                    error: KeyResharingError::SubshareMismatch,
-                });
-            }
-        }
-
         // Check that the 0-th coefficients of public polynomials (that is, the old shares)
         // add up to the expected verifying key.
-        let old_share_idxs = bc_payloads
+        let old_share_idxs = payloads
             .values()
             .map(|payload| payload.old_share_idx)
             .collect::<Vec<_>>();
-        let vkey = bc_payloads
+        let vkey = payloads
             .values()
             .map(|payload| {
                 payload.public_polynomial.coeff0()
@@ -373,8 +313,8 @@ impl<P: SchemeParams> FinalizableToResult for Round1<P> {
             .iter()
             .map(|party_idx| {
                 (
-                    bc_payloads[&party_idx].old_share_idx,
-                    dm_payloads[&party_idx].subshare,
+                    payloads[&party_idx].old_share_idx,
+                    payloads[&party_idx].subshare,
                 )
             })
             .collect::<BTreeMap<_, _>>();
@@ -386,7 +326,7 @@ impl<P: SchemeParams> FinalizableToResult for Round1<P> {
             .keys()
             .map(|party_idx| {
                 let share_idx = self.new_share_idxs[&party_idx];
-                let public_subshares = bc_payloads
+                let public_subshares = payloads
                     .values()
                     .map(|p| (p.old_share_idx, p.public_polynomial.evaluate(&share_idx)))
                     .collect::<BTreeMap<_, _>>();


### PR DESCRIPTION
Remove the distinction between direct and broadcast messages since actual broadcast is not available in real applications.

Instead, we will separate the data in the messages into the part that does not have to be echoed, and the one that does. The latter is the business of the type-erased level, and typed rounds won't have to worry about it - they will just process full messages. The only part where they do care about the echoed part is blame generation. 

Note that this changed allowed us to move message verification to `verify_message()` from `finalize()` in several places, thus removing the need in `FinalizeError::Provable`. 