### PR TITLE
Assorted fixes

### DIFF
--- a/synedrion/Cargo.toml
+++ b/synedrion/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 signature = { version = "2", default-features = false, features = ["alloc"] }
 k256 = { version = "0.13", default-features = false, features = ["ecdsa", "arithmetic"] }
-rand_core = { version = "0.6.4", default-features = false, features = ["getrandom"] }
+rand_core = { version = "0.6.4", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 sha3 = { version = "0.10", default-features = false }
 digest = { version = "0.10", default-features = false, features = ["alloc"]}
@@ -25,17 +25,13 @@ bip32 = { version = "0.5", default-features = false, features = ["alloc", "secp2
 
 # Note: `alloc` is needed for `crytpto-bigint`'s dependency `serdect` to be able
 # to serialize Uints in human-readable formats.
-crypto-bigint = { version = "0.6.0-rc.2", features = ["serde", "alloc", "rand_core", "zeroize"] }
-crypto-primes = "0.6.0-pre.1"
+crypto-bigint = { version = "0.6.0-rc.2", default-features = false, features = ["serde", "alloc", "rand_core", "zeroize"] }
+crypto-primes = { version = "0.6.0-pre.1", default-features = false }
 
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde-encoded-bytes = { version = "0.1", default-features = false, features = ["hex", "base64"] }
 bincode = { version = "2.0.0-rc.3", default-features = false, features = ["serde", "alloc"] }
-displaydoc = { version = "0.2", default-features = false}
-
-# Note: needed for the `rand_core` feature of `crypto-bigint`.
-[target.wasm32-unknown-unknown.dependencies]
-getrandom = { version = "0.2", features = ["js"]}
+displaydoc = { version = "0.2", default-features = false }
 
 [dev-dependencies]
 rand_chacha = "0.3"

--- a/synedrion/Cargo.toml
+++ b/synedrion/Cargo.toml
@@ -19,7 +19,7 @@ digest = { version = "0.10", default-features = false, features = ["alloc"]}
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 base64 = { version = "0.22", default-features = false, features = ["alloc"] }
 hashing-serializer = { version = "0.1", default-features = false }
-secrecy = { version = "0.9.0-pre.0", default-features = false, features = ["serde"] }
+secrecy = { version = "0.10", default-features = false, features = ["serde"] }
 zeroize = { version = "1.8", default-features = false, features = ["alloc", "zeroize_derive"] }
 bip32 = { version = "0.5", default-features = false, features = ["alloc", "secp256k1", "k256"] }
 

--- a/synedrion/Cargo.toml
+++ b/synedrion/Cargo.toml
@@ -25,8 +25,8 @@ bip32 = { version = "0.5", default-features = false, features = ["alloc", "secp2
 
 # Note: `alloc` is needed for `crytpto-bigint`'s dependency `serdect` to be able
 # to serialize Uints in human-readable formats.
-crypto-bigint = { version = "0.6.0-rc.2", default-features = false, features = ["serde", "alloc", "rand_core", "zeroize"] }
-crypto-primes = { version = "0.6.0-pre.1", default-features = false }
+crypto-bigint = { version = "0.6.0-rc.6", default-features = false, features = ["serde", "alloc", "rand_core", "zeroize"] }
+crypto-primes = { version = "0.6.0-pre.2", default-features = false }
 
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde-encoded-bytes = { version = "0.1", default-features = false, features = ["hex", "base64"] }

--- a/synedrion/Cargo.toml
+++ b/synedrion/Cargo.toml
@@ -16,8 +16,6 @@ rand_core = { version = "0.6.4", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 sha3 = { version = "0.10", default-features = false }
 digest = { version = "0.10", default-features = false, features = ["alloc"]}
-hex = { version = "0.4", default-features = false, features = ["alloc"] }
-base64 = { version = "0.22", default-features = false, features = ["alloc"] }
 hashing-serializer = { version = "0.1", default-features = false }
 secrecy = { version = "0.10", default-features = false, features = ["serde"] }
 zeroize = { version = "1.8", default-features = false, features = ["alloc", "zeroize_derive"] }
@@ -41,6 +39,7 @@ rand = "0.8"
 criterion = "0.5"
 k256 = {version = "0.13", default-features = false, features = ["ecdsa", "arithmetic", "pem", "serde"]}
 impls = "1"
+hex = { version = "0.4", default-features = false, features = ["alloc"] }
 
 [features]
 bench-internals = [] # makes some internal functions public to allow external benchmarks

--- a/synedrion/src/paillier/encryption.rs
+++ b/synedrion/src/paillier/encryption.rs
@@ -28,7 +28,7 @@ impl<P: PaillierParams> Randomizer<P> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ZeroizeOnDrop, Zeroize)]
+#[derive(Debug, Clone, PartialEq, Eq, ZeroizeOnDrop)]
 pub(crate) struct RandomizerMod<P: PaillierParams>(P::UintMod);
 
 impl<P: PaillierParams> RandomizerMod<P> {

--- a/synedrion/src/paillier/keys.rs
+++ b/synedrion/src/paillier/keys.rs
@@ -11,9 +11,7 @@ use crate::uint::{
     Bounded, CheckedAdd, CheckedSub, HasWide, Integer, Invert, NonZero, PowBoundedExp, RandomMod,
     RandomPrimeWithRng, Retrieve, Signed, ToMontgomery,
 };
-use crypto_bigint::{
-    Bounded as TraitBounded, InvMod, Monty, Odd, ShrVartime, Square, WrappingAdd, WrappingSub,
-};
+use crypto_bigint::{InvMod, Monty, Odd, ShrVartime, Square, WrappingAdd, WrappingSub};
 use secrecy::{ExposeSecret, SecretBox};
 
 #[derive(Debug, Deserialize, ZeroizeOnDrop, Zeroize)]
@@ -49,16 +47,8 @@ impl<P: PaillierParams> Serialize for SecretKeyPaillier<P> {
 
 impl<P: PaillierParams> SecretKeyPaillier<P> {
     pub fn random(rng: &mut impl CryptoRngCore) -> Self {
-        let p = P::HalfUint::generate_safe_prime_with_rng(
-            rng,
-            P::PRIME_BITS as u32,
-            <P as PaillierParams>::HalfUint::BITS,
-        );
-        let q = P::HalfUint::generate_safe_prime_with_rng(
-            rng,
-            P::PRIME_BITS as u32,
-            <P as PaillierParams>::HalfUint::BITS,
-        );
+        let p = P::HalfUint::generate_safe_prime_with_rng(rng, P::PRIME_BITS as u32);
+        let q = P::HalfUint::generate_safe_prime_with_rng(rng, P::PRIME_BITS as u32);
 
         Self {
             p: Box::new(p).into(),

--- a/synedrion/src/paillier/keys.rs
+++ b/synedrion/src/paillier/keys.rs
@@ -3,7 +3,7 @@ use core::fmt::Debug;
 
 use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
-use zeroize::{Zeroize, ZeroizeOnDrop};
+use zeroize::Zeroize;
 
 use super::params::PaillierParams;
 use crate::uint::{
@@ -14,7 +14,7 @@ use crate::uint::{
 use crypto_bigint::{InvMod, Monty, Odd, ShrVartime, Square, WrappingAdd, WrappingSub};
 use secrecy::{ExposeSecret, SecretBox};
 
-#[derive(Debug, Deserialize, ZeroizeOnDrop, Zeroize)]
+#[derive(Debug, Deserialize)]
 pub(crate) struct SecretKeyPaillier<P: PaillierParams> {
     p: SecretBox<P::HalfUint>,
     q: SecretBox<P::HalfUint>,


### PR DESCRIPTION
- Bump `secrecy` to the most recent stable version (0.10) (this is an internal change)
- Bump `crypto-bigint` to 0.6-rc.6 and `crypto-primes` to 0.6.0-pre.2 (this is an internal change)
- Remove unused `base64` dependency and move `hex` to dev-dependencies (should have been done in #153)
- Remove the need for `getrandom/js` dependency (`crypto-primes`'s default features were requiring it, but we don't need those features)
- Remove an explicit `Debug` for `SecretKeyPaillier` - derivation works well enough
- Remove unncecessary `Zeroize` and `ZeroizeOnDrop` derivations (don't need `Zeroize` if `ZeroizeOnDrop` is already derived, and don't need `ZeroizeOnDrop` in structs that already have all secret data in `SecretBox`)