### PR TITLE
Don't clone when preparing Echo broadcast messages

### DIFF
--- a/synedrion/src/sessions/echo.rs
+++ b/synedrion/src/sessions/echo.rs
@@ -55,16 +55,14 @@ where
         &self.destinations
     }
 
-    pub fn make_broadcast(&self) -> Box<[u8]> {
-        let message = Message {
-            broadcasts: self
-                .broadcasts
-                .clone()
-                .into_iter()
-                .map(|(idx, msg)| (idx, msg.into_unverified()))
-                .collect(),
-        };
-        serialize_message(&message).unwrap()
+    /// Serialize an [`EchoRound`] into a bincode encoded [`Message`].
+    pub fn make_broadcast(&self) -> Result<Box<[u8]>, LocalError> {
+        let message: Box<[(_, _)]> = self
+            .broadcasts
+            .iter()
+            .map(|(idx, msg)| (idx, msg.as_unverified()))
+            .collect();
+        serialize_message(&message)
     }
 
     pub fn verify_broadcast(&self, from: &I, payload: &[u8]) -> Result<(), EchoError> {

--- a/synedrion/src/sessions/session.rs
+++ b/synedrion/src/sessions/session.rs
@@ -335,7 +335,7 @@ where
                 echo_round,
             } => {
                 let round_num = next_round.round_num() - 1;
-                let payload = echo_round.make_broadcast();
+                let payload = echo_round.make_broadcast()?;
                 let artifact = DynArtifact::null();
                 let message = VerifiedMessage::new(
                     rng,


### PR DESCRIPTION
Just a small optimization. Given that bincode does not encode struct names anyway, we can get away with serializing a raw `Box` and do the serialization work on references instead.
