### PR TITLE
Bump `bincode` and `secrecy` for `no_std` builds

### DIFF
--- a/synedrion/Cargo.toml
+++ b/synedrion/Cargo.toml
@@ -29,7 +29,7 @@ crypto-bigint = { version = "0.5.3", default-features = false, features = ["serd
 crypto-primes = { version = "0.5", default-features = false }
 
 serde = { version = "1", default-features = false, features = ["derive"] }
-bincode = "1"
+bincode = { version = "2.0.0-rc.3", default-features = false, features = ["serde", "alloc"] }
 displaydoc = { version = "0.2", default-features = false}
 
 [dev-dependencies]

--- a/synedrion/Cargo.toml
+++ b/synedrion/Cargo.toml
@@ -19,7 +19,7 @@ digest = { version = "0.10", default-features = false, features = ["alloc"]}
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 base64 = { version = "0.21", default-features = false, features = ["alloc"] }
 hashing-serializer = { version = "0.1", default-features = false }
-secrecy = { version = "0.8", default-features = false, features = ["alloc", "serde"] }
+secrecy = { version = "0.9.0-pre.0", default-features = false, features = ["serde"] }
 zeroize = { version = "1.8", default-features = false, features = ["alloc", "zeroize_derive"] }
 bip32 = { version = "0.5.2", default-features = false, features = ["alloc", "secp256k1"] }
 

--- a/synedrion/src/cggmp21/entities.rs
+++ b/synedrion/src/cggmp21/entities.rs
@@ -1,5 +1,5 @@
-use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::boxed::Box;
+use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::vec::Vec;
 use core::fmt::Debug;
 use core::marker::PhantomData;
@@ -130,9 +130,9 @@ impl<P: SchemeParams, I: Clone + Ord + PartialEq + Debug> KeyShare<P, I> {
         // TODO (#68): check that party_idx is the same for both, and the number of parties is the same
         assert_eq!(self.owner, change.owner);
 
-        let secret_share = SecretBox::new(
-            Box::new(self.secret_share.expose_secret() + change.secret_share_change.expose_secret()),
-        );
+        let secret_share = SecretBox::new(Box::new(
+            self.secret_share.expose_secret() + change.secret_share_change.expose_secret(),
+        ));
         let public_shares = self
             .public_shares
             .iter()
@@ -407,7 +407,9 @@ impl<P: SchemeParams, I: Ord + Clone + PartialEq> PresigningData<P, I> {
                 PresigningData {
                     nonce,
                     ephemeral_scalar_share: SecretBox::new(Box::new(k_i)),
-                    product_share: SecretBox::new(Box::new(P::scalar_from_signed(&product_share_nonreduced))),
+                    product_share: SecretBox::new(Box::new(P::scalar_from_signed(
+                        &product_share_nonreduced,
+                    ))),
                     product_share_nonreduced,
                     cap_k: all_cap_k[&id_i].clone(),
                     values,

--- a/synedrion/src/cggmp21/protocols/aux_gen.rs
+++ b/synedrion/src/cggmp21/protocols/aux_gen.rs
@@ -1,9 +1,9 @@
 //! AuxGen protocol, a part of the paper's Auxiliary Info. & Key Refresh in Three Rounds (Fig. 6)
 //! that only generates the auxiliary data.
 
+use alloc::boxed::Box;
 use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::string::String;
-use alloc::boxed::Box;
 use core::fmt::Debug;
 use core::marker::PhantomData;
 

--- a/synedrion/src/cggmp21/protocols/aux_gen.rs
+++ b/synedrion/src/cggmp21/protocols/aux_gen.rs
@@ -3,11 +3,12 @@
 
 use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::string::String;
+use alloc::boxed::Box;
 use core::fmt::Debug;
 use core::marker::PhantomData;
 
 use rand_core::CryptoRngCore;
-use secrecy::Secret;
+use secrecy::SecretBox;
 use serde::{Deserialize, Serialize};
 
 use super::super::{
@@ -526,7 +527,7 @@ impl<P: SchemeParams, I: Debug + Clone + Ord + Serialize> FinalizableToResult<I>
 
         let secret_aux = SecretAuxInfo {
             paillier_sk: self.context.paillier_sk.to_minimal(),
-            el_gamal_sk: Secret::new(self.context.y),
+            el_gamal_sk: SecretBox::new(Box::new(self.context.y)),
         };
 
         let aux_info = AuxInfo {

--- a/synedrion/src/cggmp21/protocols/key_init.rs
+++ b/synedrion/src/cggmp21/protocols/key_init.rs
@@ -3,11 +3,12 @@
 //! auxiliary parameters need to be generated as well (during the KeyRefresh protocol).
 
 use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::boxed::Box;
 use core::fmt::Debug;
 use core::marker::PhantomData;
 
 use rand_core::CryptoRngCore;
-use secrecy::Secret;
+use secrecy::SecretBox;
 use serde::{Deserialize, Serialize};
 
 use super::super::{
@@ -367,7 +368,7 @@ impl<P: SchemeParams, I: Serialize + Clone + Ord + Debug> FinalizableToResult<I>
         public_shares.insert(my_id.clone(), self.context.public_data.cap_x);
         Ok(KeyShare {
             owner: my_id,
-            secret_share: Secret::new(self.context.x),
+            secret_share: SecretBox::new(Box::new(self.context.x)),
             public_shares,
             phantom: PhantomData,
         })

--- a/synedrion/src/cggmp21/protocols/key_init.rs
+++ b/synedrion/src/cggmp21/protocols/key_init.rs
@@ -2,8 +2,8 @@
 //! Note that this protocol only generates the key itself which is not enough to perform signing;
 //! auxiliary parameters need to be generated as well (during the KeyRefresh protocol).
 
-use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::boxed::Box;
+use alloc::collections::{BTreeMap, BTreeSet};
 use core::fmt::Debug;
 use core::marker::PhantomData;
 

--- a/synedrion/src/cggmp21/protocols/key_refresh.rs
+++ b/synedrion/src/cggmp21/protocols/key_refresh.rs
@@ -3,13 +3,14 @@
 //! for ZK proofs (e.g. Paillier keys).
 
 use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt::Debug;
 use core::marker::PhantomData;
 
 use rand_core::CryptoRngCore;
-use secrecy::Secret;
+use secrecy::SecretBox;
 use serde::{Deserialize, Serialize};
 
 use super::super::{
@@ -662,12 +663,12 @@ impl<P: SchemeParams, I: Debug + Clone + Ord + Serialize> FinalizableToResult<I>
 
         let secret_aux = SecretAuxInfo {
             paillier_sk: self.context.paillier_sk.to_minimal(),
-            el_gamal_sk: Secret::new(self.context.y),
+            el_gamal_sk: SecretBox::new(Box::new(self.context.y)),
         };
 
         let key_share_change = KeyShareChange {
             owner: my_id.clone(),
-            secret_share_change: Secret::new(x_star),
+            secret_share_change: SecretBox::new(Box::new(x_star)),
             public_share_changes: cap_x_star,
             phantom: PhantomData,
         };

--- a/synedrion/src/cggmp21/protocols/key_refresh.rs
+++ b/synedrion/src/cggmp21/protocols/key_refresh.rs
@@ -2,8 +2,8 @@
 //! This protocol generates an update to the secret key shares and new auxiliary parameters
 //! for ZK proofs (e.g. Paillier keys).
 
-use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::boxed::Box;
+use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt::Debug;

--- a/synedrion/src/cggmp21/protocols/presigning.rs
+++ b/synedrion/src/cggmp21/protocols/presigning.rs
@@ -1,7 +1,7 @@
 //! Presigning protocol, in the paper ECDSA Pre-Signing (Fig. 7).
 
-use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::boxed::Box;
+use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt::Debug;

--- a/synedrion/src/cggmp21/protocols/presigning.rs
+++ b/synedrion/src/cggmp21/protocols/presigning.rs
@@ -1,13 +1,14 @@
 //! Presigning protocol, in the paper ECDSA Pre-Signing (Fig. 7).
 
 use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt::Debug;
 use core::marker::PhantomData;
 
 use rand_core::CryptoRngCore;
-use secrecy::{ExposeSecret, Secret};
+use secrecy::{ExposeSecret, SecretBox};
 use serde::{Deserialize, Serialize};
 
 use super::super::{
@@ -733,8 +734,8 @@ impl<P: SchemeParams, I: Debug + Clone + Ord + Serialize> FinalizableToResult<I>
 
             return Ok(PresigningData {
                 nonce,
-                ephemeral_scalar_share: Secret::new(self.context.k),
-                product_share: Secret::new(P::scalar_from_signed(&self.chi)),
+                ephemeral_scalar_share: SecretBox::new(Box::new(self.context.k)),
+                product_share: SecretBox::new(Box::new(P::scalar_from_signed(&self.chi))),
                 product_share_nonreduced: self.chi,
                 cap_k: self.all_cap_k[&my_id].clone(),
                 values,

--- a/synedrion/src/curve/arithmetic.rs
+++ b/synedrion/src/curve/arithmetic.rs
@@ -24,7 +24,7 @@ use k256::{
     Secp256k1,
 };
 use rand_core::CryptoRngCore;
-use secrecy::{CloneableSecret, SecretBox, SerializableSecret};
+use secrecy::{CloneableSecret, SerializableSecret};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use zeroize::DefaultIsZeroes;
 
@@ -163,8 +163,6 @@ impl<'de> Deserialize<'de> for Scalar {
 }
 
 impl DefaultIsZeroes for Scalar {}
-
-// impl DebugSecret for Scalar {}
 
 impl CloneableSecret for Scalar {}
 

--- a/synedrion/src/curve/arithmetic.rs
+++ b/synedrion/src/curve/arithmetic.rs
@@ -24,7 +24,7 @@ use k256::{
     Secp256k1,
 };
 use rand_core::CryptoRngCore;
-use secrecy::{CloneableSecret, DebugSecret, SerializableSecret};
+use secrecy::{CloneableSecret, SecretBox, SerializableSecret};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use zeroize::DefaultIsZeroes;
 
@@ -164,7 +164,7 @@ impl<'de> Deserialize<'de> for Scalar {
 
 impl DefaultIsZeroes for Scalar {}
 
-impl DebugSecret for Scalar {}
+// impl DebugSecret for Scalar {}
 
 impl CloneableSecret for Scalar {}
 

--- a/synedrion/src/paillier/keys.rs
+++ b/synedrion/src/paillier/keys.rs
@@ -1,7 +1,6 @@
 use core::fmt::Debug;
 
 use rand_core::CryptoRngCore;
-// use secrecy::DebugSecret;
 use serde::{Deserialize, Serialize};
 use zeroize::ZeroizeOnDrop;
 

--- a/synedrion/src/paillier/keys.rs
+++ b/synedrion/src/paillier/keys.rs
@@ -1,4 +1,4 @@
-use core::fmt::{self, Debug};
+use core::fmt::Debug;
 
 use rand_core::CryptoRngCore;
 // use secrecy::DebugSecret;
@@ -12,19 +12,11 @@ use crate::uint::{
     RandomPrimeWithRng, Retrieve, Signed, UintLike, UintModLike,
 };
 
-#[derive(Clone, Serialize, Deserialize, ZeroizeOnDrop, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize, ZeroizeOnDrop)]
 pub(crate) struct SecretKeyPaillier<P: PaillierParams> {
     p: P::HalfUint,
     q: P::HalfUint,
 }
-
-// impl<P: PaillierParams> DebugSecret for SecretKeyPaillier<P> {}
-
-// impl<P: PaillierParams> Debug for SecretKeyPaillier<P> {
-//     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-//         Self::debug_secret(f)
-//     }
-// }
 
 impl<P: PaillierParams> SecretKeyPaillier<P> {
     pub fn random(rng: &mut impl CryptoRngCore) -> Self {

--- a/synedrion/src/paillier/keys.rs
+++ b/synedrion/src/paillier/keys.rs
@@ -11,10 +11,18 @@ use crate::uint::{
     RandomPrimeWithRng, Retrieve, Signed, UintLike, UintModLike,
 };
 
-#[derive(Clone, Debug, Serialize, Deserialize, ZeroizeOnDrop)]
+#[derive(Clone, Serialize, Deserialize, ZeroizeOnDrop)]
 pub(crate) struct SecretKeyPaillier<P: PaillierParams> {
     p: P::HalfUint,
     q: P::HalfUint,
+}
+
+impl<P: PaillierParams> Debug for SecretKeyPaillier<P> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
+        f.write_str("[REDACTED ")?;
+        f.write_str(core::any::type_name::<Self>())?;
+        f.write_str("]")
+    }
 }
 
 impl<P: PaillierParams> SecretKeyPaillier<P> {

--- a/synedrion/src/paillier/keys.rs
+++ b/synedrion/src/paillier/keys.rs
@@ -1,7 +1,7 @@
 use core::fmt::{self, Debug};
 
 use rand_core::CryptoRngCore;
-use secrecy::DebugSecret;
+// use secrecy::DebugSecret;
 use serde::{Deserialize, Serialize};
 use zeroize::ZeroizeOnDrop;
 
@@ -12,19 +12,19 @@ use crate::uint::{
     RandomPrimeWithRng, Retrieve, Signed, UintLike, UintModLike,
 };
 
-#[derive(Clone, Serialize, Deserialize, ZeroizeOnDrop)]
+#[derive(Clone, Serialize, Deserialize, ZeroizeOnDrop, Debug)]
 pub(crate) struct SecretKeyPaillier<P: PaillierParams> {
     p: P::HalfUint,
     q: P::HalfUint,
 }
 
-impl<P: PaillierParams> DebugSecret for SecretKeyPaillier<P> {}
+// impl<P: PaillierParams> DebugSecret for SecretKeyPaillier<P> {}
 
-impl<P: PaillierParams> Debug for SecretKeyPaillier<P> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        Self::debug_secret(f)
-    }
-}
+// impl<P: PaillierParams> Debug for SecretKeyPaillier<P> {
+//     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+//         Self::debug_secret(f)
+//     }
+// }
 
 impl<P: PaillierParams> SecretKeyPaillier<P> {
     pub fn random(rng: &mut impl CryptoRngCore) -> Self {

--- a/synedrion/src/sessions/type_erased.rs
+++ b/synedrion/src/sessions/type_erased.rs
@@ -18,7 +18,7 @@ use crate::rounds::{
 };
 
 pub(crate) fn serialize_message(message: &impl Serialize) -> Result<Box<[u8]>, LocalError> {
-    bincode::serde::encode_to_vec(message, bincode::config::legacy())
+    bincode::serde::encode_to_vec(message, bincode::config::standard())
         .map(|serialized| serialized.into_boxed_slice())
         .map_err(|err| LocalError(format!("Failed to serialize: {err:?}")))
 }
@@ -26,7 +26,7 @@ pub(crate) fn serialize_message(message: &impl Serialize) -> Result<Box<[u8]>, L
 pub(crate) fn deserialize_message<M: for<'de> Deserialize<'de>>(
     message_bytes: &[u8],
 ) -> Result<M, String> {
-    bincode::serde::decode_borrowed_from_slice(message_bytes, bincode::config::legacy())
+    bincode::serde::decode_borrowed_from_slice(message_bytes, bincode::config::standard())
         .map_err(|err| err.to_string())
 }
 

--- a/synedrion/src/sessions/type_erased.rs
+++ b/synedrion/src/sessions/type_erased.rs
@@ -18,7 +18,7 @@ use crate::rounds::{
 };
 
 pub(crate) fn serialize_message(message: &impl Serialize) -> Result<Box<[u8]>, LocalError> {
-    bincode::serialize(message)
+    bincode::serde::encode_to_vec(message, bincode::config::legacy())
         .map(|serialized| serialized.into_boxed_slice())
         .map_err(|err| LocalError(format!("Failed to serialize: {err:?}")))
 }
@@ -26,7 +26,8 @@ pub(crate) fn serialize_message(message: &impl Serialize) -> Result<Box<[u8]>, L
 pub(crate) fn deserialize_message<M: for<'de> Deserialize<'de>>(
     message_bytes: &[u8],
 ) -> Result<M, String> {
-    bincode::deserialize(message_bytes).map_err(|err| err.to_string())
+    bincode::serde::decode_borrowed_from_slice(message_bytes, bincode::config::legacy())
+        .map_err(|err| err.to_string())
 }
 
 pub(crate) enum FinalizeOutcome<I, Res: ProtocolResult> {

--- a/synedrion/src/www02/key_resharing.rs
+++ b/synedrion/src/www02/key_resharing.rs
@@ -5,8 +5,8 @@
 //! <https://doi.org/10.1109/SISW.2002.1183515>
 //! (Specifically, REDIST protocol).
 
-use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::boxed::Box;
+use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::vec::Vec;
 use core::fmt::Debug;
 use core::marker::PhantomData;

--- a/synedrion/src/www02/key_resharing.rs
+++ b/synedrion/src/www02/key_resharing.rs
@@ -6,13 +6,14 @@
 //! (Specifically, REDIST protocol).
 
 use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::fmt::Debug;
 use core::marker::PhantomData;
 
 use k256::ecdsa::VerifyingKey;
 use rand_core::CryptoRngCore;
-use secrecy::{ExposeSecret, Secret};
+use secrecy::{ExposeSecret, SecretBox};
 use serde::{Deserialize, Serialize};
 
 use super::ThresholdKeyShare;
@@ -349,7 +350,7 @@ impl<P: SchemeParams, I: Ord + Clone + Debug> FinalizableToResult<I> for Round1<
             .iter()
             .map(|id| (payloads[id].old_share_id, payloads[id].subshare))
             .collect::<BTreeMap<_, _>>();
-        let secret_share = Secret::new(shamir_join_scalars(subshares.iter()));
+        let secret_share = SecretBox::new(Box::new(shamir_join_scalars(subshares.iter())));
 
         // Generate the public shares of all the new holders.
         let public_shares = self


### PR DESCRIPTION
I've been strugging to use Synedrion as a dependency in a Substrate pallet due to one of
its dependencies pulling in `std` transitively, as mentioned in https://github.com/entropyxyz/entropy-core/issues/961.

Through a bit of digging I found that the `bincode` and `secrecy` dependencies were
pulling in `serde` without disable default features, causing `std` to be pulled in.

I've updated them to the latest releases which use better feature management to allow
`serde` to not be pulled in with default features. Note that the latest releases are
technically pre-releases.
