### PR TITLE
Compile some deps with O3 level optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,16 @@ members = [
     'synedrion',
 ]
 resolver = "2"
+
+[profile.dev.package."crypto-bigint"]
+opt-level = 3
+[profile.dev.package."crypto-primes"]
+opt-level = 3
+[profile.dev.package."digest"]
+opt-level = 3
+[profile.dev.package."k256"]
+opt-level = 3
+[profile.dev.package."sha2"]
+opt-level = 3
+[profile.dev.package."sha3"]
+opt-level = 3


### PR DESCRIPTION
This PR makes a select number of dependencies compile with the full set of optimizations even in debug mode. Given that dependencies are not often updated, the impact on the dev cycle is pretty small.

On the other hand, the speedup when running the test suite is also pretty small (less than 10% on my M3 CPU).

With O3 opt:

`cargo t  90.81s user 1.04s system 227% cpu 40.331 total`

Without O3 opt:

`cargo t  99.73s user 0.63s system 227% cpu 44.128 total`


