### PR TITLE
Fix WASM build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,12 @@ jobs:
 
   test-and-codecov:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+        target:
+          - wasm32-unknown-unknown
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -21,7 +27,8 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
           override: true
 
       - name: Install cargo-llvm-cov
@@ -34,3 +41,26 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           fail_ci_if_error: true
+
+  build-wasm:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+        target:
+          - wasm32-unknown-unknown
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
+          override: true
+
+      - name: Build
+        run: cargo build --target ${{ matrix.target }} --release --no-default-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Generate code coverage
         run: cargo llvm-cov --workspace --release --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info

--- a/synedrion/Cargo.toml
+++ b/synedrion/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 signature = { version = "2", default-features = false, features = ["alloc"] }
 k256 = { version = "0.13.2", default-features = false, features = ["ecdsa", "arithmetic"] }
-rand_core = { version = "0.6.4", default-features = false, features = ["getrandom"] }
+rand_core = { version = "0.6.4", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 sha3 = { version = "0.10", default-features = false }
 digest = { version = "0.10", default-features = false, features = ["alloc"]}
@@ -25,8 +25,8 @@ bip32 = { version = "0.5.2", default-features = false, features = ["alloc", "sec
 
 # Note: `alloc` is needed for `crytpto-bigint`'s dependency `serdect` to be able
 # to serialize Uints in human-readable formats.
-crypto-bigint = { version = "0.5.3", features = ["serde", "alloc"] }
-crypto-primes = "0.5"
+crypto-bigint = { version = "0.5.3", default-features = false, features = ["serde", "alloc"] }
+crypto-primes = { version = "0.5", default-features = false }
 
 serde = { version = "1", default-features = false, features = ["derive"] }
 bincode = "1"

--- a/synedrion/src/cggmp21/protocols/aux_gen.rs
+++ b/synedrion/src/cggmp21/protocols/aux_gen.rs
@@ -212,6 +212,7 @@ impl<P: SchemeParams, I: Debug + Clone + Ord + Serialize> Round<I> for Round1<P,
 
     fn verify_message(
         &self,
+        _rng: &mut impl CryptoRngCore,
         _from: &I,
         broadcast_msg: Self::BroadcastMessage,
         _direct_msg: Self::DirectMessage,
@@ -290,6 +291,7 @@ impl<P: SchemeParams, I: Debug + Clone + Ord + Serialize> Round<I> for Round2<P,
 
     fn verify_message(
         &self,
+        _rng: &mut impl CryptoRngCore,
         from: &I,
         broadcast_msg: Self::BroadcastMessage,
         _direct_msg: Self::DirectMessage,
@@ -454,6 +456,7 @@ impl<P: SchemeParams, I: Debug + Clone + Ord + Serialize> Round<I> for Round3<P,
 
     fn verify_message(
         &self,
+        rng: &mut impl CryptoRngCore,
         from: &I,
         _broadcast_msg: Self::BroadcastMessage,
         direct_msg: Self::DirectMessage,
@@ -465,7 +468,7 @@ impl<P: SchemeParams, I: Debug + Clone + Ord + Serialize> Round<I> for Round3<P,
         if !direct_msg
             .data2
             .psi_mod
-            .verify(&sender_data.paillier_pk, &aux)
+            .verify(rng, &sender_data.paillier_pk, &aux)
         {
             return Err(AuxGenError(AuxGenErrorEnum::Round3(
                 "Mod proof verification failed".into(),

--- a/synedrion/src/cggmp21/protocols/key_gen.rs
+++ b/synedrion/src/cggmp21/protocols/key_gen.rs
@@ -132,6 +132,7 @@ impl<P: SchemeParams, I: Debug + Clone + Ord + Serialize> Round<I> for Round1<P,
 
     fn verify_message(
         &self,
+        rng: &mut impl CryptoRngCore,
         from: &I,
         broadcast_msg: Self::BroadcastMessage,
         _direct_msg: Self::DirectMessage,
@@ -139,11 +140,11 @@ impl<P: SchemeParams, I: Debug + Clone + Ord + Serialize> Round<I> for Round1<P,
         let (key_init_message, key_refresh_message) = broadcast_msg;
         let key_init_payload = self
             .key_init_round
-            .verify_message(from, key_init_message, ())
+            .verify_message(rng, from, key_init_message, ())
             .map_err(KeyGenError::KeyInit)?;
         let key_refresh_payload = self
             .key_refresh_round
-            .verify_message(from, key_refresh_message, ())
+            .verify_message(rng, from, key_refresh_message, ())
             .map_err(KeyGenError::KeyRefresh)?;
         Ok((key_init_payload, key_refresh_payload))
     }
@@ -228,6 +229,7 @@ impl<P: SchemeParams, I: Debug + Clone + Ord + Serialize> Round<I> for Round2<P,
 
     fn verify_message(
         &self,
+        rng: &mut impl CryptoRngCore,
         from: &I,
         broadcast_msg: Self::BroadcastMessage,
         _direct_msg: Self::DirectMessage,
@@ -235,11 +237,11 @@ impl<P: SchemeParams, I: Debug + Clone + Ord + Serialize> Round<I> for Round2<P,
         let (key_init_message, key_refresh_message) = broadcast_msg;
         let key_init_payload = self
             .key_init_round
-            .verify_message(from, key_init_message, ())
+            .verify_message(rng, from, key_init_message, ())
             .map_err(KeyGenError::KeyInit)?;
         let key_refresh_payload = self
             .key_refresh_round
-            .verify_message(from, key_refresh_message, ())
+            .verify_message(rng, from, key_refresh_message, ())
             .map_err(KeyGenError::KeyRefresh)?;
         Ok((key_init_payload, key_refresh_payload))
     }
@@ -323,6 +325,7 @@ impl<P: SchemeParams, I: Debug + Clone + Ord + Serialize> Round<I> for Round3<P,
 
     fn verify_message(
         &self,
+        rng: &mut impl CryptoRngCore,
         from: &I,
         broadcast_msg: Self::BroadcastMessage,
         direct_msg: Self::DirectMessage,
@@ -330,11 +333,11 @@ impl<P: SchemeParams, I: Debug + Clone + Ord + Serialize> Round<I> for Round3<P,
         #[allow(clippy::let_unit_value)]
         let key_init_payload = self
             .key_init_round
-            .verify_message(from, broadcast_msg, ())
+            .verify_message(rng, from, broadcast_msg, ())
             .map_err(KeyGenError::KeyInit)?;
         let key_refresh_payload = self
             .key_refresh_round
-            .verify_message(from, (), direct_msg)
+            .verify_message(rng, from, (), direct_msg)
             .map_err(KeyGenError::KeyRefresh)?;
         Ok((key_init_payload, key_refresh_payload))
     }

--- a/synedrion/src/cggmp21/protocols/key_init.rs
+++ b/synedrion/src/cggmp21/protocols/key_init.rs
@@ -167,6 +167,7 @@ impl<P: SchemeParams, I: Clone + Ord + Serialize + Debug> Round<I> for Round1<P,
 
     fn verify_message(
         &self,
+        _rng: &mut impl CryptoRngCore,
         _from: &I,
         broadcast_msg: Self::BroadcastMessage,
         _direct_msg: Self::DirectMessage,
@@ -244,6 +245,7 @@ impl<P: SchemeParams, I: Serialize + Ord + Clone + Debug> Round<I> for Round2<P,
 
     fn verify_message(
         &self,
+        _rng: &mut impl CryptoRngCore,
         from: &I,
         broadcast_msg: Self::BroadcastMessage,
         _direct_msg: Self::DirectMessage,
@@ -334,6 +336,7 @@ impl<P: SchemeParams, I: Serialize + Ord + Clone + Debug> Round<I> for Round3<P,
 
     fn verify_message(
         &self,
+        _rng: &mut impl CryptoRngCore,
         from: &I,
         broadcast_msg: Self::BroadcastMessage,
         _direct_msg: Self::DirectMessage,

--- a/synedrion/src/cggmp21/protocols/key_refresh.rs
+++ b/synedrion/src/cggmp21/protocols/key_refresh.rs
@@ -256,6 +256,7 @@ impl<P: SchemeParams, I: Debug + Clone + Ord + Serialize> Round<I> for Round1<P,
 
     fn verify_message(
         &self,
+        _rng: &mut impl CryptoRngCore,
         _from: &I,
         broadcast_msg: Self::BroadcastMessage,
         _direct_msg: Self::DirectMessage,
@@ -335,6 +336,7 @@ impl<P: SchemeParams, I: Debug + Clone + Ord + Serialize> Round<I> for Round2<P,
 
     fn verify_message(
         &self,
+        _rng: &mut impl CryptoRngCore,
         from: &I,
         broadcast_msg: Self::BroadcastMessage,
         _direct_msg: Self::DirectMessage,
@@ -534,6 +536,7 @@ impl<P: SchemeParams, I: Debug + Clone + Ord + Serialize> Round<I> for Round3<P,
 
     fn verify_message(
         &self,
+        rng: &mut impl CryptoRngCore,
         from: &I,
         _broadcast_msg: Self::BroadcastMessage,
         direct_msg: Self::DirectMessage,
@@ -565,7 +568,7 @@ impl<P: SchemeParams, I: Debug + Clone + Ord + Serialize> Round<I> for Round3<P,
         if !direct_msg
             .data2
             .psi_mod
-            .verify(&sender_data.paillier_pk, &aux)
+            .verify(rng, &sender_data.paillier_pk, &aux)
         {
             return Err(KeyRefreshError(KeyRefreshErrorEnum::Round3(
                 "Mod proof verification failed".into(),

--- a/synedrion/src/cggmp21/protocols/presigning.rs
+++ b/synedrion/src/cggmp21/protocols/presigning.rs
@@ -192,6 +192,7 @@ impl<P: SchemeParams, I: Debug + Clone + Ord + Serialize> Round<I> for Round1<P,
 
     fn verify_message(
         &self,
+        _rng: &mut impl CryptoRngCore,
         from: &I,
         broadcast_msg: Self::BroadcastMessage,
         direct_msg: Self::DirectMessage,
@@ -438,6 +439,7 @@ impl<P: SchemeParams, I: Debug + Clone + Ord + Serialize> Round<I> for Round2<P,
 
     fn verify_message(
         &self,
+        _rng: &mut impl CryptoRngCore,
         from: &I,
         _broadcast_msg: Self::BroadcastMessage,
         direct_msg: Self::DirectMessage,
@@ -653,6 +655,7 @@ impl<P: SchemeParams, I: Debug + Clone + Ord + Serialize> Round<I> for Round3<P,
 
     fn verify_message(
         &self,
+        _rng: &mut impl CryptoRngCore,
         from: &I,
         _broadcast_msg: Self::BroadcastMessage,
         direct_msg: Self::DirectMessage,

--- a/synedrion/src/cggmp21/protocols/signing.rs
+++ b/synedrion/src/cggmp21/protocols/signing.rs
@@ -132,6 +132,7 @@ impl<P: SchemeParams, I: Debug + Clone + Ord + Serialize> Round<I> for Round1<P,
 
     fn verify_message(
         &self,
+        _rng: &mut impl CryptoRngCore,
         _from: &I,
         broadcast_msg: Self::BroadcastMessage,
         _direct_msg: Self::DirectMessage,

--- a/synedrion/src/cggmp21/sigma/mod_.rs
+++ b/synedrion/src/cggmp21/sigma/mod_.rs
@@ -2,7 +2,7 @@
 
 use alloc::vec::Vec;
 
-use rand_core::{CryptoRngCore, OsRng};
+use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
 
 use super::super::SchemeParams;
@@ -137,6 +137,7 @@ impl<P: SchemeParams> ModProof<P> {
 
     pub fn verify(
         &self,
+        rng: &mut impl CryptoRngCore,
         pk: &PublicKeyPaillierPrecomputed<P::Paillier>,
         aux: &impl Hashable,
     ) -> bool {
@@ -153,8 +154,7 @@ impl<P: SchemeParams> ModProof<P> {
         // It is possible to pass the external RNG similarly to how it's done for `new()`,
         // but it would require quite a bit of changes because an external RNG is not accessible
         // at the callsite.
-        // TODO (#105): consider if we should keep using the default RNG here.
-        if pk.modulus().is_prime_with_rng(&mut OsRng) {
+        if pk.modulus().is_prime_with_rng(rng) {
             return false;
         }
 
@@ -202,6 +202,6 @@ mod tests {
         let aux: &[u8] = b"abcde";
 
         let proof = ModProof::<Params>::new(&mut OsRng, &sk, &aux);
-        assert!(proof.verify(pk, &aux));
+        assert!(proof.verify(&mut OsRng, pk, &aux));
     }
 }

--- a/synedrion/src/rounds/generic.rs
+++ b/synedrion/src/rounds/generic.rs
@@ -66,6 +66,7 @@ pub(crate) trait Round<I: Ord + Clone> {
     // in the received message, from which we can construct `broadcast_msg`.
     fn verify_message(
         &self,
+        rng: &mut impl CryptoRngCore,
         from: &I,
         broadcast_msg: Self::BroadcastMessage,
         direct_msg: Self::DirectMessage,

--- a/synedrion/src/rounds/test_utils.rs
+++ b/synedrion/src/rounds/test_utils.rs
@@ -93,7 +93,7 @@ where
     for (to, from, (broadcast, direct)) in messages.into_iter() {
         let round = &rounds[&to];
         let payload = round
-            .verify_message(&from, broadcast, direct)
+            .verify_message(rng, &from, broadcast, direct)
             .map_err(|err| StepError::Receive(format!("{:?}", err)))?;
         payload_accums.get_mut(&to).unwrap().insert(from, payload);
     }

--- a/synedrion/src/rounds/wrappers.rs
+++ b/synedrion/src/rounds/wrappers.rs
@@ -75,12 +75,13 @@ impl<I: Ord + Clone, T: RoundWrapper<I> + WrappedRound> Round<I> for T {
 
     fn verify_message(
         &self,
+        rng: &mut impl CryptoRngCore,
         from: &I,
         broadcast_msg: Self::BroadcastMessage,
         direct_msg: Self::DirectMessage,
     ) -> Result<Self::Payload, <Self::Result as ProtocolResult>::ProvableError> {
         self.inner_round()
-            .verify_message(from, broadcast_msg, direct_msg)
+            .verify_message(rng, from, broadcast_msg, direct_msg)
             .map_err(Self::Result::wrap_error)
     }
     fn finalization_requirement() -> FinalizationRequirement {

--- a/synedrion/src/sessions/session.rs
+++ b/synedrion/src/sessions/session.rs
@@ -446,6 +446,7 @@ where
     /// Process a received message from another party.
     pub fn process_message(
         &self,
+        rng: &mut impl CryptoRngCore,
         preprocessed: PreprocessedMessage<Sig, Verifier>,
     ) -> Result<ProcessedMessage<Sig, Verifier>, Error<Res, Verifier>> {
         let from = preprocessed.from;
@@ -453,6 +454,7 @@ where
         match &self.tp {
             SessionType::Normal { this_round, .. } => {
                 let result = this_round.verify_message(
+                    rng,
                     &from,
                     message.broadcast_payload(),
                     message.direct_payload(),

--- a/synedrion/src/sessions/type_erased.rs
+++ b/synedrion/src/sessions/type_erased.rs
@@ -109,6 +109,7 @@ pub(crate) trait DynRound<I, Res: ProtocolResult>: Send + Sync {
     ) -> Result<(Option<Box<[u8]>>, DynArtifact), LocalError>;
     fn verify_message(
         &self,
+        rng: &mut dyn CryptoRngCore,
         from: &I,
         broadcast_data: Option<&[u8]>,
         direct_data: Option<&[u8]>,
@@ -188,6 +189,7 @@ where
 
     fn verify_message(
         &self,
+        rng: &mut dyn CryptoRngCore,
         from: &I,
         broadcast_data: Option<&[u8]>,
         direct_data: Option<&[u8]>,
@@ -229,8 +231,10 @@ where
             Err(err) => return Err(ReceiveError::CannotDeserialize(err)),
         };
 
+        let mut boxed_rng = BoxedRng(rng);
+
         let payload = self
-            .verify_message(from, broadcast_message, direct_message)
+            .verify_message(&mut boxed_rng, from, broadcast_message, direct_message)
             .map_err(ReceiveError::Protocol)?;
 
         Ok(DynPayload(Box::new(payload)))

--- a/synedrion/src/www02/key_resharing.rs
+++ b/synedrion/src/www02/key_resharing.rs
@@ -231,6 +231,7 @@ impl<P: SchemeParams, I: Clone + Ord + Debug> Round<I> for Round1<P, I> {
 
     fn verify_message(
         &self,
+        _rng: &mut impl CryptoRngCore,
         from: &I,
         broadcast_msg: Self::BroadcastMessage,
         direct_msg: Self::DirectMessage,

--- a/synedrion/tests/sessions.rs
+++ b/synedrion/tests/sessions.rs
@@ -65,7 +65,7 @@ async fn run_session<Res: ProtocolResult>(
         for preprocessed in cached_messages {
             // In production usage, this will happen in a spawned task.
             println!("{key_str}: applying a cached message");
-            let result = session.process_message(preprocessed).unwrap();
+            let result = session.process_message(&mut OsRng, preprocessed).unwrap();
 
             // This will happen in a host task.
             accum.add_processed_message(result).unwrap().unwrap();
@@ -87,7 +87,7 @@ async fn run_session<Res: ProtocolResult>(
             if let Some(preprocessed) = preprocessed {
                 // In production usage, this will happen in a spawned task.
                 println!("{key_str}: applying a message from {}", key_to_str(&from));
-                let result = session.process_message(preprocessed).unwrap();
+                let result = session.process_message(&mut OsRng, preprocessed).unwrap();
 
                 // This will happen in a host task.
                 accum.add_processed_message(result).unwrap().unwrap();

--- a/synedrion/tests/threshold.rs
+++ b/synedrion/tests/threshold.rs
@@ -66,7 +66,7 @@ async fn run_session<Res: ProtocolResult>(
         for preprocessed in cached_messages {
             // In production usage, this will happen in a spawned task.
             println!("{key_str}: applying a cached message");
-            let result = session.process_message(preprocessed).unwrap();
+            let result = session.process_message(&mut OsRng, preprocessed).unwrap();
 
             // This will happen in a host task.
             accum.add_processed_message(result).unwrap().unwrap();
@@ -88,7 +88,7 @@ async fn run_session<Res: ProtocolResult>(
             if let Some(preprocessed) = preprocessed {
                 // In production usage, this will happen in a spawned task.
                 println!("{key_str}: applying a message from {}", key_to_str(&from));
-                let result = session.process_message(preprocessed).unwrap();
+                let result = session.process_message(&mut OsRng, preprocessed).unwrap();
 
                 // This will happen in a host task.
                 accum.add_processed_message(result).unwrap().unwrap();


### PR DESCRIPTION
- Add a CI step to test building on the WASM target
- Add the RNG parameter to `Round::verify_message()`. Fixes #105