### PR TITLE
Return all RustCrypto libs but `crypto-bigint` to stable versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `FirstRound::Context` renamed to `Inputs`. ([#102])
 - `Payload` and `Artifact` values are hidden in wrapper types where they were previously exposed. ([#102])
-- A number of crates set to their `pre` releases hinging on the `pre` release of `crypto-bigint`.
+- A number of crates set to their `pre` releases hinging on the `pre` release of `crypto-bigint`. ([#120])
+- Signature and elliptic curve dependencies reset back to stable versions. (#[154])
 
 
 ### Added
@@ -20,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#96]: https://github.com/entropyxyz/synedrion/pull/96
 [#102]: https://github.com/entropyxyz/synedrion/pull/102
+[#120]: https://github.com/entropyxyz/synedrion/pull/120
+[#154]: https://github.com/entropyxyz/synedrion/pull/154
 
 
 ## [0.1.0] - 2023-12-07

--- a/synedrion/Cargo.toml
+++ b/synedrion/Cargo.toml
@@ -10,22 +10,22 @@ readme = "README.md"
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-signature = { version = "2.3.0-pre.4", default-features = false, features = ["alloc"] }
-k256 = {version = "0.14.0-pre.2", default-features = false, features = ["ecdsa", "arithmetic"]}
+signature = { version = "2", default-features = false, features = ["alloc"] }
+k256 = { version = "0.13", default-features = false, features = ["ecdsa", "arithmetic"] }
 rand_core = { version = "0.6.4", default-features = false, features = ["getrandom"] }
-sha2 = { version = "0.11.0-pre.4", default-features = false }
-sha3 = { version = "0.11.0-pre.4", default-features = false }
-digest = { version = "0.11.0-pre.9", default-features = false, features = ["alloc"]}
+sha2 = { version = "0.10", default-features = false }
+sha3 = { version = "0.10", default-features = false }
+digest = { version = "0.10", default-features = false, features = ["alloc"]}
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
-base64 = { version = "0.22.1", default-features = false, features = ["alloc"] }
-hashing-serializer = { version = "0.2.0-pre.0", default-features = false }
+base64 = { version = "0.22", default-features = false, features = ["alloc"] }
+hashing-serializer = { version = "0.1", default-features = false }
 secrecy = { version = "0.9.0-pre.0", default-features = false, features = ["serde"] }
 zeroize = { version = "1.8", default-features = false, features = ["alloc", "zeroize_derive"] }
-bip32 = { version = "0.6.0-pre.0", default-features = false, features = ["alloc", "secp256k1", "k256"] }
+bip32 = { version = "0.5", default-features = false, features = ["alloc", "secp256k1", "k256"] }
 
 # Note: `alloc` is needed for `crytpto-bigint`'s dependency `serdect` to be able
 # to serialize Uints in human-readable formats.
-crypto-bigint = { version = "0.6.0-rc.2", features = ["serde", "alloc", "rand_core"] }
+crypto-bigint = { version = "0.6.0-rc.2", features = ["serde", "alloc", "rand_core", "zeroize"] }
 crypto-primes = "0.6.0-pre.1"
 
 serde = { version = "1", default-features = false, features = ["derive"] }
@@ -43,7 +43,7 @@ serde_assert = "0.8"
 tokio = { version = "1", features = ["rt", "sync", "time", "macros"] }
 rand = "0.8"
 criterion = "0.5"
-k256 = {version = "0.14.0-pre.2", default-features = false, features = ["ecdsa", "arithmetic", "pem", "serde"]}
+k256 = {version = "0.13", default-features = false, features = ["ecdsa", "arithmetic", "pem", "serde"]}
 impls = "1"
 
 [features]

--- a/synedrion/src/curve/ecdsa.rs
+++ b/synedrion/src/curve/ecdsa.rs
@@ -21,7 +21,7 @@ impl RecoverableSignature {
         // Normalize the `s` component.
         // `BackendSignature`'s constructor does not require `s` to be normalized,
         // but consequent usage of it may fail otherwise.
-        let signature = signature.normalize_s();
+        let signature = signature.normalize_s().unwrap_or(signature);
 
         let message_bytes = message.to_bytes();
         let recovery_id = RecoveryId::trial_recovery_from_prehash(

--- a/synedrion/src/uint.rs
+++ b/synedrion/src/uint.rs
@@ -4,13 +4,13 @@ mod traits;
 
 pub(crate) use crypto_bigint::{
     modular::Retrieve, subtle, CheckedAdd, CheckedMul, CheckedSub, Encoding, Integer, Invert,
-    NonZero, PowBoundedExp, RandomMod, ShlVartime, WrappingSub, Zero, U1024, U2048, U4096, U512,
-    U8192,
+    NonZero, PowBoundedExp, RandomMod, ShlVartime, Uint, WrappingSub, Zero, U1024, U2048, U4096,
+    U512, U8192,
 };
 pub(crate) use crypto_primes::RandomPrimeWithRng;
 
 pub(crate) use bounded::Bounded;
 pub(crate) use signed::Signed;
 pub(crate) use traits::{
-    upcast_uint, Exponentiable, HasWide, ToMontgomery, U1024Mod, U2048Mod, U4096Mod, U512Mod,
+    Exponentiable, HasWide, ToMontgomery, U1024Mod, U2048Mod, U4096Mod, U512Mod,
 };

--- a/synedrion/src/uint/traits.rs
+++ b/synedrion/src/uint/traits.rs
@@ -2,25 +2,11 @@ use crypto_bigint::{
     modular::MontyForm,
     nlimbs,
     subtle::{ConditionallySelectable, CtOption},
-    Bounded, Encoding, Integer, Invert, PowBoundedExp, RandomMod, Square, Uint, Zero, U1024, U2048,
+    Bounded, Encoding, Integer, Invert, PowBoundedExp, RandomMod, Square, Zero, U1024, U2048,
     U4096, U512, U8192,
 };
 
 use crate::uint::Signed;
-
-pub(crate) const fn upcast_uint<const N1: usize, const N2: usize>(value: Uint<N1>) -> Uint<N2> {
-    assert!(
-        N2 >= N1,
-        "Upcast target must be bigger than the upcast candidate"
-    );
-    let mut result_words = [0; N2];
-    let mut i = 0;
-    while i < N1 {
-        result_words[i] = value.as_words()[i];
-        i += 1;
-    }
-    Uint::from_words(result_words)
-}
 
 pub trait ToMontgomery: Integer {
     fn to_montgomery(
@@ -252,31 +238,3 @@ impl Exponentiable<U512> for U512Mod {}
 impl Exponentiable<U1024> for U1024Mod {}
 impl Exponentiable<U2048> for U2048Mod {}
 impl Exponentiable<U4096> for U4096Mod {}
-
-#[cfg(test)]
-mod tests {
-    use super::upcast_uint;
-    use crypto_bigint::{U256, U64};
-    #[test]
-    fn upcast_uint_results_in_a_bigger_type() {
-        let n = U64::from_u8(10);
-        let expected = U256::from_u8(10);
-        let bigger_n: U256 = upcast_uint(n);
-
-        assert_eq!(bigger_n, expected);
-    }
-
-    #[test]
-    #[should_panic(expected = "Upcast target must be bigger than the upcast candidate")]
-    fn upcast_uint_panics_in_test_if_actually_attempting_downcast() {
-        let n256 = U256::from_u8(8);
-        let _n: U64 = upcast_uint(n256);
-    }
-
-    #[test]
-    fn upcast_uint_allows_casting_to_same_size() {
-        let n256 = U256::from_u8(8);
-        let n: U256 = upcast_uint(n256);
-        assert_eq!(n, n256)
-    }
-}


### PR DESCRIPTION
This will make it possible for `entropy-core` to still use our `master` branch. `crypto-bigint` can stay at the pre-release since it is not directly exposed to the user.