### PR TITLE
Implement `serde` for CGGMP21 params

### DIFF
--- a/synedrion/src/cggmp21/params.rs
+++ b/synedrion/src/cggmp21/params.rs
@@ -10,7 +10,7 @@ use crate::uint::{
 
 use serde::{Serialize, Deserialize};
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PaillierTest;
 
 impl PaillierParams for PaillierTest {
@@ -65,7 +65,7 @@ impl PaillierParams for PaillierTest {
     type ExtraWideUint = U4096;
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PaillierProduction;
 
 impl PaillierParams for PaillierProduction {

--- a/synedrion/src/cggmp21/params.rs
+++ b/synedrion/src/cggmp21/params.rs
@@ -8,7 +8,7 @@ use crate::uint::{
     U2048Mod, U4096Mod, U512Mod, Zero, U1024, U2048, U4096, U512, U8192,
 };
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PaillierTest;

--- a/synedrion/src/cggmp21/params.rs
+++ b/synedrion/src/cggmp21/params.rs
@@ -8,6 +8,8 @@ use crate::uint::{
     U2048Mod, U4096Mod, U512Mod, Zero, U1024, U2048, U4096, U512, U8192,
 };
 
+use serde::{Serialize, Deserialize};
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct PaillierTest;
 
@@ -167,7 +169,7 @@ impl<P: SchemeParams> HashableType for P {
 
 /// Scheme parameters **for testing purposes only**.
 /// Security is weakened to allow for faster execution.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TestParams;
 
 // Some requirements from range proofs etc:
@@ -191,7 +193,7 @@ impl SchemeParams for TestParams {
 }
 
 /// Production strength parameters.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProductionParams;
 
 impl SchemeParams for ProductionParams {


### PR DESCRIPTION
I was updating Entropy Core to use the latest Synedrion `HEAD` but got blocked because of
these missing trait implementations.

I only needed them for the Test and Production parameters, but figured adding them to the
Paillier parameters wouldn't hurt.
