### PR TITLE
Make verification key derivation independent of keyshares

### DIFF
--- a/synedrion/src/lib.rs
+++ b/synedrion/src/lib.rs
@@ -49,4 +49,4 @@ pub use constructors::{
 pub use curve::RecoverableSignature;
 pub use rounds::ProtocolResult;
 pub use sessions::{FinalizeOutcome, MessageBundle, Session, SessionId};
-pub use www02::{KeyResharingInputs, KeyResharingResult, NewHolder, OldHolder, ThresholdKeyShare, derived_verifying_key_bip32};
+pub use www02::{KeyResharingInputs, KeyResharingResult, NewHolder, OldHolder, ThresholdKeyShare, DeriveChildKey};

--- a/synedrion/src/lib.rs
+++ b/synedrion/src/lib.rs
@@ -49,4 +49,4 @@ pub use constructors::{
 pub use curve::RecoverableSignature;
 pub use rounds::ProtocolResult;
 pub use sessions::{FinalizeOutcome, MessageBundle, Session, SessionId};
-pub use www02::{KeyResharingInputs, KeyResharingResult, NewHolder, OldHolder, ThresholdKeyShare};
+pub use www02::{KeyResharingInputs, KeyResharingResult, NewHolder, OldHolder, ThresholdKeyShare, derived_verifying_key_bip32};

--- a/synedrion/src/lib.rs
+++ b/synedrion/src/lib.rs
@@ -49,4 +49,6 @@ pub use constructors::{
 pub use curve::RecoverableSignature;
 pub use rounds::ProtocolResult;
 pub use sessions::{FinalizeOutcome, MessageBundle, Session, SessionId};
-pub use www02::{KeyResharingInputs, KeyResharingResult, NewHolder, OldHolder, ThresholdKeyShare, DeriveChildKey};
+pub use www02::{
+    DeriveChildKey, KeyResharingInputs, KeyResharingResult, NewHolder, OldHolder, ThresholdKeyShare,
+};

--- a/synedrion/src/www02.rs
+++ b/synedrion/src/www02.rs
@@ -1,5 +1,6 @@
 mod entities;
 pub(crate) mod key_resharing;
 
+pub use entities::derived_verifying_key_bip32;
 pub use entities::ThresholdKeyShare;
 pub use key_resharing::{KeyResharingInputs, KeyResharingResult, NewHolder, OldHolder};

--- a/synedrion/src/www02.rs
+++ b/synedrion/src/www02.rs
@@ -1,5 +1,5 @@
 mod entities;
 pub(crate) mod key_resharing;
 
-pub use entities::{ThresholdKeyShare, DeriveChildKey};
+pub use entities::{DeriveChildKey, ThresholdKeyShare};
 pub use key_resharing::{KeyResharingInputs, KeyResharingResult, NewHolder, OldHolder};

--- a/synedrion/src/www02.rs
+++ b/synedrion/src/www02.rs
@@ -1,6 +1,5 @@
 mod entities;
 pub(crate) mod key_resharing;
 
-pub use entities::derived_verifying_key_bip32;
-pub use entities::ThresholdKeyShare;
+pub use entities::{ThresholdKeyShare, DeriveChildKey};
 pub use key_resharing::{KeyResharingInputs, KeyResharingResult, NewHolder, OldHolder};

--- a/synedrion/tests/threshold.rs
+++ b/synedrion/tests/threshold.rs
@@ -8,8 +8,8 @@ use tokio::time::{sleep, Duration};
 
 use synedrion::{
     make_aux_gen_session, make_interactive_signing_session, make_key_init_session,
-    make_key_resharing_session, FinalizeOutcome, KeyResharingInputs, MessageBundle, NewHolder,
-    OldHolder, ProtocolResult, Session, SessionId, TestParams, ThresholdKeyShare,
+    make_key_resharing_session, DeriveChildKey, FinalizeOutcome, KeyResharingInputs, MessageBundle,
+    NewHolder, OldHolder, ProtocolResult, Session, SessionId, TestParams, ThresholdKeyShare,
 };
 
 type MessageOut = (VerifyingKey, VerifyingKey, MessageBundle<Signature>);
@@ -243,11 +243,7 @@ async fn full_sequence() {
         .collect::<Vec<_>>();
 
     // The full verifying key can be obtained both from the original key shares and child key shares
-    let child_vkey = ThresholdKeyShare::<TestParams, VerifyingKey>::derived_verifying_key_bip32(
-        &t_key_shares[0].verifying_key(),
-        &path,
-    )
-    .unwrap();
+    let child_vkey = t_key_shares[0].derive_verifying_key_bip32(&path).unwrap();
     assert_eq!(child_vkey, child_key_shares[0].verifying_key());
 
     // Reshare to `n` nodes
@@ -317,11 +313,8 @@ async fn full_sequence() {
     );
 
     // Check that resharing did not change the derived child key
-    let child_vkey_after_resharing =
-        ThresholdKeyShare::<TestParams, VerifyingKey>::derived_verifying_key_bip32(
-            &new_t_key_shares[0].verifying_key(),
-            &path,
-        )
+    let child_vkey_after_resharing = new_t_key_shares[0]
+        .derive_verifying_key_bip32(&path)
         .unwrap();
     assert_eq!(child_vkey, child_vkey_after_resharing);
 


### PR DESCRIPTION
I want to be able to use the derivation functionality from the on-chain Registry pallet
code, which doesn't have access to a `ThresholdKeyShare`. Instead it only has access to a
`VerifyingKey`.

This PR adds a new trait, `DeriveChildKey`, which is implemented for `ThresholdKeyShare`
and `VerifyingKey`, allowing both to derive child verification keys.

I also considered having just a standalone function, but figured it would be nice to
implement the method on both types. Let me know if you'd prefer the first solution.

I'm also not entirely sure how to test this. Given that the `ThresholdKeyShare` tests
already use the verifying key internally, it seems covered? But maybe at some point in
the future the implementations could differ and cause problems.
