### PR TITLE
Updates for CGGMP'24: Paillier/ring-Pedersen level 

### DIFF
--- a/synedrion/src/cggmp21/aux_gen.rs
+++ b/synedrion/src/cggmp21/aux_gen.rs
@@ -28,8 +28,8 @@ use super::{
 use crate::{
     curve::{Point, Scalar},
     paillier::{
-        PublicKeyPaillier, PublicKeyPaillierPrecomputed, RPParams, RPParamsMod, RPSecret, SecretKeyPaillier,
-        SecretKeyPaillierPrecomputed,
+        PublicKeyPaillier, PublicKeyPaillierWire, RPParams, RPParamsWire, RPSecret, SecretKeyPaillier,
+        SecretKeyPaillierWire,
     },
     tools::{
         bitvec::BitVec,
@@ -133,7 +133,7 @@ impl<P: SchemeParams, I: PartyId> EntryPoint<I> for AuxGen<P, I> {
             .finalize();
 
         // $p_i$, $q_i$
-        let paillier_sk = SecretKeyPaillier::<P::Paillier>::random(rng);
+        let paillier_sk = SecretKeyPaillierWire::<P::Paillier>::random(rng);
         // $N_i$
         let paillier_pk = paillier_sk.public_key();
 
@@ -147,7 +147,7 @@ impl<P: SchemeParams, I: PartyId> EntryPoint<I> for AuxGen<P, I> {
 
         let rp_secret = RPSecret::random(rng);
         // Ring-Pedersen parameters ($s$, $t$) bundled in a single object.
-        let rp_params = RPParamsMod::random_with_secret(rng, &rp_secret);
+        let rp_params = RPParams::random_with_secret(rng, &rp_secret);
 
         let aux = (&sid_hash, id);
         let hat_psi = PrmProof::<P>::new(rng, &rp_secret, &rp_params, &aux);
@@ -159,7 +159,7 @@ impl<P: SchemeParams, I: PartyId> EntryPoint<I> for AuxGen<P, I> {
             cap_y,
             cap_b,
             paillier_pk: paillier_pk.clone(),
-            rp_params: rp_params.retrieve(),
+            rp_params: rp_params.to_wire(),
             hat_psi,
             rho,
             u,
@@ -191,8 +191,8 @@ impl<P: SchemeParams, I: PartyId> EntryPoint<I> for AuxGen<P, I> {
 struct PublicData1<P: SchemeParams> {
     cap_y: Point,
     cap_b: SchCommitment,
-    paillier_pk: PublicKeyPaillier<P::Paillier>, // $N_i$
-    rp_params: RPParams<P::Paillier>,            // $s_i$ and $t_i$
+    paillier_pk: PublicKeyPaillierWire<P::Paillier>, // $N_i$
+    rp_params: RPParamsWire<P::Paillier>,            // $s_i$ and $t_i$
     hat_psi: PrmProof<P>,
     rho: BitVec,
     u: BitVec,
@@ -201,13 +201,13 @@ struct PublicData1<P: SchemeParams> {
 #[derive(Debug, Clone)]
 struct PublicData1Precomp<P: SchemeParams> {
     data: PublicData1<P>,
-    paillier_pk: PublicKeyPaillierPrecomputed<P::Paillier>,
-    rp_params: RPParamsMod<P::Paillier>,
+    paillier_pk: PublicKeyPaillier<P::Paillier>,
+    rp_params: RPParams<P::Paillier>,
 }
 
 #[derive(Debug)]
 struct Context<P: SchemeParams, I> {
-    paillier_sk: SecretKeyPaillierPrecomputed<P::Paillier>,
+    paillier_sk: SecretKeyPaillier<P::Paillier>,
     y: Scalar,
     tau_y: SchSecret,
     data_precomp: PublicData1Precomp<P>,
@@ -390,7 +390,7 @@ impl<P: SchemeParams, I: PartyId> Round<I> for Round2<P, I> {
 
         let aux = (&self.context.sid_hash, &from);
 
-        let rp_params = normal_broadcast.data.rp_params.to_mod();
+        let rp_params = normal_broadcast.data.rp_params.to_precomputed();
         if !normal_broadcast.data.hat_psi.verify(&rp_params, &aux) {
             return Err(ReceiveError::protocol(AuxGenError(AuxGenErrorEnum::Round2(
                 "PRM verification failed".into(),
@@ -604,15 +604,15 @@ impl<P: SchemeParams, I: PartyId + Serialize> Round<I> for Round3<P, I> {
                     id,
                     PublicAuxInfo {
                         el_gamal_pk: data.data.cap_y,
-                        paillier_pk: data.paillier_pk.into_minimal(),
-                        rp_params: data.rp_params.retrieve(),
+                        paillier_pk: data.paillier_pk.into_wire(),
+                        rp_params: data.rp_params.to_wire(),
                     },
                 )
             })
             .collect();
 
         let secret_aux = SecretAuxInfo {
-            paillier_sk: self.context.paillier_sk.into_minimal(),
+            paillier_sk: self.context.paillier_sk.into_wire(),
             el_gamal_sk: SecretBox::new(Box::new(self.context.y)),
         };
 

--- a/synedrion/src/cggmp21/aux_gen.rs
+++ b/synedrion/src/cggmp21/aux_gen.rs
@@ -133,7 +133,7 @@ impl<P: SchemeParams, I: PartyId> EntryPoint<I> for AuxGen<P, I> {
             .finalize();
 
         // $p_i$, $q_i$
-        let paillier_sk = SecretKeyPaillier::<P::Paillier>::random(rng).to_precomputed();
+        let paillier_sk = SecretKeyPaillier::<P::Paillier>::random(rng);
         // $N_i$
         let paillier_pk = paillier_sk.public_key();
 
@@ -145,12 +145,12 @@ impl<P: SchemeParams, I: PartyId> EntryPoint<I> for AuxGen<P, I> {
         let tau_y = SchSecret::random(rng); // $\tau$
         let cap_b = SchCommitment::new(&tau_y);
 
-        let lambda = RPSecret::random(rng, &paillier_sk);
+        let rp_secret = RPSecret::random(rng);
         // Ring-Pedersen parameters ($s$, $t$) bundled in a single object.
-        let rp_params = RPParamsMod::random_with_secret(rng, &lambda, paillier_pk);
+        let rp_params = RPParamsMod::random_with_secret(rng, &rp_secret);
 
         let aux = (&sid_hash, id);
-        let hat_psi = PrmProof::<P>::new(rng, &paillier_sk, &lambda, &rp_params, &aux);
+        let hat_psi = PrmProof::<P>::new(rng, &rp_secret, &rp_params, &aux);
 
         let rho = BitVec::random(rng, P::SECURITY_PARAMETER);
         let u = BitVec::random(rng, P::SECURITY_PARAMETER);
@@ -158,7 +158,7 @@ impl<P: SchemeParams, I: PartyId> EntryPoint<I> for AuxGen<P, I> {
         let data = PublicData1 {
             cap_y,
             cap_b,
-            paillier_pk: paillier_pk.to_minimal(),
+            paillier_pk: paillier_pk.clone(),
             rp_params: rp_params.retrieve(),
             hat_psi,
             rho,
@@ -167,12 +167,12 @@ impl<P: SchemeParams, I: PartyId> EntryPoint<I> for AuxGen<P, I> {
 
         let data_precomp = PublicData1Precomp {
             data,
-            paillier_pk: paillier_pk.clone(),
+            paillier_pk: paillier_pk.into_precomputed(),
             rp_params,
         };
 
         let context = Context {
-            paillier_sk,
+            paillier_sk: paillier_sk.into_precomputed(),
             y,
             tau_y,
             data_precomp,
@@ -380,7 +380,7 @@ impl<P: SchemeParams, I: PartyId> Round<I> for Round2<P, I> {
             ))));
         }
 
-        let paillier_pk = normal_broadcast.data.paillier_pk.to_precomputed();
+        let paillier_pk = normal_broadcast.data.paillier_pk.clone().into_precomputed();
 
         if (paillier_pk.modulus().bits_vartime() as usize) < 8 * P::SECURITY_PARAMETER {
             return Err(ReceiveError::protocol(AuxGenError(AuxGenErrorEnum::Round2(
@@ -390,7 +390,7 @@ impl<P: SchemeParams, I: PartyId> Round<I> for Round2<P, I> {
 
         let aux = (&self.context.sid_hash, &from);
 
-        let rp_params = normal_broadcast.data.rp_params.to_mod(&paillier_pk);
+        let rp_params = normal_broadcast.data.rp_params.to_mod();
         if !normal_broadcast.data.hat_psi.verify(&rp_params, &aux) {
             return Err(ReceiveError::protocol(AuxGenError(AuxGenErrorEnum::Round2(
                 "PRM verification failed".into(),
@@ -604,7 +604,7 @@ impl<P: SchemeParams, I: PartyId + Serialize> Round<I> for Round3<P, I> {
                     id,
                     PublicAuxInfo {
                         el_gamal_pk: data.data.cap_y,
-                        paillier_pk: data.paillier_pk.to_minimal(),
+                        paillier_pk: data.paillier_pk.into_minimal(),
                         rp_params: data.rp_params.retrieve(),
                     },
                 )
@@ -612,7 +612,7 @@ impl<P: SchemeParams, I: PartyId + Serialize> Round<I> for Round3<P, I> {
             .collect();
 
         let secret_aux = SecretAuxInfo {
-            paillier_sk: self.context.paillier_sk.to_minimal(),
+            paillier_sk: self.context.paillier_sk.into_minimal(),
             el_gamal_sk: SecretBox::new(Box::new(self.context.y)),
         };
 

--- a/synedrion/src/cggmp21/entities.rs
+++ b/synedrion/src/cggmp21/entities.rs
@@ -224,13 +224,12 @@ impl<P: SchemeParams, I: Ord + Clone> AuxInfo<P, I> {
             .iter()
             .zip(secret_aux.iter())
             .map(|(id, secret)| {
-                let sk = secret.paillier_sk.to_precomputed();
                 (
                     id.clone(),
                     PublicAuxInfo {
-                        paillier_pk: sk.public_key().to_minimal(),
+                        paillier_pk: secret.paillier_sk.public_key(),
                         el_gamal_pk: secret.el_gamal_sk.expose_secret().mul_by_generator(),
-                        rp_params: RPParamsMod::random(rng, &sk).retrieve(),
+                        rp_params: RPParamsMod::random(rng).retrieve(),
                     },
                 )
             })
@@ -251,23 +250,23 @@ impl<P: SchemeParams, I: Ord + Clone> AuxInfo<P, I> {
             .collect()
     }
 
-    pub(crate) fn to_precomputed(&self) -> AuxInfoPrecomputed<P, I> {
+    pub(crate) fn into_precomputed(self) -> AuxInfoPrecomputed<P, I> {
         AuxInfoPrecomputed {
             secret_aux: SecretAuxInfoPrecomputed {
-                paillier_sk: self.secret_aux.paillier_sk.to_precomputed(),
+                paillier_sk: self.secret_aux.paillier_sk.clone().into_precomputed(),
                 el_gamal_sk: self.secret_aux.el_gamal_sk.clone(),
             },
             public_aux: self
                 .public_aux
                 .iter()
                 .map(|(id, public_aux)| {
-                    let paillier_pk = public_aux.paillier_pk.to_precomputed();
+                    let paillier_pk = public_aux.paillier_pk.clone().into_precomputed();
                     (
                         id.clone(),
                         PublicAuxInfoPrecomputed {
                             el_gamal_pk: public_aux.el_gamal_pk,
                             paillier_pk: paillier_pk.clone(),
-                            rp_params: public_aux.rp_params.to_mod(&paillier_pk),
+                            rp_params: public_aux.rp_params.to_mod(),
                         },
                     )
                 })

--- a/synedrion/src/cggmp21/interactive_signing.rs
+++ b/synedrion/src/cggmp21/interactive_signing.rs
@@ -26,7 +26,7 @@ use super::{
 };
 use crate::{
     curve::{Point, RecoverableSignature, Scalar},
-    paillier::{Ciphertext, CiphertextMod, PaillierParams, Randomizer, RandomizerMod},
+    paillier::{Ciphertext, CiphertextWire, PaillierParams, Randomizer, RandomizerWire},
     tools::{
         hashing::{Chain, FofHasher, HashOutput},
         DowncastMap, Without,
@@ -160,11 +160,11 @@ impl<P: SchemeParams, I: PartyId> EntryPoint<I> for InteractiveSigning<P, I> {
 
         let pk = aux_info.secret_aux.paillier_sk.public_key();
 
-        let nu = RandomizerMod::<P::Paillier>::random(rng, pk);
-        let cap_g = CiphertextMod::new_with_randomizer(pk, &P::uint_from_scalar(&gamma), &nu.retrieve());
+        let nu = Randomizer::<P::Paillier>::random(rng, pk);
+        let cap_g = Ciphertext::new_with_randomizer(pk, &P::uint_from_scalar(&gamma), &nu.to_wire());
 
-        let rho = RandomizerMod::<P::Paillier>::random(rng, pk);
-        let cap_k = CiphertextMod::new_with_randomizer(pk, &P::uint_from_scalar(&k), &rho.retrieve());
+        let rho = Randomizer::<P::Paillier>::random(rng, pk);
+        let cap_k = Ciphertext::new_with_randomizer(pk, &P::uint_from_scalar(&k), &rho.to_wire());
 
         Ok(BoxedRound::new_dynamic(Round1 {
             context: Context {
@@ -195,23 +195,23 @@ struct Context<P: SchemeParams, I: Ord> {
     aux_info: AuxInfoPrecomputed<P, I>,
     k: Scalar,
     gamma: Scalar,
-    rho: RandomizerMod<P::Paillier>,
-    nu: RandomizerMod<P::Paillier>,
+    rho: Randomizer<P::Paillier>,
+    nu: Randomizer<P::Paillier>,
 }
 
 #[derive(Debug)]
 struct Round1<P: SchemeParams, I: Ord> {
     context: Context<P, I>,
-    cap_k: CiphertextMod<P::Paillier>,
-    cap_g: CiphertextMod<P::Paillier>,
+    cap_k: Ciphertext<P::Paillier>,
+    cap_g: Ciphertext<P::Paillier>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "Ciphertext<P::Paillier>: Serialize"))]
-#[serde(bound(deserialize = "Ciphertext<P::Paillier>: for<'x> Deserialize<'x>"))]
+#[serde(bound(serialize = "CiphertextWire<P::Paillier>: Serialize"))]
+#[serde(bound(deserialize = "CiphertextWire<P::Paillier>: for<'x> Deserialize<'x>"))]
 struct Round1BroadcastMessage<P: SchemeParams> {
-    cap_k: Ciphertext<P::Paillier>,
-    cap_g: Ciphertext<P::Paillier>,
+    cap_k: CiphertextWire<P::Paillier>,
+    cap_g: CiphertextWire<P::Paillier>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -222,8 +222,8 @@ struct Round1DirectMessage<P: SchemeParams> {
 }
 
 struct Round1Payload<P: SchemeParams> {
-    cap_k: Ciphertext<P::Paillier>,
-    cap_g: Ciphertext<P::Paillier>,
+    cap_k: CiphertextWire<P::Paillier>,
+    cap_g: CiphertextWire<P::Paillier>,
 }
 
 impl<P: SchemeParams, I: PartyId> Round<I> for Round1<P, I> {
@@ -253,8 +253,8 @@ impl<P: SchemeParams, I: PartyId> Round<I> for Round1<P, I> {
         EchoBroadcast::new(
             serializer,
             Round1BroadcastMessage::<P> {
-                cap_k: self.cap_k.retrieve(),
-                cap_g: self.cap_g.retrieve(),
+                cap_k: self.cap_k.to_wire(),
+                cap_g: self.cap_g.to_wire(),
             },
         )
     }
@@ -301,7 +301,7 @@ impl<P: SchemeParams, I: PartyId> Round<I> for Round1<P, I> {
 
         if !direct_message.psi0.verify(
             from_pk,
-            &echo_broadcast.cap_k.to_mod(from_pk),
+            &echo_broadcast.cap_k.to_precomputed(from_pk),
             &public_aux.rp_params,
             &aux,
         ) {
@@ -334,7 +334,7 @@ impl<P: SchemeParams, I: PartyId> Round<I> for Round1<P, I> {
         let mut all_cap_k = others_cap_k
             .into_iter()
             .map(|(id, ciphertext)| {
-                let ciphertext_mod = ciphertext.to_mod(&self.context.aux_info.public_aux[&id].paillier_pk);
+                let ciphertext_mod = ciphertext.to_precomputed(&self.context.aux_info.public_aux[&id].paillier_pk);
                 (id, ciphertext_mod)
             })
             .collect::<BTreeMap<_, _>>();
@@ -343,7 +343,7 @@ impl<P: SchemeParams, I: PartyId> Round<I> for Round1<P, I> {
         let mut all_cap_g = others_cap_g
             .into_iter()
             .map(|(id, ciphertext)| {
-                let ciphertext_mod = ciphertext.to_mod(&self.context.aux_info.public_aux[&id].paillier_pk);
+                let ciphertext_mod = ciphertext.to_precomputed(&self.context.aux_info.public_aux[&id].paillier_pk);
                 (id, ciphertext_mod)
             })
             .collect::<BTreeMap<_, _>>();
@@ -360,27 +360,27 @@ impl<P: SchemeParams, I: PartyId> Round<I> for Round1<P, I> {
 #[derive(Debug)]
 struct Round2<P: SchemeParams, I: Ord> {
     context: Context<P, I>,
-    all_cap_k: BTreeMap<I, CiphertextMod<P::Paillier>>,
-    all_cap_g: BTreeMap<I, CiphertextMod<P::Paillier>>,
+    all_cap_k: BTreeMap<I, Ciphertext<P::Paillier>>,
+    all_cap_g: BTreeMap<I, Ciphertext<P::Paillier>>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(bound(serialize = "
-    Ciphertext<P::Paillier>: Serialize,
+    CiphertextWire<P::Paillier>: Serialize,
     AffGProof<P>: Serialize,
     LogStarProof<P>: Serialize,
 "))]
 #[serde(bound(deserialize = "
-    Ciphertext<P::Paillier>: for<'x> Deserialize<'x>,
+    CiphertextWire<P::Paillier>: for<'x> Deserialize<'x>,
     AffGProof<P>: for<'x> Deserialize<'x>,
     LogStarProof<P>: for<'x> Deserialize<'x>,
 "))]
 struct Round2Message<P: SchemeParams> {
     cap_gamma: Point,
-    cap_d: Ciphertext<P::Paillier>,
-    hat_cap_d: Ciphertext<P::Paillier>,
-    cap_f: Ciphertext<P::Paillier>,
-    hat_cap_f: Ciphertext<P::Paillier>,
+    cap_d: CiphertextWire<P::Paillier>,
+    hat_cap_d: CiphertextWire<P::Paillier>,
+    cap_f: CiphertextWire<P::Paillier>,
+    hat_cap_f: CiphertextWire<P::Paillier>,
     psi: AffGProof<P>,
     hat_psi: AffGProof<P>,
     hat_psi_prime: LogStarProof<P>,
@@ -390,22 +390,22 @@ struct Round2Message<P: SchemeParams> {
 struct Round2Artifact<P: SchemeParams> {
     beta: SecretBox<Signed<<P::Paillier as PaillierParams>::Uint>>,
     hat_beta: SecretBox<Signed<<P::Paillier as PaillierParams>::Uint>>,
-    r: Randomizer<P::Paillier>,
-    s: Randomizer<P::Paillier>,
-    hat_r: Randomizer<P::Paillier>,
-    hat_s: Randomizer<P::Paillier>,
-    cap_d: CiphertextMod<P::Paillier>,
-    cap_f: CiphertextMod<P::Paillier>,
-    hat_cap_d: CiphertextMod<P::Paillier>,
-    hat_cap_f: CiphertextMod<P::Paillier>,
+    r: RandomizerWire<P::Paillier>,
+    s: RandomizerWire<P::Paillier>,
+    hat_r: RandomizerWire<P::Paillier>,
+    hat_s: RandomizerWire<P::Paillier>,
+    cap_d: Ciphertext<P::Paillier>,
+    cap_f: Ciphertext<P::Paillier>,
+    hat_cap_d: Ciphertext<P::Paillier>,
+    hat_cap_f: Ciphertext<P::Paillier>,
 }
 
 struct Round2Payload<P: SchemeParams> {
     cap_gamma: Point,
     alpha: Signed<<P::Paillier as PaillierParams>::Uint>,
     hat_alpha: Signed<<P::Paillier as PaillierParams>::Uint>,
-    cap_d: CiphertextMod<P::Paillier>,
-    hat_cap_d: CiphertextMod<P::Paillier>,
+    cap_d: Ciphertext<P::Paillier>,
+    hat_cap_d: Ciphertext<P::Paillier>,
 }
 
 impl<P: SchemeParams, I: PartyId> Round<I> for Round2<P, I> {
@@ -442,19 +442,19 @@ impl<P: SchemeParams, I: PartyId> Round<I> for Round2<P, I> {
 
         let beta = SecretBox::new(Box::new(Signed::random_bounded_bits(rng, P::LP_BOUND)));
         let hat_beta = SecretBox::new(Box::new(Signed::random_bounded_bits(rng, P::LP_BOUND)));
-        let r = RandomizerMod::random(rng, pk);
-        let s = RandomizerMod::random(rng, target_pk);
-        let hat_r = RandomizerMod::random(rng, pk);
-        let hat_s = RandomizerMod::random(rng, target_pk);
+        let r = Randomizer::random(rng, pk);
+        let s = Randomizer::random(rng, target_pk);
+        let hat_r = Randomizer::random(rng, pk);
+        let hat_s = Randomizer::random(rng, target_pk);
 
-        let cap_f = CiphertextMod::new_with_randomizer_signed(pk, beta.expose_secret(), &r.retrieve());
+        let cap_f = Ciphertext::new_with_randomizer_signed(pk, beta.expose_secret(), &r.to_wire());
         let cap_d = &self.all_cap_k[destination] * P::signed_from_scalar(&self.context.gamma)
-            + CiphertextMod::new_with_randomizer_signed(target_pk, &-beta.expose_secret(), &s.retrieve());
+            + Ciphertext::new_with_randomizer_signed(target_pk, &-beta.expose_secret(), &s.to_wire());
 
-        let hat_cap_f = CiphertextMod::new_with_randomizer_signed(pk, hat_beta.expose_secret(), &hat_r.retrieve());
+        let hat_cap_f = Ciphertext::new_with_randomizer_signed(pk, hat_beta.expose_secret(), &hat_r.to_wire());
         let hat_cap_d = &self.all_cap_k[destination]
             * P::signed_from_scalar(self.context.key_share.secret_share.expose_secret())
-            + CiphertextMod::new_with_randomizer_signed(target_pk, &-hat_beta.expose_secret(), &hat_s.retrieve());
+            + Ciphertext::new_with_randomizer_signed(target_pk, &-hat_beta.expose_secret(), &hat_s.to_wire());
 
         let public_aux = &self.context.aux_info.public_aux[destination];
         let rp = &public_aux.rp_params;
@@ -507,10 +507,10 @@ impl<P: SchemeParams, I: PartyId> Round<I> for Round2<P, I> {
             serializer,
             Round2Message::<P> {
                 cap_gamma,
-                cap_d: cap_d.retrieve(),
-                cap_f: cap_f.retrieve(),
-                hat_cap_d: hat_cap_d.retrieve(),
-                hat_cap_f: hat_cap_f.retrieve(),
+                cap_d: cap_d.to_wire(),
+                cap_f: cap_f.to_wire(),
+                hat_cap_d: hat_cap_d.to_wire(),
+                hat_cap_f: hat_cap_f.to_wire(),
                 psi,
                 hat_psi,
                 hat_psi_prime,
@@ -520,10 +520,10 @@ impl<P: SchemeParams, I: PartyId> Round<I> for Round2<P, I> {
         let artifact = Artifact::new(Round2Artifact::<P> {
             beta,
             hat_beta,
-            r: r.retrieve(),
-            s: s.retrieve(),
-            hat_r: hat_r.retrieve(),
-            hat_s: hat_s.retrieve(),
+            r: r.to_wire(),
+            s: s.to_wire(),
+            hat_r: hat_r.to_wire(),
+            hat_s: hat_s.to_wire(),
             cap_d,
             cap_f,
             hat_cap_d,
@@ -555,15 +555,15 @@ impl<P: SchemeParams, I: PartyId> Round<I> for Round2<P, I> {
         let public_aux = &self.context.aux_info.public_aux[&self.context.my_id];
         let rp = &public_aux.rp_params;
 
-        let cap_d = direct_message.cap_d.to_mod(pk);
-        let hat_cap_d = direct_message.hat_cap_d.to_mod(pk);
+        let cap_d = direct_message.cap_d.to_precomputed(pk);
+        let hat_cap_d = direct_message.hat_cap_d.to_precomputed(pk);
 
         if !direct_message.psi.verify(
             pk,
             from_pk,
             &self.all_cap_k[&self.context.my_id],
             &cap_d,
-            &direct_message.cap_f.to_mod(from_pk),
+            &direct_message.cap_f.to_precomputed(from_pk),
             &direct_message.cap_gamma,
             rp,
             &aux,
@@ -578,7 +578,7 @@ impl<P: SchemeParams, I: PartyId> Round<I> for Round2<P, I> {
             from_pk,
             &self.all_cap_k[&self.context.my_id],
             &hat_cap_d,
-            &direct_message.hat_cap_f.to_mod(from_pk),
+            &direct_message.hat_cap_f.to_precomputed(from_pk),
             &cap_x,
             rp,
             &aux,
@@ -679,10 +679,10 @@ struct Round3<P: SchemeParams, I: Ord> {
     chi: Signed<<P::Paillier as PaillierParams>::Uint>,
     cap_delta: Point,
     cap_gamma: Point,
-    all_cap_k: BTreeMap<I, CiphertextMod<P::Paillier>>,
-    all_cap_g: BTreeMap<I, CiphertextMod<P::Paillier>>,
-    cap_ds: BTreeMap<I, CiphertextMod<P::Paillier>>,
-    hat_cap_ds: BTreeMap<I, CiphertextMod<P::Paillier>>,
+    all_cap_k: BTreeMap<I, Ciphertext<P::Paillier>>,
+    all_cap_g: BTreeMap<I, Ciphertext<P::Paillier>>,
+    cap_ds: BTreeMap<I, Ciphertext<P::Paillier>>,
+    hat_cap_ds: BTreeMap<I, Ciphertext<P::Paillier>>,
     round2_artifacts: BTreeMap<I, Round2Artifact<P>>,
 }
 
@@ -880,8 +880,8 @@ impl<P: SchemeParams, I: PartyId> Round<I> for Round3<P, I> {
                     rng,
                     &P::signed_from_scalar(&self.context.gamma),
                     beta,
-                    s.to_mod(target_pk),
-                    r.to_mod(pk),
+                    s.to_precomputed(target_pk),
+                    r.to_precomputed(pk),
                     target_pk,
                     pk,
                     &self.all_cap_k[id_j],
@@ -909,9 +909,9 @@ impl<P: SchemeParams, I: PartyId> Round<I> for Round3<P, I> {
 
         // Mul proof
 
-        let rho = RandomizerMod::random(rng, pk);
+        let rho = Randomizer::random(rng, pk);
         let cap_h = (&self.all_cap_g[&self.context.my_id] * P::bounded_from_scalar(&self.context.k))
-            .mul_randomizer(&rho.retrieve());
+            .mul_randomizer(&rho.to_wire());
 
         let p_mul = MulProof::<P>::new(
             rng,
@@ -1106,8 +1106,8 @@ impl<P: SchemeParams, I: PartyId> Round<I> for Round4<P, I> {
                     rng,
                     &P::signed_from_scalar(self.context.key_share.secret_share.expose_secret()),
                     &values.hat_beta,
-                    values.hat_s.to_mod(target_pk),
-                    values.hat_r.to_mod(pk),
+                    values.hat_s.to_precomputed(target_pk),
+                    values.hat_r.to_precomputed(pk),
                     target_pk,
                     pk,
                     &values.cap_k,
@@ -1138,9 +1138,9 @@ impl<P: SchemeParams, I: PartyId> Round<I> for Round4<P, I> {
         let x = &self.context.key_share.secret_share;
         let cap_x = self.context.key_share.public_shares[&my_id];
 
-        let rho = RandomizerMod::random(rng, pk);
+        let rho = Randomizer::random(rng, pk);
         let hat_cap_h =
-            (&self.presigning.cap_k * P::bounded_from_scalar(x.expose_secret())).mul_randomizer(&rho.retrieve());
+            (&self.presigning.cap_k * P::bounded_from_scalar(x.expose_secret())).mul_randomizer(&rho.to_wire());
 
         let aux = (&self.context.ssid_hash, &my_id);
 

--- a/synedrion/src/cggmp21/interactive_signing.rs
+++ b/synedrion/src/cggmp21/interactive_signing.rs
@@ -608,10 +608,10 @@ impl<P: SchemeParams, I: PartyId> Round<I> for Round2<P, I> {
         // where `q` is the curve order.
         // We will need this bound later, so we're asserting it.
         let alpha = alpha
-            .assert_bit_bound_usize(core::cmp::max(2 * P::L_BOUND, P::LP_BOUND) + 1)
+            .assert_bit_bound(core::cmp::max(2 * P::L_BOUND, P::LP_BOUND) + 1)
             .ok_or_else(|| ReceiveError::protocol(InteractiveSigningError::OutOfBoundsAlpha))?;
         let hat_alpha = hat_alpha
-            .assert_bit_bound_usize(core::cmp::max(2 * P::L_BOUND, P::LP_BOUND) + 1)
+            .assert_bit_bound(core::cmp::max(2 * P::L_BOUND, P::LP_BOUND) + 1)
             .ok_or_else(|| ReceiveError::protocol(InteractiveSigningError::OutOfBoundsHatAlpha))?;
 
         Ok(Payload::new(Round2Payload::<P> {

--- a/synedrion/src/cggmp21/interactive_signing.rs
+++ b/synedrion/src/cggmp21/interactive_signing.rs
@@ -149,7 +149,7 @@ impl<P: SchemeParams, I: PartyId> EntryPoint<I> for InteractiveSigning<P, I> {
             .chain(&aux_info.public_aux)
             .finalize();
 
-        let aux_info = aux_info.to_precomputed();
+        let aux_info = aux_info.into_precomputed();
 
         // TODO (#68): check that KeyShare is consistent with AuxInfo
 

--- a/synedrion/src/cggmp21/key_refresh.rs
+++ b/synedrion/src/cggmp21/key_refresh.rs
@@ -29,8 +29,8 @@ use super::{
 use crate::{
     curve::{Point, Scalar},
     paillier::{
-        Ciphertext, CiphertextMod, PublicKeyPaillier, PublicKeyPaillierPrecomputed, RPParams, RPParamsMod, RPSecret,
-        Randomizer, SecretKeyPaillier, SecretKeyPaillierPrecomputed,
+        Ciphertext, CiphertextWire, PublicKeyPaillier, PublicKeyPaillierWire, RPParams, RPParamsWire, RPSecret,
+        RandomizerWire, SecretKeyPaillier, SecretKeyPaillierWire,
     },
     tools::{
         bitvec::BitVec,
@@ -69,9 +69,9 @@ enum KeyRefreshErrorEnum<P: SchemeParams> {
     // TODO (#43): this can be removed when error verification is added
     #[allow(dead_code)]
     Round3MismatchedSecret {
-        cap_c: Ciphertext<P::Paillier>,
+        cap_c: CiphertextWire<P::Paillier>,
         x: Scalar,
-        mu: Randomizer<P::Paillier>,
+        mu: RandomizerWire<P::Paillier>,
     },
 }
 
@@ -155,7 +155,7 @@ impl<P: SchemeParams, I: PartyId> EntryPoint<I> for KeyRefresh<P, I> {
             .finalize();
 
         // $p_i$, $q_i$
-        let paillier_sk = SecretKeyPaillier::<P::Paillier>::random(rng);
+        let paillier_sk = SecretKeyPaillierWire::<P::Paillier>::random(rng);
         // $N_i$
         let paillier_pk = paillier_sk.public_key();
 
@@ -180,7 +180,7 @@ impl<P: SchemeParams, I: PartyId> EntryPoint<I> for KeyRefresh<P, I> {
 
         let rp_secret = RPSecret::random(rng);
         // Ring-Pedersen parameters ($s$, $t$) bundled in a single object.
-        let rp_params = RPParamsMod::random_with_secret(rng, &rp_secret);
+        let rp_params = RPParams::random_with_secret(rng, &rp_secret);
 
         let aux = (&sid_hash, id);
         let hat_psi = PrmProof::<P>::new(rng, &rp_secret, &rp_params, &aux);
@@ -204,7 +204,7 @@ impl<P: SchemeParams, I: PartyId> EntryPoint<I> for KeyRefresh<P, I> {
             cap_y,
             cap_b,
             paillier_pk: paillier_pk.clone(),
-            rp_params: rp_params.retrieve(),
+            rp_params: rp_params.to_wire(),
             hat_psi,
             rho,
             u,
@@ -245,8 +245,8 @@ struct PublicData1<P: SchemeParams> {
     cap_a_to_send: Vec<SchCommitment>, // $A_i^j$ where $i$ is this party's index
     cap_y: Point,
     cap_b: SchCommitment,
-    paillier_pk: PublicKeyPaillier<P::Paillier>, // $N_i$
-    rp_params: RPParams<P::Paillier>,            // $s_i$ and $t_i$
+    paillier_pk: PublicKeyPaillierWire<P::Paillier>, // $N_i$
+    rp_params: RPParamsWire<P::Paillier>,            // $s_i$ and $t_i$
     hat_psi: PrmProof<P>,
     rho: BitVec,
     u: BitVec,
@@ -255,13 +255,13 @@ struct PublicData1<P: SchemeParams> {
 #[derive(Debug, Clone)]
 struct PublicData1Precomp<P: SchemeParams> {
     data: PublicData1<P>,
-    paillier_pk: PublicKeyPaillierPrecomputed<P::Paillier>,
-    rp_params: RPParamsMod<P::Paillier>,
+    paillier_pk: PublicKeyPaillier<P::Paillier>,
+    rp_params: RPParams<P::Paillier>,
 }
 
 #[derive(Debug)]
 struct Context<P: SchemeParams, I> {
-    paillier_sk: SecretKeyPaillierPrecomputed<P::Paillier>,
+    paillier_sk: SecretKeyPaillier<P::Paillier>,
     y: Scalar,
     x_to_send: BTreeMap<I, Scalar>, // $x_i^j$ where $i$ is this party's index
     tau_y: SchSecret,
@@ -453,7 +453,7 @@ impl<P: SchemeParams, I: PartyId> Round<I> for Round2<P, I> {
 
         let aux = (&self.context.sid_hash, &from);
 
-        let rp_params = normal_broadcast.data.rp_params.to_mod();
+        let rp_params = normal_broadcast.data.rp_params.to_precomputed();
         if !normal_broadcast.data.hat_psi.verify(&rp_params, &aux) {
             return Err(ReceiveError::protocol(KeyRefreshError(KeyRefreshErrorEnum::Round2(
                 "PRM verification failed".into(),
@@ -507,19 +507,19 @@ struct Round3<P: SchemeParams, I> {
 #[serde(bound(serialize = "
     ModProof<P>: Serialize,
     FacProof<P>: Serialize,
-    Ciphertext<P::Paillier>: Serialize,
+    CiphertextWire<P::Paillier>: Serialize,
 "))]
 #[serde(bound(deserialize = "
     ModProof<P>: for<'x> Deserialize<'x>,
     FacProof<P>: for<'x> Deserialize<'x>,
-    Ciphertext<P::Paillier>: for<'x> Deserialize<'x>,
+    CiphertextWire<P::Paillier>: for<'x> Deserialize<'x>,
 "))]
 struct PublicData2<P: SchemeParams> {
     psi_mod: ModProof<P>, // $\psi_i$, a P^{mod} for the Paillier modulus
     phi: FacProof<P>,
     pi: SchProof,
-    paillier_enc_x: Ciphertext<P::Paillier>, // `C_j,i`
-    psi_sch: SchProof,                       // $psi_i^j$, a P^{sch} for the secret share change
+    paillier_enc_x: CiphertextWire<P::Paillier>, // `C_j,i`
+    psi_sch: SchProof,                           // $psi_i^j$, a P^{sch} for the secret share change
 }
 
 impl<P: SchemeParams, I: PartyId> Round3<P, I> {
@@ -603,7 +603,7 @@ impl<P: SchemeParams, I: PartyId> Round<I> for Round3<P, I> {
 
         let x_secret = self.context.x_to_send[destination];
         let x_public = self.context.data_precomp.data.cap_x_to_send[destination_idx];
-        let ciphertext = CiphertextMod::new(rng, &data.paillier_pk, &P::uint_from_scalar(&x_secret));
+        let ciphertext = Ciphertext::new(rng, &data.paillier_pk, &P::uint_from_scalar(&x_secret));
 
         let psi_sch = SchProof::new(
             &self.context.tau_x[destination],
@@ -617,7 +617,7 @@ impl<P: SchemeParams, I: PartyId> Round<I> for Round3<P, I> {
             psi_mod: self.psi_mod.clone(),
             phi,
             pi: self.pi.clone(),
-            paillier_enc_x: ciphertext.retrieve(),
+            paillier_enc_x: ciphertext.to_wire(),
             psi_sch,
         };
 
@@ -646,7 +646,7 @@ impl<P: SchemeParams, I: PartyId> Round<I> for Round3<P, I> {
         let enc_x = direct_message
             .data2
             .paillier_enc_x
-            .to_mod(&self.context.data_precomp.paillier_pk);
+            .to_precomputed(&self.context.data_precomp.paillier_pk);
 
         let x = P::scalar_from_uint(&enc_x.decrypt(&self.context.paillier_sk));
 
@@ -658,7 +658,7 @@ impl<P: SchemeParams, I: PartyId> Round<I> for Round3<P, I> {
                 KeyRefreshErrorEnum::Round3MismatchedSecret {
                     cap_c: direct_message.data2.paillier_enc_x,
                     x,
-                    mu: mu.retrieve(),
+                    mu: mu.to_wire(),
                 },
             )));
         }
@@ -745,15 +745,15 @@ impl<P: SchemeParams, I: PartyId> Round<I> for Round3<P, I> {
                     id,
                     PublicAuxInfo {
                         el_gamal_pk: data.data.cap_y,
-                        paillier_pk: data.paillier_pk.into_minimal(),
-                        rp_params: data.rp_params.retrieve(),
+                        paillier_pk: data.paillier_pk.into_wire(),
+                        rp_params: data.rp_params.to_wire(),
                     },
                 )
             })
             .collect();
 
         let secret_aux = SecretAuxInfo {
-            paillier_sk: self.context.paillier_sk.into_minimal(),
+            paillier_sk: self.context.paillier_sk.into_wire(),
             el_gamal_sk: SecretBox::new(Box::new(self.context.y)),
         };
 

--- a/synedrion/src/cggmp21/params.rs
+++ b/synedrion/src/cggmp21/params.rs
@@ -77,7 +77,7 @@ impl PaillierParams for PaillierTest {
     are much smaller than 2*PRIME_BITS.
     */
 
-    const PRIME_BITS: usize = 397;
+    const PRIME_BITS: u32 = 397;
     type HalfUint = U512;
     type HalfUintMod = U512Mod;
     type Uint = U1024;
@@ -91,7 +91,7 @@ impl PaillierParams for PaillierTest {
 pub struct PaillierProduction;
 
 impl PaillierParams for PaillierProduction {
-    const PRIME_BITS: usize = 1024;
+    const PRIME_BITS: u32 = 1024;
     type HalfUint = U1024;
     type HalfUintMod = U1024Mod;
     type Uint = U2048;
@@ -112,11 +112,11 @@ pub trait SchemeParams: Debug + Clone + Send + PartialEq + Eq + Send + Sync + 's
     /// The scheme's statistical security parameter.
     const SECURITY_PARAMETER: usize; // $\kappa$
     /// The bound for secret values.
-    const L_BOUND: usize; // $\ell$, paper sets it to $\log2(q)$ (see Table 2)
+    const L_BOUND: u32; // $\ell$, paper sets it to $\log2(q)$ (see Table 2)
     /// The error bound for secret masks.
-    const LP_BOUND: usize; // $\ell^\prime$, in paper $= 5 \ell$ (see Table 2)
+    const LP_BOUND: u32; // $\ell^\prime$, in paper $= 5 \ell$ (see Table 2)
     /// The error bound for range checks (referred to in the paper as the slackness parameter).
-    const EPS_BOUND: usize; // $\eps$, in paper $= 2 \ell$ (see Table 2)
+    const EPS_BOUND: u32; // $\eps$, in paper $= 2 \ell$ (see Table 2)
     /// The parameters of the Paillier encryption.
     ///
     /// Note: `PaillierParams::Uint` must be able to contain the full range of `Scalar` values
@@ -213,9 +213,9 @@ pub struct TestParams;
 // - P^{fac} assumes $N ~ 2^{4 \ell + 2 \eps}$
 impl SchemeParams for TestParams {
     const SECURITY_PARAMETER: usize = 10;
-    const L_BOUND: usize = 256;
-    const LP_BOUND: usize = 256;
-    const EPS_BOUND: usize = 320;
+    const L_BOUND: u32 = 256;
+    const LP_BOUND: u32 = 256;
+    const EPS_BOUND: u32 = 320;
     type Paillier = PaillierTest;
     const CURVE_ORDER: NonZero<<Self::Paillier as PaillierParams>::Uint> = convert_uint(upcast_uint(ORDER))
         .to_nz()
@@ -231,9 +231,9 @@ pub struct ProductionParams;
 
 impl SchemeParams for ProductionParams {
     const SECURITY_PARAMETER: usize = 80; // The value is given in Table 2 in the paper
-    const L_BOUND: usize = 256;
-    const LP_BOUND: usize = Self::L_BOUND * 5;
-    const EPS_BOUND: usize = Self::L_BOUND * 2;
+    const L_BOUND: u32 = 256;
+    const LP_BOUND: u32 = Self::L_BOUND * 5;
+    const EPS_BOUND: u32 = Self::L_BOUND * 2;
     type Paillier = PaillierProduction;
     const CURVE_ORDER: NonZero<<Self::Paillier as PaillierParams>::Uint> = convert_uint(upcast_uint(ORDER))
         .to_nz()

--- a/synedrion/src/cggmp21/sigma/aff_g.rs
+++ b/synedrion/src/cggmp21/sigma/aff_g.rs
@@ -8,8 +8,8 @@ use super::super::SchemeParams;
 use crate::{
     curve::Point,
     paillier::{
-        Ciphertext, CiphertextMod, PaillierParams, PublicKeyPaillierPrecomputed, RPCommitment, RPParamsMod, Randomizer,
-        RandomizerMod,
+        Ciphertext, CiphertextWire, PaillierParams, PublicKeyPaillier, RPCommitmentWire, RPParams, Randomizer,
+        RandomizerWire,
     },
     tools::hashing::{Chain, Hashable, XofHasher},
     uint::Signed,
@@ -42,19 +42,19 @@ Public inputs:
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct AffGProof<P: SchemeParams> {
     e: Signed<<P::Paillier as PaillierParams>::Uint>,
-    cap_a: Ciphertext<P::Paillier>,
+    cap_a: CiphertextWire<P::Paillier>,
     cap_b_x: Point,
-    cap_b_y: Ciphertext<P::Paillier>,
-    cap_e: RPCommitment<P::Paillier>,
-    cap_s: RPCommitment<P::Paillier>,
-    cap_f: RPCommitment<P::Paillier>,
-    cap_t: RPCommitment<P::Paillier>,
+    cap_b_y: CiphertextWire<P::Paillier>,
+    cap_e: RPCommitmentWire<P::Paillier>,
+    cap_s: RPCommitmentWire<P::Paillier>,
+    cap_f: RPCommitmentWire<P::Paillier>,
+    cap_t: RPCommitmentWire<P::Paillier>,
     z1: Signed<<P::Paillier as PaillierParams>::Uint>,
     z2: Signed<<P::Paillier as PaillierParams>::Uint>,
     z3: Signed<<P::Paillier as PaillierParams>::WideUint>,
     z4: Signed<<P::Paillier as PaillierParams>::WideUint>,
-    omega: Randomizer<P::Paillier>,
-    omega_y: Randomizer<P::Paillier>,
+    omega: RandomizerWire<P::Paillier>,
+    omega_y: RandomizerWire<P::Paillier>,
 }
 
 impl<P: SchemeParams> AffGProof<P> {
@@ -63,15 +63,15 @@ impl<P: SchemeParams> AffGProof<P> {
         rng: &mut impl CryptoRngCore,
         x: &Signed<<P::Paillier as PaillierParams>::Uint>,
         y: &SecretBox<Signed<<P::Paillier as PaillierParams>::Uint>>,
-        rho: RandomizerMod<P::Paillier>,
-        rho_y: RandomizerMod<P::Paillier>,
-        pk0: &PublicKeyPaillierPrecomputed<P::Paillier>,
-        pk1: &PublicKeyPaillierPrecomputed<P::Paillier>,
-        cap_c: &CiphertextMod<P::Paillier>,
-        cap_d: &CiphertextMod<P::Paillier>,
-        cap_y: &CiphertextMod<P::Paillier>,
+        rho: Randomizer<P::Paillier>,
+        rho_y: Randomizer<P::Paillier>,
+        pk0: &PublicKeyPaillier<P::Paillier>,
+        pk1: &PublicKeyPaillier<P::Paillier>,
+        cap_c: &Ciphertext<P::Paillier>,
+        cap_d: &Ciphertext<P::Paillier>,
+        cap_y: &Ciphertext<P::Paillier>,
         cap_x: &Point,
-        setup: &RPParamsMod<P::Paillier>,
+        setup: &RPParams<P::Paillier>,
         aux: &impl Hashable,
     ) -> Self {
         x.assert_bound(P::L_BOUND);
@@ -85,26 +85,25 @@ impl<P: SchemeParams> AffGProof<P> {
         let alpha = Signed::random_bounded_bits(rng, P::L_BOUND + P::EPS_BOUND);
         let beta = Signed::random_bounded_bits(rng, P::LP_BOUND + P::EPS_BOUND);
 
-        let r_mod = RandomizerMod::random(rng, pk0);
-        let r_y_mod = RandomizerMod::random(rng, pk1);
+        let r_mod = Randomizer::random(rng, pk0);
+        let r_y_mod = Randomizer::random(rng, pk1);
 
         let gamma = Signed::random_bounded_bits_scaled(rng, P::L_BOUND + P::EPS_BOUND, hat_cap_n);
         let m = Signed::random_bounded_bits_scaled(rng, P::L_BOUND, hat_cap_n);
         let delta = Signed::random_bounded_bits_scaled(rng, P::L_BOUND + P::EPS_BOUND, hat_cap_n);
         let mu = Signed::random_bounded_bits_scaled(rng, P::L_BOUND, hat_cap_n);
 
-        let cap_a =
-            (cap_c * alpha + CiphertextMod::new_with_randomizer_signed(pk0, &beta, &r_mod.retrieve())).retrieve();
+        let cap_a = (cap_c * alpha + Ciphertext::new_with_randomizer_signed(pk0, &beta, &r_mod.to_wire())).to_wire();
         let cap_b_x = P::scalar_from_signed(&alpha).mul_by_generator();
-        let cap_b_y = CiphertextMod::new_with_randomizer_signed(pk1, &beta, &r_y_mod.retrieve()).retrieve();
-        let cap_e = setup.commit(&alpha, &gamma).retrieve();
-        let cap_s = setup.commit(x, &m).retrieve();
-        let cap_f = setup.commit(&beta, &delta).retrieve();
+        let cap_b_y = Ciphertext::new_with_randomizer_signed(pk1, &beta, &r_y_mod.to_wire()).to_wire();
+        let cap_e = setup.commit(&alpha, &gamma).to_wire();
+        let cap_s = setup.commit(x, &m).to_wire();
+        let cap_f = setup.commit(&beta, &delta).to_wire();
 
         // NOTE: deviation from the paper to support a different $D$
         // (see the comment in `AffGProof`)
         // Original: $s^y$. Modified: $s^{-y}$
-        let cap_t = setup.commit(&(-y.expose_secret()), &mu).retrieve();
+        let cap_t = setup.commit(&(-y.expose_secret()), &mu).to_wire();
 
         let mut reader = XofHasher::new_with_dst(HASH_TAG)
             // commitments
@@ -116,13 +115,13 @@ impl<P: SchemeParams> AffGProof<P> {
             .chain(&cap_s)
             .chain(&cap_t)
             // public parameters
-            .chain(pk0.as_minimal())
-            .chain(pk1.as_minimal())
-            .chain(&cap_c.retrieve())
-            .chain(&cap_d.retrieve())
-            .chain(&cap_y.retrieve())
+            .chain(pk0.as_wire())
+            .chain(pk1.as_wire())
+            .chain(&cap_c.to_wire())
+            .chain(&cap_d.to_wire())
+            .chain(&cap_y.to_wire())
             .chain(cap_x)
-            .chain(&setup.retrieve())
+            .chain(&setup.to_wire())
             .chain(aux)
             .finalize_to_reader();
 
@@ -141,12 +140,12 @@ impl<P: SchemeParams> AffGProof<P> {
         let z3 = gamma + e_wide * m;
         let z4 = delta + e_wide * mu;
 
-        let omega = (r_mod * rho.pow_signed_vartime(&e)).retrieve();
+        let omega = (r_mod * rho.pow_signed_vartime(&e)).to_wire();
 
         // NOTE: deviation from the paper to support a different $D$
         // (see the comment in `AffGProof`)
         // Original: $\rho_y^e$. Modified: $\rho_y^{-e}$.
-        let omega_y = (r_y_mod * rho_y.pow_signed_vartime(&-e)).retrieve();
+        let omega_y = (r_y_mod * rho_y.pow_signed_vartime(&-e)).to_wire();
 
         Self {
             e,
@@ -169,13 +168,13 @@ impl<P: SchemeParams> AffGProof<P> {
     #[allow(clippy::too_many_arguments)]
     pub fn verify(
         &self,
-        pk0: &PublicKeyPaillierPrecomputed<P::Paillier>,
-        pk1: &PublicKeyPaillierPrecomputed<P::Paillier>,
-        cap_c: &CiphertextMod<P::Paillier>,
-        cap_d: &CiphertextMod<P::Paillier>,
-        cap_y: &CiphertextMod<P::Paillier>,
+        pk0: &PublicKeyPaillier<P::Paillier>,
+        pk1: &PublicKeyPaillier<P::Paillier>,
+        cap_c: &Ciphertext<P::Paillier>,
+        cap_d: &Ciphertext<P::Paillier>,
+        cap_y: &Ciphertext<P::Paillier>,
         cap_x: &Point,
-        setup: &RPParamsMod<P::Paillier>,
+        setup: &RPParams<P::Paillier>,
         aux: &impl Hashable,
     ) -> bool {
         assert!(cap_c.public_key() == pk0);
@@ -192,13 +191,13 @@ impl<P: SchemeParams> AffGProof<P> {
             .chain(&self.cap_s)
             .chain(&self.cap_t)
             // public parameters
-            .chain(pk0.as_minimal())
-            .chain(pk1.as_minimal())
-            .chain(&cap_c.retrieve())
-            .chain(&cap_d.retrieve())
-            .chain(&cap_y.retrieve())
+            .chain(pk0.as_wire())
+            .chain(pk1.as_wire())
+            .chain(&cap_c.to_wire())
+            .chain(&cap_d.to_wire())
+            .chain(&cap_y.to_wire())
             .chain(cap_x)
-            .chain(&setup.retrieve())
+            .chain(&setup.to_wire())
             .chain(aux)
             .finalize_to_reader();
 
@@ -221,8 +220,8 @@ impl<P: SchemeParams> AffGProof<P> {
 
         // C^{z_1} (1 + N_0)^{z_2} \omega^{N_0} = A D^e \mod N_0^2
         // => C (*) z_1 (+) encrypt_0(z_2, \omega) = A (+) D (*) e
-        if cap_c * self.z1 + CiphertextMod::new_with_randomizer_signed(pk0, &self.z2, &self.omega)
-            != cap_d * e + self.cap_a.to_mod(pk0)
+        if cap_c * self.z1 + Ciphertext::new_with_randomizer_signed(pk0, &self.z2, &self.omega)
+            != cap_d * e + self.cap_a.to_precomputed(pk0)
         {
             return false;
         }
@@ -237,22 +236,22 @@ impl<P: SchemeParams> AffGProof<P> {
         // Original: `Y^e`. Modified `Y^{-e}`.
         // (1 + N_1)^{z_2} \omega_y^{N_1} = B_y Y^(-e) \mod N_1^2
         // => encrypt_1(z_2, \omega_y) = B_y (+) Y (*) (-e)
-        if CiphertextMod::new_with_randomizer_signed(pk1, &self.z2, &self.omega_y)
-            != cap_y * (-e) + self.cap_b_y.to_mod(pk1)
+        if Ciphertext::new_with_randomizer_signed(pk1, &self.z2, &self.omega_y)
+            != cap_y * (-e) + self.cap_b_y.to_precomputed(pk1)
         {
             return false;
         }
 
         // s^{z_1} t^{z_3} = E S^e \mod \hat{N}
-        let cap_e_mod = self.cap_e.to_mod(setup);
-        let cap_s_mod = self.cap_s.to_mod(setup);
+        let cap_e_mod = self.cap_e.to_precomputed(setup);
+        let cap_s_mod = self.cap_s.to_precomputed(setup);
         if setup.commit(&self.z1, &self.z3) != &cap_e_mod * &cap_s_mod.pow_signed_vartime(&e) {
             return false;
         }
 
         // s^{z_2} t^{z_4} = F T^e \mod \hat{N}
-        let cap_f_mod = self.cap_f.to_mod(setup);
-        let cap_t_mod = self.cap_t.to_mod(setup);
+        let cap_f_mod = self.cap_f.to_precomputed(setup);
+        let cap_t_mod = self.cap_t.to_precomputed(setup);
         if setup.commit(&self.z2, &self.z4) != &cap_f_mod * &cap_t_mod.pow_signed_vartime(&e) {
             return false;
         }
@@ -269,7 +268,7 @@ mod tests {
     use super::AffGProof;
     use crate::{
         cggmp21::{SchemeParams, TestParams},
-        paillier::{CiphertextMod, RPParamsMod, RandomizerMod, SecretKeyPaillier},
+        paillier::{Ciphertext, RPParams, Randomizer, SecretKeyPaillierWire},
         uint::Signed,
     };
 
@@ -278,26 +277,26 @@ mod tests {
         type Params = TestParams;
         type Paillier = <Params as SchemeParams>::Paillier;
 
-        let sk0 = SecretKeyPaillier::<Paillier>::random(&mut OsRng).into_precomputed();
+        let sk0 = SecretKeyPaillierWire::<Paillier>::random(&mut OsRng).into_precomputed();
         let pk0 = sk0.public_key();
 
-        let sk1 = SecretKeyPaillier::<Paillier>::random(&mut OsRng).into_precomputed();
+        let sk1 = SecretKeyPaillierWire::<Paillier>::random(&mut OsRng).into_precomputed();
         let pk1 = sk1.public_key();
 
-        let rp_params = RPParamsMod::random(&mut OsRng);
+        let rp_params = RPParams::random(&mut OsRng);
 
         let aux: &[u8] = b"abcde";
 
         let x = Signed::random_bounded_bits(&mut OsRng, Params::L_BOUND);
         let y = SecretBox::new(Box::new(Signed::random_bounded_bits(&mut OsRng, Params::LP_BOUND)));
 
-        let rho = RandomizerMod::random(&mut OsRng, pk0);
-        let rho_y = RandomizerMod::random(&mut OsRng, pk1);
+        let rho = Randomizer::random(&mut OsRng, pk0);
+        let rho_y = Randomizer::random(&mut OsRng, pk1);
         let secret = Signed::random_bounded_bits(&mut OsRng, Params::L_BOUND);
-        let cap_c = CiphertextMod::new_signed(&mut OsRng, pk0, &secret);
+        let cap_c = Ciphertext::new_signed(&mut OsRng, pk0, &secret);
 
-        let cap_d = &cap_c * x + CiphertextMod::new_with_randomizer_signed(pk0, &-y.expose_secret(), &rho.retrieve());
-        let cap_y = CiphertextMod::new_with_randomizer_signed(pk1, y.expose_secret(), &rho_y.retrieve());
+        let cap_d = &cap_c * x + Ciphertext::new_with_randomizer_signed(pk0, &-y.expose_secret(), &rho.to_wire());
+        let cap_y = Ciphertext::new_with_randomizer_signed(pk1, y.expose_secret(), &rho_y.to_wire());
         let cap_x = Params::scalar_from_signed(&x).mul_by_generator();
 
         let proof = AffGProof::<Params>::new(

--- a/synedrion/src/cggmp21/sigma/dec.rs
+++ b/synedrion/src/cggmp21/sigma/dec.rs
@@ -56,7 +56,7 @@ impl<P: SchemeParams> DecProof<P> {
     ) -> Self {
         assert_eq!(cap_c.public_key(), pk0);
 
-        let hat_cap_n = &setup.public_key().modulus_bounded(); // $\hat{N}$
+        let hat_cap_n = &setup.modulus_bounded(); // $\hat{N}$
 
         let alpha = Signed::random_bounded_bits(rng, P::L_BOUND + P::EPS_BOUND);
         let mu = Signed::random_bounded_bits_scaled(rng, P::L_BOUND, hat_cap_n);
@@ -147,8 +147,8 @@ impl<P: SchemeParams> DecProof<P> {
         }
 
         // s^{z_1} t^{z_2} == T S^e
-        let cap_s_mod = self.cap_s.to_mod(setup.public_key());
-        let cap_t_mod = self.cap_t.to_mod(setup.public_key());
+        let cap_s_mod = self.cap_s.to_mod(setup);
+        let cap_t_mod = self.cap_t.to_mod(setup);
         if setup.commit_wide(&self.z1, &self.z2) != &cap_t_mod * &cap_s_mod.pow_signed_vartime(&e) {
             return false;
         }
@@ -173,11 +173,10 @@ mod tests {
         type Params = TestParams;
         type Paillier = <Params as SchemeParams>::Paillier;
 
-        let sk = SecretKeyPaillier::<Paillier>::random(&mut OsRng).to_precomputed();
+        let sk = SecretKeyPaillier::<Paillier>::random(&mut OsRng).into_precomputed();
         let pk = sk.public_key();
 
-        let aux_sk = SecretKeyPaillier::<Paillier>::random(&mut OsRng).to_precomputed();
-        let setup = RPParamsMod::random(&mut OsRng, &aux_sk);
+        let setup = RPParamsMod::random(&mut OsRng);
 
         let aux: &[u8] = b"abcde";
 

--- a/synedrion/src/cggmp21/sigma/dec.rs
+++ b/synedrion/src/cggmp21/sigma/dec.rs
@@ -7,8 +7,8 @@ use super::super::SchemeParams;
 use crate::{
     curve::Scalar,
     paillier::{
-        Ciphertext, CiphertextMod, PaillierParams, PublicKeyPaillierPrecomputed, RPCommitment, RPParamsMod, Randomizer,
-        RandomizerMod,
+        Ciphertext, CiphertextWire, PaillierParams, PublicKeyPaillier, RPCommitmentWire, RPParams, Randomizer,
+        RandomizerWire,
     },
     tools::hashing::{Chain, Hashable, XofHasher},
     uint::Signed,
@@ -33,13 +33,13 @@ Public inputs:
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct DecProof<P: SchemeParams> {
     e: Signed<<P::Paillier as PaillierParams>::Uint>,
-    cap_s: RPCommitment<P::Paillier>,
-    cap_t: RPCommitment<P::Paillier>,
-    cap_a: Ciphertext<P::Paillier>,
+    cap_s: RPCommitmentWire<P::Paillier>,
+    cap_t: RPCommitmentWire<P::Paillier>,
+    cap_a: CiphertextWire<P::Paillier>,
     gamma: Scalar,
     z1: Signed<<P::Paillier as PaillierParams>::WideUint>,
     z2: Signed<<P::Paillier as PaillierParams>::WideUint>,
-    omega: Randomizer<P::Paillier>,
+    omega: RandomizerWire<P::Paillier>,
 }
 
 impl<P: SchemeParams> DecProof<P> {
@@ -47,11 +47,11 @@ impl<P: SchemeParams> DecProof<P> {
     pub fn new(
         rng: &mut impl CryptoRngCore,
         y: &Signed<<P::Paillier as PaillierParams>::Uint>,
-        rho: &RandomizerMod<P::Paillier>,
-        pk0: &PublicKeyPaillierPrecomputed<P::Paillier>,
+        rho: &Randomizer<P::Paillier>,
+        pk0: &PublicKeyPaillier<P::Paillier>,
         x: &Scalar,
-        cap_c: &CiphertextMod<P::Paillier>,
-        setup: &RPParamsMod<P::Paillier>,
+        cap_c: &Ciphertext<P::Paillier>,
+        setup: &RPParams<P::Paillier>,
         aux: &impl Hashable,
     ) -> Self {
         assert_eq!(cap_c.public_key(), pk0);
@@ -61,11 +61,11 @@ impl<P: SchemeParams> DecProof<P> {
         let alpha = Signed::random_bounded_bits(rng, P::L_BOUND + P::EPS_BOUND);
         let mu = Signed::random_bounded_bits_scaled(rng, P::L_BOUND, hat_cap_n);
         let nu = Signed::random_bounded_bits_scaled(rng, P::L_BOUND + P::EPS_BOUND, hat_cap_n);
-        let r = RandomizerMod::random(rng, pk0);
+        let r = Randomizer::random(rng, pk0);
 
-        let cap_s = setup.commit(y, &mu).retrieve();
-        let cap_t = setup.commit(&alpha, &nu).retrieve();
-        let cap_a = CiphertextMod::new_with_randomizer_signed(pk0, &alpha, &r.retrieve()).retrieve();
+        let cap_s = setup.commit(y, &mu).to_wire();
+        let cap_t = setup.commit(&alpha, &nu).to_wire();
+        let cap_a = Ciphertext::new_with_randomizer_signed(pk0, &alpha, &r.to_wire()).to_wire();
         let gamma = P::scalar_from_signed(&alpha);
 
         let mut reader = XofHasher::new_with_dst(HASH_TAG)
@@ -78,10 +78,10 @@ impl<P: SchemeParams> DecProof<P> {
             .chain(&cap_a)
             .chain(&gamma)
             // public parameters
-            .chain(pk0.as_minimal())
+            .chain(pk0.as_wire())
             .chain(x)
-            .chain(&cap_c.retrieve())
-            .chain(&setup.retrieve())
+            .chain(&cap_c.to_wire())
+            .chain(&setup.to_wire())
             .chain(aux)
             .finalize_to_reader();
 
@@ -91,7 +91,7 @@ impl<P: SchemeParams> DecProof<P> {
         let z1 = alpha.into_wide() + e.mul_wide(y);
         let z2 = nu + e.into_wide() * mu;
 
-        let omega = (r * rho.pow_signed_vartime(&e)).retrieve();
+        let omega = (r * rho.pow_signed_vartime(&e)).to_wire();
 
         Self {
             e,
@@ -107,10 +107,10 @@ impl<P: SchemeParams> DecProof<P> {
 
     pub fn verify(
         &self,
-        pk0: &PublicKeyPaillierPrecomputed<P::Paillier>,
+        pk0: &PublicKeyPaillier<P::Paillier>,
         x: &Scalar,
-        cap_c: &CiphertextMod<P::Paillier>,
-        setup: &RPParamsMod<P::Paillier>,
+        cap_c: &Ciphertext<P::Paillier>,
+        setup: &RPParams<P::Paillier>,
         aux: &impl Hashable,
     ) -> bool {
         assert_eq!(cap_c.public_key(), pk0);
@@ -122,10 +122,10 @@ impl<P: SchemeParams> DecProof<P> {
             .chain(&self.cap_a)
             .chain(&self.gamma)
             // public parameters
-            .chain(pk0.as_minimal())
+            .chain(pk0.as_wire())
             .chain(x)
-            .chain(&cap_c.retrieve())
-            .chain(&setup.retrieve())
+            .chain(&cap_c.to_wire())
+            .chain(&setup.to_wire())
             .chain(aux)
             .finalize_to_reader();
 
@@ -137,7 +137,9 @@ impl<P: SchemeParams> DecProof<P> {
         }
 
         // enc(z_1, \omega) == A (+) C (*) e
-        if CiphertextMod::new_with_randomizer_wide(pk0, &self.z1, &self.omega) != self.cap_a.to_mod(pk0) + cap_c * e {
+        if Ciphertext::new_with_randomizer_wide(pk0, &self.z1, &self.omega)
+            != self.cap_a.to_precomputed(pk0) + cap_c * e
+        {
             return false;
         }
 
@@ -147,8 +149,8 @@ impl<P: SchemeParams> DecProof<P> {
         }
 
         // s^{z_1} t^{z_2} == T S^e
-        let cap_s_mod = self.cap_s.to_mod(setup);
-        let cap_t_mod = self.cap_t.to_mod(setup);
+        let cap_s_mod = self.cap_s.to_precomputed(setup);
+        let cap_t_mod = self.cap_t.to_precomputed(setup);
         if setup.commit_wide(&self.z1, &self.z2) != &cap_t_mod * &cap_s_mod.pow_signed_vartime(&e) {
             return false;
         }
@@ -164,7 +166,7 @@ mod tests {
     use super::DecProof;
     use crate::{
         cggmp21::{SchemeParams, TestParams},
-        paillier::{CiphertextMod, PaillierParams, RPParamsMod, RandomizerMod, SecretKeyPaillier},
+        paillier::{Ciphertext, PaillierParams, RPParams, Randomizer, SecretKeyPaillierWire},
         uint::Signed,
     };
 
@@ -173,10 +175,10 @@ mod tests {
         type Params = TestParams;
         type Paillier = <Params as SchemeParams>::Paillier;
 
-        let sk = SecretKeyPaillier::<Paillier>::random(&mut OsRng).into_precomputed();
+        let sk = SecretKeyPaillierWire::<Paillier>::random(&mut OsRng).into_precomputed();
         let pk = sk.public_key();
 
-        let setup = RPParamsMod::random(&mut OsRng);
+        let setup = RPParams::random(&mut OsRng);
 
         let aux: &[u8] = b"abcde";
 
@@ -184,8 +186,8 @@ mod tests {
         let y = Signed::random_bounded_bits(&mut OsRng, Paillier::PRIME_BITS * 2 - 2);
         let x = Params::scalar_from_signed(&y);
 
-        let rho = RandomizerMod::random(&mut OsRng, pk);
-        let cap_c = CiphertextMod::new_with_randomizer_signed(pk, &y, &rho.retrieve());
+        let rho = Randomizer::random(&mut OsRng, pk);
+        let cap_c = Ciphertext::new_with_randomizer_signed(pk, &y, &rho.to_wire());
 
         let proof = DecProof::<Params>::new(&mut OsRng, &y, &rho, pk, &x, &cap_c, &setup, &aux);
         assert!(proof.verify(pk, &x, &cap_c, &setup, &aux));

--- a/synedrion/src/cggmp21/sigma/enc.rs
+++ b/synedrion/src/cggmp21/sigma/enc.rs
@@ -6,8 +6,8 @@ use serde::{Deserialize, Serialize};
 use super::super::SchemeParams;
 use crate::{
     paillier::{
-        Ciphertext, CiphertextMod, PaillierParams, PublicKeyPaillierPrecomputed, RPCommitment, RPParamsMod, Randomizer,
-        RandomizerMod,
+        Ciphertext, CiphertextWire, PaillierParams, PublicKeyPaillier, RPCommitmentWire, RPParams, Randomizer,
+        RandomizerWire,
     },
     tools::hashing::{Chain, Hashable, XofHasher},
     uint::Signed,
@@ -30,11 +30,11 @@ Public inputs:
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct EncProof<P: SchemeParams> {
     e: Signed<<P::Paillier as PaillierParams>::Uint>,
-    cap_s: RPCommitment<P::Paillier>,
-    cap_a: Ciphertext<P::Paillier>,
-    cap_c: RPCommitment<P::Paillier>,
+    cap_s: RPCommitmentWire<P::Paillier>,
+    cap_a: CiphertextWire<P::Paillier>,
+    cap_c: RPCommitmentWire<P::Paillier>,
     z1: Signed<<P::Paillier as PaillierParams>::Uint>,
-    z2: Randomizer<P::Paillier>,
+    z2: RandomizerWire<P::Paillier>,
     z3: Signed<<P::Paillier as PaillierParams>::WideUint>,
 }
 
@@ -42,10 +42,10 @@ impl<P: SchemeParams> EncProof<P> {
     pub fn new(
         rng: &mut impl CryptoRngCore,
         k: &Signed<<P::Paillier as PaillierParams>::Uint>,
-        rho: &RandomizerMod<P::Paillier>,
-        pk0: &PublicKeyPaillierPrecomputed<P::Paillier>,
-        cap_k: &CiphertextMod<P::Paillier>,
-        setup: &RPParamsMod<P::Paillier>,
+        rho: &Randomizer<P::Paillier>,
+        pk0: &PublicKeyPaillier<P::Paillier>,
+        cap_k: &Ciphertext<P::Paillier>,
+        setup: &RPParams<P::Paillier>,
         aux: &impl Hashable,
     ) -> Self {
         k.assert_bound(P::L_BOUND);
@@ -57,12 +57,12 @@ impl<P: SchemeParams> EncProof<P> {
         // This will ensure that the range check on the prover side will pass.
         let alpha = Signed::random_bounded_bits(rng, P::L_BOUND + P::EPS_BOUND);
         let mu = Signed::random_bounded_bits_scaled(rng, P::L_BOUND, hat_cap_n);
-        let r = RandomizerMod::random(rng, pk0);
+        let r = Randomizer::random(rng, pk0);
         let gamma = Signed::random_bounded_bits_scaled(rng, P::L_BOUND + P::EPS_BOUND, hat_cap_n);
 
-        let cap_s = setup.commit(k, &mu).retrieve();
-        let cap_a = CiphertextMod::new_with_randomizer_signed(pk0, &alpha, &r.retrieve()).retrieve();
-        let cap_c = setup.commit(&alpha, &gamma).retrieve();
+        let cap_s = setup.commit(k, &mu).to_wire();
+        let cap_a = Ciphertext::new_with_randomizer_signed(pk0, &alpha, &r.to_wire()).to_wire();
+        let cap_c = setup.commit(&alpha, &gamma).to_wire();
 
         let mut reader = XofHasher::new_with_dst(HASH_TAG)
             // commitments
@@ -70,9 +70,9 @@ impl<P: SchemeParams> EncProof<P> {
             .chain(&cap_a)
             .chain(&cap_c)
             // public parameters
-            .chain(pk0.as_minimal())
-            .chain(&cap_k.retrieve())
-            .chain(&setup.retrieve())
+            .chain(pk0.as_wire())
+            .chain(&cap_k.to_wire())
+            .chain(&setup.to_wire())
             .chain(aux)
             .finalize_to_reader();
 
@@ -80,7 +80,7 @@ impl<P: SchemeParams> EncProof<P> {
         let e = Signed::from_xof_reader_bounded(&mut reader, &P::CURVE_ORDER);
 
         let z1 = alpha + e * k;
-        let z2 = (r * rho.pow_signed_vartime(&e)).retrieve();
+        let z2 = (r * rho.pow_signed_vartime(&e)).to_wire();
         let z3 = gamma + mu * e.into_wide();
 
         Self {
@@ -96,9 +96,9 @@ impl<P: SchemeParams> EncProof<P> {
 
     pub fn verify(
         &self,
-        pk0: &PublicKeyPaillierPrecomputed<P::Paillier>,
-        cap_k: &CiphertextMod<P::Paillier>,
-        setup: &RPParamsMod<P::Paillier>,
+        pk0: &PublicKeyPaillier<P::Paillier>,
+        cap_k: &Ciphertext<P::Paillier>,
+        setup: &RPParams<P::Paillier>,
         aux: &impl Hashable,
     ) -> bool {
         assert_eq!(cap_k.public_key(), pk0);
@@ -109,9 +109,9 @@ impl<P: SchemeParams> EncProof<P> {
             .chain(&self.cap_a)
             .chain(&self.cap_c)
             // public parameters
-            .chain(pk0.as_minimal())
-            .chain(&cap_k.retrieve())
-            .chain(&setup.retrieve())
+            .chain(pk0.as_wire())
+            .chain(&cap_k.to_wire())
+            .chain(&setup.to_wire())
             .chain(aux)
             .finalize_to_reader();
 
@@ -128,14 +128,14 @@ impl<P: SchemeParams> EncProof<P> {
         }
 
         // enc_0(z1, z2) == A (+) K (*) e
-        let c = CiphertextMod::new_with_randomizer_signed(pk0, &self.z1, &self.z2);
-        if c != self.cap_a.to_mod(pk0) + cap_k * e {
+        let c = Ciphertext::new_with_randomizer_signed(pk0, &self.z1, &self.z2);
+        if c != self.cap_a.to_precomputed(pk0) + cap_k * e {
             return false;
         }
 
         // s^{z_1} t^{z_3} == C S^e \mod \hat{N}
-        let cap_c_mod = self.cap_c.to_mod(setup);
-        let cap_s_mod = self.cap_s.to_mod(setup);
+        let cap_c_mod = self.cap_c.to_precomputed(setup);
+        let cap_s_mod = self.cap_s.to_precomputed(setup);
         if setup.commit(&self.z1, &self.z3) != &cap_c_mod * &cap_s_mod.pow_signed_vartime(&e) {
             return false;
         }
@@ -151,7 +151,7 @@ mod tests {
     use super::EncProof;
     use crate::{
         cggmp21::{SchemeParams, TestParams},
-        paillier::{CiphertextMod, RPParamsMod, RandomizerMod, SecretKeyPaillier},
+        paillier::{Ciphertext, RPParams, Randomizer, SecretKeyPaillierWire},
         uint::Signed,
     };
 
@@ -160,16 +160,16 @@ mod tests {
         type Params = TestParams;
         type Paillier = <Params as SchemeParams>::Paillier;
 
-        let sk = SecretKeyPaillier::<Paillier>::random(&mut OsRng).into_precomputed();
+        let sk = SecretKeyPaillierWire::<Paillier>::random(&mut OsRng).into_precomputed();
         let pk = sk.public_key();
 
-        let setup = RPParamsMod::random(&mut OsRng);
+        let setup = RPParams::random(&mut OsRng);
 
         let aux: &[u8] = b"abcde";
 
         let secret = Signed::random_bounded_bits(&mut OsRng, Params::L_BOUND);
-        let randomizer = RandomizerMod::random(&mut OsRng, pk);
-        let ciphertext = CiphertextMod::new_with_randomizer_signed(pk, &secret, &randomizer.retrieve());
+        let randomizer = Randomizer::random(&mut OsRng, pk);
+        let ciphertext = Ciphertext::new_with_randomizer_signed(pk, &secret, &randomizer.to_wire());
 
         let proof = EncProof::<Params>::new(&mut OsRng, &secret, &randomizer, pk, &ciphertext, &setup, &aux);
         assert!(proof.verify(pk, &ciphertext, &setup, &aux));

--- a/synedrion/src/cggmp21/sigma/enc.rs
+++ b/synedrion/src/cggmp21/sigma/enc.rs
@@ -51,7 +51,7 @@ impl<P: SchemeParams> EncProof<P> {
         k.assert_bound(P::L_BOUND);
         assert_eq!(cap_k.public_key(), pk0);
 
-        let hat_cap_n = &setup.public_key().modulus_bounded(); // $\hat{N}$
+        let hat_cap_n = &setup.modulus_bounded(); // $\hat{N}$
 
         // TODO (#86): should we instead sample in range $+- 2^{\ell + \eps} - q 2^\ell$?
         // This will ensure that the range check on the prover side will pass.
@@ -134,8 +134,8 @@ impl<P: SchemeParams> EncProof<P> {
         }
 
         // s^{z_1} t^{z_3} == C S^e \mod \hat{N}
-        let cap_c_mod = self.cap_c.to_mod(setup.public_key());
-        let cap_s_mod = self.cap_s.to_mod(setup.public_key());
+        let cap_c_mod = self.cap_c.to_mod(setup);
+        let cap_s_mod = self.cap_s.to_mod(setup);
         if setup.commit(&self.z1, &self.z3) != &cap_c_mod * &cap_s_mod.pow_signed_vartime(&e) {
             return false;
         }
@@ -160,11 +160,10 @@ mod tests {
         type Params = TestParams;
         type Paillier = <Params as SchemeParams>::Paillier;
 
-        let sk = SecretKeyPaillier::<Paillier>::random(&mut OsRng).to_precomputed();
+        let sk = SecretKeyPaillier::<Paillier>::random(&mut OsRng).into_precomputed();
         let pk = sk.public_key();
 
-        let aux_sk = SecretKeyPaillier::<Paillier>::random(&mut OsRng).to_precomputed();
-        let setup = RPParamsMod::random(&mut OsRng, &aux_sk);
+        let setup = RPParamsMod::random(&mut OsRng);
 
         let aux: &[u8] = b"abcde";
 

--- a/synedrion/src/cggmp21/sigma/fac.rs
+++ b/synedrion/src/cggmp21/sigma/fac.rs
@@ -58,7 +58,7 @@ impl<P: SchemeParams> FacProof<P> {
         // `z1` and `z2` during verification.
         let sqrt_cap_n = Bounded::new(
             <P::Paillier as PaillierParams>::Uint::one() << (<P::Paillier as PaillierParams>::PRIME_BITS - 2),
-            <P::Paillier as PaillierParams>::PRIME_BITS as u32,
+            <P::Paillier as PaillierParams>::PRIME_BITS,
         )
         .expect("the value is bounded by `2^PRIME_BITS` by construction");
 

--- a/synedrion/src/cggmp21/sigma/log_star.rs
+++ b/synedrion/src/cggmp21/sigma/log_star.rs
@@ -58,7 +58,7 @@ impl<P: SchemeParams> LogStarProof<P> {
         x.assert_bound(P::L_BOUND);
         assert_eq!(cap_c.public_key(), pk0);
 
-        let hat_cap_n = &setup.public_key().modulus_bounded(); // $\hat{N}$
+        let hat_cap_n = &setup.modulus_bounded(); // $\hat{N}$
 
         let alpha = Signed::random_bounded_bits(rng, P::L_BOUND + P::EPS_BOUND);
         let mu = Signed::random_bounded_bits_scaled(rng, P::L_BOUND, hat_cap_n);
@@ -155,8 +155,8 @@ impl<P: SchemeParams> LogStarProof<P> {
         }
 
         // s^{z_1} t^{z_3} == D S^e \mod \hat{N}
-        let cap_d_mod = self.cap_d.to_mod(setup.public_key());
-        let cap_s_mod = self.cap_s.to_mod(setup.public_key());
+        let cap_d_mod = self.cap_d.to_mod(setup);
+        let cap_s_mod = self.cap_s.to_mod(setup);
         if setup.commit(&self.z1, &self.z3) != &cap_d_mod * &cap_s_mod.pow_signed_vartime(&e) {
             return false;
         }
@@ -182,11 +182,10 @@ mod tests {
         type Params = TestParams;
         type Paillier = <Params as SchemeParams>::Paillier;
 
-        let sk = SecretKeyPaillier::<Paillier>::random(&mut OsRng).to_precomputed();
+        let sk = SecretKeyPaillier::<Paillier>::random(&mut OsRng).into_precomputed();
         let pk = sk.public_key();
 
-        let aux_sk = SecretKeyPaillier::<Paillier>::random(&mut OsRng).to_precomputed();
-        let setup = RPParamsMod::random(&mut OsRng, &aux_sk);
+        let setup = RPParamsMod::random(&mut OsRng);
 
         let aux: &[u8] = b"abcde";
 

--- a/synedrion/src/cggmp21/sigma/mod_.rs
+++ b/synedrion/src/cggmp21/sigma/mod_.rs
@@ -2,7 +2,7 @@
 
 use alloc::vec::Vec;
 
-use crypto_bigint::{PowBoundedExp, Square};
+use crypto_bigint::Square;
 use rand_core::CryptoRngCore;
 use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
@@ -11,7 +11,7 @@ use super::super::SchemeParams;
 use crate::{
     paillier::{PaillierParams, PublicKeyPaillierPrecomputed, SecretKeyPaillierPrecomputed},
     tools::hashing::{uint_from_xof, Chain, Hashable, XofHasher},
-    uint::{RandomPrimeWithRng, Retrieve, ToMontgomery},
+    uint::{Exponentiable, RandomPrimeWithRng, Retrieve, ToMontgomery},
 };
 
 const HASH_TAG: &[u8] = b"P_mod";
@@ -120,10 +120,7 @@ impl<P: SchemeParams> ModProof<P> {
 
                 let y = challenge.0[i].to_montgomery(pk.monty_params_mod_n());
                 let sk_inv_modulus = sk.inv_modulus();
-                let z = y.pow_bounded_exp(
-                    sk_inv_modulus.expose_secret().as_ref(),
-                    sk_inv_modulus.expose_secret().bound(),
-                );
+                let z = y.pow_bounded(sk_inv_modulus.expose_secret());
 
                 ModProofElem {
                     x: y_4th,
@@ -170,7 +167,7 @@ impl<P: SchemeParams> ModProof<P> {
             let z_m = elem.z.to_montgomery(monty_params);
             let mut y_m = y.to_montgomery(monty_params);
             let pk_modulus_bounded = pk.modulus_bounded();
-            if z_m.pow_bounded_exp(pk_modulus_bounded.as_ref(), pk_modulus_bounded.bound()) != y_m {
+            if z_m.pow_bounded(&pk_modulus_bounded) != y_m {
                 return false;
             }
 

--- a/synedrion/src/cggmp21/sigma/mod_.rs
+++ b/synedrion/src/cggmp21/sigma/mod_.rs
@@ -21,7 +21,7 @@ struct ModCommitment<P: SchemeParams>(<P::Paillier as PaillierParams>::Uint);
 
 impl<P: SchemeParams> ModCommitment<P> {
     fn random(rng: &mut impl CryptoRngCore, sk: &SecretKeyPaillier<P::Paillier>) -> Self {
-        Self(sk.random_nonsquare_group_elem(rng))
+        Self(sk.random_nonsquare_residue(rng))
     }
 }
 

--- a/synedrion/src/cggmp21/sigma/mul.rs
+++ b/synedrion/src/cggmp21/sigma/mul.rs
@@ -59,11 +59,8 @@ impl<P: SchemeParams> MulProof<P> {
         let r_mod = Randomizer::random(rng, pk);
         let s_mod = Randomizer::random(rng, pk);
 
-        let alpha = Bounded::new(
-            alpha_mod.retrieve(),
-            <P::Paillier as PaillierParams>::MODULUS_BITS as u32,
-        )
-        .expect("the value is bounded by `MODULUS_BITS` by construction");
+        let alpha = Bounded::new(alpha_mod.retrieve(), <P::Paillier as PaillierParams>::MODULUS_BITS)
+            .expect("the value is bounded by `MODULUS_BITS` by construction");
         let r = r_mod.to_wire();
         let s = s_mod.to_wire();
 

--- a/synedrion/src/cggmp21/sigma/mul.rs
+++ b/synedrion/src/cggmp21/sigma/mul.rs
@@ -55,7 +55,7 @@ impl<P: SchemeParams> MulProof<P> {
         assert_eq!(cap_y.public_key(), pk);
         assert_eq!(cap_c.public_key(), pk);
 
-        let alpha_mod = pk.random_invertible_group_elem(rng);
+        let alpha_mod = pk.random_invertible_residue(rng);
         let r_mod = Randomizer::random(rng, pk);
         let s_mod = Randomizer::random(rng, pk);
 

--- a/synedrion/src/cggmp21/sigma/mul.rs
+++ b/synedrion/src/cggmp21/sigma/mul.rs
@@ -165,7 +165,7 @@ mod tests {
         type Params = TestParams;
         type Paillier = <Params as SchemeParams>::Paillier;
 
-        let sk = SecretKeyPaillier::<Paillier>::random(&mut OsRng).to_precomputed();
+        let sk = SecretKeyPaillier::<Paillier>::random(&mut OsRng).into_precomputed();
         let pk = sk.public_key();
 
         let aux: &[u8] = b"abcde";

--- a/synedrion/src/cggmp21/sigma/mul.rs
+++ b/synedrion/src/cggmp21/sigma/mul.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use super::super::SchemeParams;
 use crate::{
-    paillier::{Ciphertext, CiphertextMod, PaillierParams, PublicKeyPaillierPrecomputed, Randomizer, RandomizerMod},
+    paillier::{Ciphertext, CiphertextWire, PaillierParams, PublicKeyPaillier, Randomizer, RandomizerWire},
     tools::hashing::{Chain, Hashable, XofHasher},
     uint::{Bounded, Retrieve, Signed},
 };
@@ -15,11 +15,11 @@ const HASH_TAG: &[u8] = b"P_mul";
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct MulProof<P: SchemeParams> {
     e: Signed<<P::Paillier as PaillierParams>::Uint>,
-    cap_a: Ciphertext<P::Paillier>,
-    cap_b: Ciphertext<P::Paillier>,
+    cap_a: CiphertextWire<P::Paillier>,
+    cap_b: CiphertextWire<P::Paillier>,
     z: Signed<<P::Paillier as PaillierParams>::WideUint>,
-    u: Randomizer<P::Paillier>,
-    v: Randomizer<P::Paillier>,
+    u: RandomizerWire<P::Paillier>,
+    v: RandomizerWire<P::Paillier>,
 }
 
 /**
@@ -43,12 +43,12 @@ impl<P: SchemeParams> MulProof<P> {
     pub fn new(
         rng: &mut impl CryptoRngCore,
         x: &Signed<<P::Paillier as PaillierParams>::Uint>,
-        rho_x: &RandomizerMod<P::Paillier>,
-        rho: &RandomizerMod<P::Paillier>,
-        pk: &PublicKeyPaillierPrecomputed<P::Paillier>,
-        cap_x: &CiphertextMod<P::Paillier>,
-        cap_y: &CiphertextMod<P::Paillier>,
-        cap_c: &CiphertextMod<P::Paillier>,
+        rho_x: &Randomizer<P::Paillier>,
+        rho: &Randomizer<P::Paillier>,
+        pk: &PublicKeyPaillier<P::Paillier>,
+        cap_x: &Ciphertext<P::Paillier>,
+        cap_y: &Ciphertext<P::Paillier>,
+        cap_c: &Ciphertext<P::Paillier>,
         aux: &impl Hashable,
     ) -> Self {
         assert_eq!(cap_x.public_key(), pk);
@@ -56,29 +56,29 @@ impl<P: SchemeParams> MulProof<P> {
         assert_eq!(cap_c.public_key(), pk);
 
         let alpha_mod = pk.random_invertible_group_elem(rng);
-        let r_mod = RandomizerMod::random(rng, pk);
-        let s_mod = RandomizerMod::random(rng, pk);
+        let r_mod = Randomizer::random(rng, pk);
+        let s_mod = Randomizer::random(rng, pk);
 
         let alpha = Bounded::new(
             alpha_mod.retrieve(),
             <P::Paillier as PaillierParams>::MODULUS_BITS as u32,
         )
         .expect("the value is bounded by `MODULUS_BITS` by construction");
-        let r = r_mod.retrieve();
-        let s = s_mod.retrieve();
+        let r = r_mod.to_wire();
+        let s = s_mod.to_wire();
 
-        let cap_a = (cap_y * alpha).mul_randomizer(&r).retrieve();
-        let cap_b = CiphertextMod::new_with_randomizer(pk, alpha.as_ref(), &s).retrieve();
+        let cap_a = (cap_y * alpha).mul_randomizer(&r).to_wire();
+        let cap_b = Ciphertext::new_with_randomizer(pk, alpha.as_ref(), &s).to_wire();
 
         let mut reader = XofHasher::new_with_dst(HASH_TAG)
             // commitments
             .chain(&cap_a)
             .chain(&cap_b)
             // public parameters
-            .chain(pk.as_minimal())
-            .chain(&cap_x.retrieve())
-            .chain(&cap_y.retrieve())
-            .chain(&cap_c.retrieve())
+            .chain(pk.as_wire())
+            .chain(&cap_x.to_wire())
+            .chain(&cap_y.to_wire())
+            .chain(&cap_c.to_wire())
             .chain(aux)
             .finalize_to_reader();
 
@@ -90,8 +90,8 @@ impl<P: SchemeParams> MulProof<P> {
             .into_signed()
             .expect("conversion to `WideUint` provides enough space for a sign bit")
             + e.mul_wide(x);
-        let u = (r_mod * rho.pow_signed_vartime(&e)).retrieve();
-        let v = (s_mod * rho_x.pow_signed_vartime(&e)).retrieve();
+        let u = (r_mod * rho.pow_signed_vartime(&e)).to_wire();
+        let v = (s_mod * rho_x.pow_signed_vartime(&e)).to_wire();
 
         Self {
             e,
@@ -105,10 +105,10 @@ impl<P: SchemeParams> MulProof<P> {
 
     pub fn verify(
         &self,
-        pk: &PublicKeyPaillierPrecomputed<P::Paillier>,
-        cap_x: &CiphertextMod<P::Paillier>,
-        cap_y: &CiphertextMod<P::Paillier>,
-        cap_c: &CiphertextMod<P::Paillier>,
+        pk: &PublicKeyPaillier<P::Paillier>,
+        cap_x: &Ciphertext<P::Paillier>,
+        cap_y: &Ciphertext<P::Paillier>,
+        cap_c: &Ciphertext<P::Paillier>,
         aux: &impl Hashable,
     ) -> bool {
         assert_eq!(cap_x.public_key(), pk);
@@ -120,10 +120,10 @@ impl<P: SchemeParams> MulProof<P> {
             .chain(&self.cap_a)
             .chain(&self.cap_b)
             // public parameters
-            .chain(pk.as_minimal())
-            .chain(&cap_x.retrieve())
-            .chain(&cap_y.retrieve())
-            .chain(&cap_c.retrieve())
+            .chain(pk.as_wire())
+            .chain(&cap_x.to_wire())
+            .chain(&cap_y.to_wire())
+            .chain(&cap_c.to_wire())
             .chain(aux)
             .finalize_to_reader();
 
@@ -135,13 +135,13 @@ impl<P: SchemeParams> MulProof<P> {
         }
 
         // Y^z u^N = A * C^e \mod N^2
-        if cap_y.homomorphic_mul_wide(&self.z).mul_randomizer(&self.u) != self.cap_a.to_mod(pk) + cap_c * e {
+        if cap_y.homomorphic_mul_wide(&self.z).mul_randomizer(&self.u) != self.cap_a.to_precomputed(pk) + cap_c * e {
             return false;
         }
 
         // enc(z, v) == B * X^e \mod N^2
         // (Note: typo in the paper, it uses `c` and not `v` here)
-        if CiphertextMod::new_with_randomizer_wide(pk, &self.z, &self.v) != self.cap_b.to_mod(pk) + cap_x * e {
+        if Ciphertext::new_with_randomizer_wide(pk, &self.z, &self.v) != self.cap_b.to_precomputed(pk) + cap_x * e {
             return false;
         }
 
@@ -156,7 +156,7 @@ mod tests {
     use super::MulProof;
     use crate::{
         cggmp21::{SchemeParams, TestParams},
-        paillier::{CiphertextMod, RandomizerMod, SecretKeyPaillier},
+        paillier::{Ciphertext, Randomizer, SecretKeyPaillierWire},
         uint::Signed,
     };
 
@@ -165,19 +165,19 @@ mod tests {
         type Params = TestParams;
         type Paillier = <Params as SchemeParams>::Paillier;
 
-        let sk = SecretKeyPaillier::<Paillier>::random(&mut OsRng).into_precomputed();
+        let sk = SecretKeyPaillierWire::<Paillier>::random(&mut OsRng).into_precomputed();
         let pk = sk.public_key();
 
         let aux: &[u8] = b"abcde";
 
         let x = Signed::random_bounded_bits(&mut OsRng, Params::L_BOUND);
         let y = Signed::random_bounded_bits(&mut OsRng, Params::L_BOUND);
-        let rho_x = RandomizerMod::random(&mut OsRng, pk);
-        let rho = RandomizerMod::random(&mut OsRng, pk);
+        let rho_x = Randomizer::random(&mut OsRng, pk);
+        let rho = Randomizer::random(&mut OsRng, pk);
 
-        let cap_x = CiphertextMod::new_with_randomizer_signed(pk, &x, &rho_x.retrieve());
-        let cap_y = CiphertextMod::new_signed(&mut OsRng, pk, &y);
-        let cap_c = (&cap_y * x).mul_randomizer(&rho.retrieve());
+        let cap_x = Ciphertext::new_with_randomizer_signed(pk, &x, &rho_x.to_wire());
+        let cap_y = Ciphertext::new_signed(&mut OsRng, pk, &y);
+        let cap_c = (&cap_y * x).mul_randomizer(&rho.to_wire());
 
         let proof = MulProof::<Params>::new(&mut OsRng, &x, &rho_x, &rho, pk, &cap_x, &cap_y, &cap_c, &aux);
         assert!(proof.verify(pk, &cap_x, &cap_y, &cap_c, &aux));

--- a/synedrion/src/cggmp21/sigma/mul_star.rs
+++ b/synedrion/src/cggmp21/sigma/mul_star.rs
@@ -66,7 +66,7 @@ impl<P: SchemeParams> MulStarProof<P> {
         assert_eq!(cap_c.public_key(), pk0);
         assert_eq!(cap_d.public_key(), pk0);
 
-        let hat_cap_n = &setup.public_key().modulus_bounded(); // $\hat{N}$
+        let hat_cap_n = &setup.modulus_bounded(); // $\hat{N}$
 
         let r = RandomizerMod::random(rng, pk0);
         let alpha = Signed::random_bounded_bits(rng, P::L_BOUND + P::EPS_BOUND);
@@ -148,8 +148,6 @@ impl<P: SchemeParams> MulStarProof<P> {
             return false;
         }
 
-        let aux_pk = setup.public_key();
-
         // Range check
         if !self.z1.in_range_bits(P::L_BOUND + P::EPS_BOUND) {
             return false;
@@ -166,8 +164,8 @@ impl<P: SchemeParams> MulStarProof<P> {
         }
 
         // s^{z_1} t^{z_2} == E S^e
-        let cap_e_mod = self.cap_e.to_mod(aux_pk);
-        let cap_s_mod = self.cap_s.to_mod(aux_pk);
+        let cap_e_mod = self.cap_e.to_mod(setup);
+        let cap_s_mod = self.cap_s.to_mod(setup);
         if setup.commit(&self.z1, &self.z2) != &cap_e_mod * &cap_s_mod.pow_signed_vartime(&e) {
             return false;
         }
@@ -192,11 +190,10 @@ mod tests {
         type Params = TestParams;
         type Paillier = <Params as SchemeParams>::Paillier;
 
-        let sk = SecretKeyPaillier::<Paillier>::random(&mut OsRng).to_precomputed();
+        let sk = SecretKeyPaillier::<Paillier>::random(&mut OsRng).into_precomputed();
         let pk = sk.public_key();
 
-        let aux_sk = SecretKeyPaillier::<Paillier>::random(&mut OsRng).to_precomputed();
-        let setup = RPParamsMod::random(&mut OsRng, &aux_sk);
+        let setup = RPParamsMod::random(&mut OsRng);
 
         let aux: &[u8] = b"abcde";
 

--- a/synedrion/src/cggmp21/sigma/prm.rs
+++ b/synedrion/src/cggmp21/sigma/prm.rs
@@ -29,7 +29,7 @@ struct PrmSecret<P: SchemeParams>(Vec<Bounded<<P::Paillier as PaillierParams>::U
 impl<P: SchemeParams> PrmSecret<P> {
     fn random(rng: &mut impl CryptoRngCore, secret: &RPSecret<P::Paillier>) -> Self {
         let secret = (0..P::SECURITY_PARAMETER)
-            .map(|_| secret.random_field_elem(rng))
+            .map(|_| secret.random_residue_mod_totient(rng))
             .collect();
         Self(secret)
     }

--- a/synedrion/src/cggmp21/sigma/prm.rs
+++ b/synedrion/src/cggmp21/sigma/prm.rs
@@ -90,7 +90,7 @@ impl<P: SchemeParams> PrmProof<P> {
         setup: &RPParams<P::Paillier>,
         aux: &impl Hashable,
     ) -> Self {
-        // TODO: check that secret.public_modulus == setup.public_modulus?
+        debug_assert!(&secret.modulus() == setup.modulus());
         let proof_secret = PrmSecret::<P>::random(rng, secret);
         let commitment = PrmCommitment::new(&proof_secret, setup.base());
 

--- a/synedrion/src/paillier.rs
+++ b/synedrion/src/paillier.rs
@@ -2,6 +2,7 @@ mod encryption;
 mod keys;
 mod params;
 mod ring_pedersen;
+mod rsa;
 
 pub(crate) use encryption::{Ciphertext, CiphertextMod, Randomizer, RandomizerMod};
 pub(crate) use keys::{

--- a/synedrion/src/paillier.rs
+++ b/synedrion/src/paillier.rs
@@ -4,9 +4,7 @@ mod params;
 mod ring_pedersen;
 mod rsa;
 
-pub(crate) use encryption::{Ciphertext, CiphertextMod, Randomizer, RandomizerMod};
-pub(crate) use keys::{
-    PublicKeyPaillier, PublicKeyPaillierPrecomputed, SecretKeyPaillier, SecretKeyPaillierPrecomputed,
-};
+pub(crate) use encryption::{Ciphertext, CiphertextWire, Randomizer, RandomizerWire};
+pub(crate) use keys::{PublicKeyPaillier, PublicKeyPaillierWire, SecretKeyPaillier, SecretKeyPaillierWire};
 pub(crate) use params::PaillierParams;
-pub(crate) use ring_pedersen::{RPCommitment, RPParams, RPParamsMod, RPSecret};
+pub(crate) use ring_pedersen::{RPCommitmentWire, RPParams, RPParamsWire, RPSecret};

--- a/synedrion/src/paillier/encryption.rs
+++ b/synedrion/src/paillier/encryption.rs
@@ -231,7 +231,7 @@ impl<P: PaillierParams> Ciphertext<P> {
 
         let mut result = Signed::new_from_unsigned(
             P::Uint::conditional_select(&positive_result, &negative_result, is_negative),
-            P::MODULUS_BITS as u32 - 1,
+            P::MODULUS_BITS - 1,
         )
         .expect("the value is within `[-2^(MODULUS_BITS-1), 2^(MODULUS_BITS-1)]` by construction");
 
@@ -419,7 +419,7 @@ mod tests {
         } else {
             result
         };
-        let mut signed_result = Signed::new_from_unsigned(twos_complement_result, P::MODULUS_BITS as u32 - 1).unwrap();
+        let mut signed_result = Signed::new_from_unsigned(twos_complement_result, P::MODULUS_BITS - 1).unwrap();
         signed_result.conditional_negate(val.is_negative());
         signed_result
     }
@@ -442,8 +442,7 @@ mod tests {
     fn signed_roundtrip() {
         let sk = SecretKeyPaillierWire::<PaillierTest>::random(&mut OsRng).into_precomputed();
         let pk = sk.public_key();
-        let plaintext =
-            Signed::random_bounded_bits(&mut OsRng, <PaillierTest as PaillierParams>::Uint::BITS as usize - 2);
+        let plaintext = Signed::random_bounded_bits(&mut OsRng, <PaillierTest as PaillierParams>::Uint::BITS - 2);
         let ciphertext = Ciphertext::new_signed(&mut OsRng, pk, &plaintext);
         let plaintext_back = ciphertext.decrypt_signed(&sk);
         let plaintext_reduced = reduce::<PaillierTest>(&plaintext, &pk.modulus_nonzero());
@@ -468,7 +467,7 @@ mod tests {
         let plaintext = <PaillierTest as PaillierParams>::Uint::random_mod(&mut OsRng, &pk.modulus_nonzero());
         let ciphertext = Ciphertext::<PaillierTest>::new(&mut OsRng, pk, &plaintext);
 
-        let coeff = Signed::random_bounded_bits(&mut OsRng, <PaillierTest as PaillierParams>::Uint::BITS as usize - 2);
+        let coeff = Signed::random_bounded_bits(&mut OsRng, <PaillierTest as PaillierParams>::Uint::BITS - 2);
         let new_ciphertext = ciphertext * coeff;
         let new_plaintext = new_ciphertext.decrypt(&sk);
 
@@ -498,8 +497,7 @@ mod tests {
         let pk = sk.public_key();
 
         let plaintext1 = <PaillierTest as PaillierParams>::Uint::random_mod(&mut OsRng, &pk.modulus_nonzero());
-        let plaintext2 =
-            Signed::random_bounded_bits(&mut OsRng, <PaillierTest as PaillierParams>::Uint::BITS as usize - 2);
+        let plaintext2 = Signed::random_bounded_bits(&mut OsRng, <PaillierTest as PaillierParams>::Uint::BITS - 2);
         let plaintext3 = <PaillierTest as PaillierParams>::Uint::random_mod(&mut OsRng, &pk.modulus_nonzero());
 
         let ciphertext1 = Ciphertext::<PaillierTest>::new(&mut OsRng, pk, &plaintext1);

--- a/synedrion/src/paillier/encryption.rs
+++ b/synedrion/src/paillier/encryption.rs
@@ -37,7 +37,7 @@ pub(crate) struct Randomizer<P: PaillierParams>(P::UintMod);
 
 impl<P: PaillierParams> Randomizer<P> {
     pub fn random(rng: &mut impl CryptoRngCore, pk: &PublicKeyPaillier<P>) -> Self {
-        Self(pk.random_invertible_group_elem(rng))
+        Self(pk.random_invertible_residue(rng))
     }
 
     pub fn to_wire(&self) -> RandomizerWire<P> {

--- a/synedrion/src/paillier/keys.rs
+++ b/synedrion/src/paillier/keys.rs
@@ -95,7 +95,7 @@ where
                 (*modulus.modulus())
                     .inv_mod(primes.totient().expose_secret())
                     .expect("pq is invertible mod ϕ(pq) because gcd(pq, (p-1)(q-1)) = 1"),
-                P::MODULUS_BITS as u32,
+                P::MODULUS_BITS,
             )
             .expect("We assume `P::MODULUS_BITS` is properly configured")
         })
@@ -224,7 +224,7 @@ where
                 .wrapping_shr_vartime(2)
                 .wrapping_add(&<P::HalfUint as Integer>::one())
         });
-        let candidate = x.pow_bounded_exp(power.expose_secret(), P::PRIME_BITS as u32 - 1);
+        let candidate = x.pow_bounded_exp(power.expose_secret(), P::PRIME_BITS - 1);
         if candidate.square() == *x {
             Some(candidate)
         } else {

--- a/synedrion/src/paillier/keys.rs
+++ b/synedrion/src/paillier/keys.rs
@@ -264,7 +264,7 @@ where
     /// Returns a random $w \in [0, N)$ such that $w$ is not a square modulo $N$,
     /// where $N$ is the public key
     /// (or, equivalently, such that the Jacobi symbol $(w|N) = -1$).
-    pub fn random_nonsquare_group_elem(&self, rng: &mut impl CryptoRngCore) -> P::Uint {
+    pub fn random_nonsquare_residue(&self, rng: &mut impl CryptoRngCore) -> P::Uint {
         /*
         (The sampling method and the explanation by Thomas Pornin)
 
@@ -284,7 +284,7 @@ where
         which we get by selecting $y$ uniformly from $\mathbb{Z}_N^*$ and taking $x = y^2 \mod N$.
         After that, we select uniformly between $u x$ and $-u x$.
         */
-        let y = self.public_key.modulus.random_square_group_elem(rng);
+        let y = self.public_key.modulus.random_quadratic_residue(rng);
         let b = Choice::from(rng.next_u32() as u8 & 1);
         let w = y * self.nonsquare_sampling_constant.expose_secret();
         P::UintMod::conditional_select(&w, &-w, b).retrieve()
@@ -371,8 +371,8 @@ impl<P: PaillierParams> PublicKeyPaillier<P> {
 
     /// Finds an invertible group element via rejection sampling. Returns the
     /// element in Montgomery form.
-    pub fn random_invertible_group_elem(&self, rng: &mut impl CryptoRngCore) -> P::UintMod {
-        self.modulus.random_invertible_group_elem(rng)
+    pub fn random_invertible_residue(&self, rng: &mut impl CryptoRngCore) -> P::UintMod {
+        self.modulus.random_invertible_residue(rng)
     }
 }
 

--- a/synedrion/src/paillier/keys.rs
+++ b/synedrion/src/paillier/keys.rs
@@ -1,167 +1,68 @@
-use alloc::boxed::Box;
-use core::fmt::Debug;
-
-use crypto_bigint::{InvMod, Monty, Odd, ShrVartime, Square, WrappingAdd, WrappingSub};
-use rand_core::CryptoRngCore;
-use secrecy::{ExposeSecret, SecretBox};
-use serde::{Deserialize, Serialize};
-use zeroize::Zeroize;
-
-use super::params::PaillierParams;
-use crate::uint::{
-    subtle::{Choice, ConditionallySelectable},
-    Bounded, CheckedAdd, CheckedSub, HasWide, Integer, Invert, NonZero, PowBoundedExp, RandomMod, RandomPrimeWithRng,
-    Retrieve, Signed, ToMontgomery,
+use core::{
+    fmt::Debug,
+    ops::{AddAssign, SubAssign},
 };
 
-#[derive(Debug, Deserialize)]
+use crypto_bigint::{InvMod, Monty, Odd, ShrVartime, Square, WrappingAdd};
+use rand_core::CryptoRngCore;
+use secrecy::{ExposeSecret, ExposeSecretMut, SecretBox};
+use serde::{Deserialize, Serialize};
+
+use super::{
+    params::PaillierParams,
+    rsa::{PublicModulus, PublicModulusPrecomputed, SecretPrimes, SecretPrimesPrecomputed},
+};
+use crate::{
+    tools::Secret,
+    uint::{
+        subtle::{Choice, ConditionallySelectable},
+        Bounded, CheckedAdd, CheckedSub, HasWide, Integer, Invert, NonZero, PowBoundedExp, Retrieve, Signed,
+        ToMontgomery,
+    },
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(bound(serialize = "SecretPrimes<P>: Serialize"))]
+#[serde(bound(deserialize = "for<'x> SecretPrimes<P>: Deserialize<'x>"))]
 pub(crate) struct SecretKeyPaillier<P: PaillierParams> {
-    p: SecretBox<P::HalfUint>,
-    q: SecretBox<P::HalfUint>,
-}
-
-impl<P: PaillierParams> PartialEq for SecretKeyPaillier<P> {
-    fn eq(&self, other: &Self) -> bool {
-        self.p.expose_secret() == other.p.expose_secret() && self.q.expose_secret() == other.q.expose_secret()
-    }
-}
-
-impl<P: PaillierParams> Clone for SecretKeyPaillier<P> {
-    fn clone(&self) -> Self {
-        Self {
-            p: Box::new(self.p.expose_secret().clone()).into(),
-            q: Box::new(self.q.expose_secret().clone()).into(),
-        }
-    }
-}
-
-impl<P: PaillierParams> Serialize for SecretKeyPaillier<P> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        (self.p.expose_secret(), self.q.expose_secret()).serialize(serializer)
-    }
+    primes: SecretPrimes<P>,
 }
 
 impl<P: PaillierParams> SecretKeyPaillier<P> {
     pub fn random(rng: &mut impl CryptoRngCore) -> Self {
-        let p = P::HalfUint::generate_safe_prime_with_rng(rng, P::PRIME_BITS as u32);
-        let q = P::HalfUint::generate_safe_prime_with_rng(rng, P::PRIME_BITS as u32);
-
         Self {
-            p: Box::new(p).into(),
-            q: Box::new(q).into(),
+            primes: SecretPrimes::<P>::random_paillier_blum(rng),
         }
     }
 
-    pub fn to_precomputed(&self) -> SecretKeyPaillierPrecomputed<P> {
-        // Euler's totient function of $p q$ - the number of positive integers up to $p q$
-        // that are relatively prime to it.
-        // Since $p$ and $q$ are primes, $\phi(p q) = (p - 1) (q - 1)$.
-        let one = <P::HalfUint as Integer>::one();
-        let p_minus_one = self
-            .p
-            .expose_secret()
-            .checked_sub(&one)
-            .expect("`p` is prime, so greater than one");
-        let q_minus_one = self
-            .q
-            .expose_secret()
-            .checked_sub(&one)
-            .expect("`q` is prime, so greater than one");
-        let totient = Bounded::new(p_minus_one.mul_wide(&q_minus_one), P::MODULUS_BITS as u32)
-            .expect("The pre-configured bound set in `P::MODULUS_BITS` is assumed to be valid");
+    pub fn into_precomputed(self) -> SecretKeyPaillierPrecomputed<P> {
+        SecretKeyPaillierPrecomputed::new(self)
+    }
 
-        let precomputed_mod_p = P::HalfUintMod::new_params_vartime(
-            Odd::new(self.p.expose_secret().clone()).expect("`p` is assumed to be a prime greater than 2"),
-        );
-        let precomputed_mod_q = P::HalfUintMod::new_params_vartime(
-            Odd::new(self.q.expose_secret().clone()).expect("`q` is assumed to be a prime greater than 2"),
-        );
-
-        let public_key = PublicKeyPaillier {
-            modulus: self.p.expose_secret().mul_wide(self.q.expose_secret()),
-        };
-        let public_key = public_key.to_precomputed();
-
-        let inv_totient = totient
-            .into_inner()
-            .to_montgomery(public_key.precomputed_modulus())
-            .invert()
-            .expect(concat![
-                "The modulus is pq. ϕ(pq) = (p-1)(q-1) is invertible mod pq because ",
-                "neither (p-1) nor (q-1) share factors with pq."
-            ]);
-
-        let modulus: &P::Uint = public_key.modulus(); // pq
-        let inv_modulus = Bounded::new(
-            modulus
-                .inv_mod(totient.as_ref())
-                .expect("pq is invertible mod ϕ(pq) because gcd(pq, (p-1)(q-1)) = 1"),
-            P::MODULUS_BITS as u32,
-        )
-        .expect("We assume `P::MODULUS_BITS` is properly configured");
-
-        let inv_p_mod_q = self
-            .p
-            .expose_secret()
-            .clone()
-            .to_montgomery(&precomputed_mod_q)
-            .invert()
-            .expect("All non-zero integers mod a prime have a multiplicative inverse");
-
-        let inv_q_mod_p = self
-            .q
-            .expose_secret()
-            .clone()
-            .to_montgomery(&precomputed_mod_p)
-            .invert()
-            .expect("All non-zero integers have a multiplicative inverse mod a prime");
-
-        // Calculate $u$ such that $u = 1 \mod p$ and $u = -1 \mod q$.
-        // Using step of Garner's algorithm:
-        // $u = q - 1 + q (2 q^{-1} - 1 \mod p)$
-        let t = (inv_q_mod_p.clone() + inv_q_mod_p.clone() - <P::HalfUintMod as Monty>::one(precomputed_mod_p.clone()))
-            .retrieve();
-        // Note that the wrapping add/sub won't overflow by construction.
-        let nonsquare_sampling_constant = t
-            .mul_wide(self.q.expose_secret())
-            .wrapping_add(&self.q.expose_secret().clone().into_wide())
-            .wrapping_sub(&<P::Uint as Integer>::one());
-
-        let nonsquare_sampling_constant = P::UintMod::new(
-            nonsquare_sampling_constant,
-            Clone::clone(public_key.precomputed_modulus()),
-        );
-
-        SecretKeyPaillierPrecomputed {
-            sk: self.clone(),
-            totient: Box::new(totient).into(),
-            inv_totient,
-            inv_modulus,
-            inv_p_mod_q,
-            nonsquare_sampling_constant,
-            precomputed_mod_p: precomputed_mod_p.clone(),
-            precomputed_mod_q: precomputed_mod_q.clone(),
-            public_key,
-        }
+    pub fn public_key(&self) -> PublicKeyPaillier<P> {
+        PublicKeyPaillier::new(&self.primes)
     }
 }
 
 #[derive(Debug, Clone)]
 pub(crate) struct SecretKeyPaillierPrecomputed<P: PaillierParams> {
-    sk: SecretKeyPaillier<P>,
-    totient: SecretBox<Bounded<P::Uint>>,
-    /// $\phi(N)^{-1} \mod N$
-    inv_totient: P::UintMod,
-    /// $N^{-1} \mod \phi(N)$
-    inv_modulus: Bounded<P::Uint>,
-    inv_p_mod_q: P::HalfUintMod,
-    // $u$ such that $u = 1 \mod p$ and $u = -1 \mod q$.
-    nonsquare_sampling_constant: P::UintMod,
-    precomputed_mod_p: <P::HalfUintMod as Monty>::Params,
-    precomputed_mod_q: <P::HalfUintMod as Monty>::Params,
+    /// The secret primes with some precomputed constants,
+    primes: SecretPrimesPrecomputed<P>,
+    /// The inverse of the totient modulo the modulus ($\phi(N)^{-1} \mod N$).
+    inv_totient: Secret<P::UintMod>,
+    /// The inverse of the modulus modulo the totient ($N^{-1} \mod \phi(N)$).
+    inv_modulus: Secret<Bounded<P::Uint>>,
+    /// $p^{-1} \mod q$, a constant used when joining an RNS-represented number using Garner's algorithm.
+    inv_p_mod_q: Secret<P::HalfUintMod>,
+    // $u$ such that $u = -1 \mod p$ and $u = 1 \mod q$. Used for sampling of non-square residues.
+    nonsquare_sampling_constant: Secret<P::UintMod>,
+    // TODO: these should be secret, but they are not zeroizable.
+    // See https://github.com/RustCrypto/crypto-bigint/issues/704
+    /// Montgomery parameters for operations modulo $p$.
+    monty_params_mod_p: <P::HalfUintMod as Monty>::Params,
+    /// Montgomery parameters for operations modulo $q$.
+    monty_params_mod_q: <P::HalfUintMod as Monty>::Params,
+    /// The precomputed public key
     public_key: PublicKeyPaillierPrecomputed<P>,
 }
 
@@ -169,65 +70,125 @@ impl<P> SecretKeyPaillierPrecomputed<P>
 where
     P: PaillierParams,
 {
-    pub fn to_minimal(&self) -> SecretKeyPaillier<P> {
-        self.sk.clone()
+    pub fn new(secret_key: SecretKeyPaillier<P>) -> Self {
+        let primes = secret_key.primes.into_precomputed();
+        let modulus = primes.modulus().into_precomputed();
+
+        let monty_params_mod_p = P::HalfUintMod::new_params_vartime(*primes.p_half_odd().expose_secret());
+        let monty_params_mod_q = P::HalfUintMod::new_params_vartime(*primes.q_half_odd().expose_secret());
+
+        let inv_totient = SecretBox::init_with(|| {
+            primes
+                .totient()
+                .expose_secret()
+                .to_montgomery(modulus.monty_params_mod_n())
+                .invert()
+                .expect(concat![
+                    "The modulus is pq. ϕ(pq) = (p-1)(q-1) is invertible mod pq because ",
+                    "neither (p-1) nor (q-1) share factors with pq."
+                ])
+        })
+        .into();
+
+        let inv_modulus = SecretBox::init_with(|| {
+            Bounded::new(
+                (*modulus.modulus())
+                    .inv_mod(primes.totient().expose_secret())
+                    .expect("pq is invertible mod ϕ(pq) because gcd(pq, (p-1)(q-1)) = 1"),
+                P::MODULUS_BITS as u32,
+            )
+            .expect("We assume `P::MODULUS_BITS` is properly configured")
+        })
+        .into();
+
+        let inv_p_mod_q = Secret::from(SecretBox::init_with(|| {
+            primes
+                .p_half()
+                .expose_secret()
+                // NOTE: `monty_params_mod_q` is cloned here and can remain on the stack.
+                // See https://github.com/RustCrypto/crypto-bigint/issues/704
+                .to_montgomery(&monty_params_mod_q)
+                .invert()
+                .expect("All non-zero integers mod a prime have a multiplicative inverse")
+        }));
+
+        // Calculate $u$ such that $u = -1 \mod p$ and $u = 1 \mod q$.
+        // Using one step of Garner's algorithm:
+        // $u = p - 1 + p (2 p^{-1} - 1 \mod q)$
+
+        // Calculate $t = 2 p^{-1} - 1 \mod q$
+
+        let one = SecretBox::init_with(|| {
+            // NOTE: `monty_params_mod_q` is cloned here and can remain on the stack.
+            // See https://github.com/RustCrypto/crypto-bigint/issues/704
+            P::HalfUintMod::one(monty_params_mod_q.clone())
+        });
+        let mut t_mod = inv_p_mod_q.clone();
+        t_mod.expose_secret_mut().add_assign(inv_p_mod_q.expose_secret());
+        t_mod.expose_secret_mut().sub_assign(one.expose_secret());
+        let t = SecretBox::init_with(|| t_mod.expose_secret().retrieve());
+
+        // Calculate $u$
+
+        let u = SecretBox::init_with(|| t.expose_secret().mul_wide(primes.p_half().expose_secret()));
+        let u = SecretBox::init_with(|| {
+            u.expose_secret()
+                .checked_add(primes.p().expose_secret())
+                .expect("does not overflow by construction")
+        });
+        let u = SecretBox::init_with(|| {
+            u.expose_secret()
+                .checked_sub(&<P::Uint as Integer>::one())
+                .expect("does not overflow by construction")
+        });
+        let nonsquare_sampling_constant =
+            SecretBox::init_with(|| P::UintMod::new(*u.expose_secret(), modulus.monty_params_mod_n().clone())).into();
+
+        let public_key = PublicKeyPaillierPrecomputed::new(modulus);
+
+        Self {
+            primes,
+            inv_totient,
+            inv_modulus,
+            inv_p_mod_q,
+            nonsquare_sampling_constant,
+            monty_params_mod_p,
+            monty_params_mod_q,
+            public_key,
+        }
     }
 
-    #[allow(clippy::type_complexity)]
-    pub fn primes(&self) -> (SecretBox<Signed<P::Uint>>, SecretBox<Signed<P::Uint>>) {
-        // The primes are positive, but where this method is used Signed is needed,
-        // so we return that for convenience.
-        (
-            SecretBox::new(Box::new(
-                Signed::new_positive(self.sk.p.expose_secret().clone().into_wide(), P::PRIME_BITS as u32).expect(
-                    concat![
-                        "The primes in the `SecretKeyPaillier` are 'safe primes' ",
-                        "and positive by construction; the bound is assumed to be configured correctly by the user."
-                    ],
-                ),
-            )),
-            SecretBox::new(Box::new(
-                Signed::new_positive(self.sk.q.expose_secret().clone().into_wide(), P::PRIME_BITS as u32).expect(
-                    concat![
-                        "The primes in the `SecretKeyPaillier` are 'safe primes' ",
-                        "and positive by construction; the bound is assumed to be configured correctly by the user."
-                    ],
-                ),
-            )),
-        )
+    pub fn into_minimal(self) -> SecretKeyPaillier<P> {
+        SecretKeyPaillier {
+            primes: self.primes.into_minimal(),
+        }
+    }
+
+    pub fn p_signed(&self) -> SecretBox<Signed<P::Uint>> {
+        self.primes.p_signed()
+    }
+
+    pub fn q_signed(&self) -> SecretBox<Signed<P::Uint>> {
+        self.primes.q_signed()
+    }
+
+    pub fn p_wide_signed(&self) -> SecretBox<Signed<P::WideUint>> {
+        self.primes.p_wide_signed()
     }
 
     /// Returns Euler's totient function (`φ(n)`) of the modulus, wrapped in a [`SecretBox`].
-    pub fn totient(&self) -> SecretBox<Bounded<P::Uint>> {
-        self.totient.clone()
-    }
-
-    /// Returns Euler's totient function (`φ(n)`) of the modulus as a [`NonZero`], wrapped in a [`SecretBox`].
-    pub fn totient_nonzero(&self) -> SecretBox<NonZero<P::Uint>> {
-        let p = NonZero::new(self.totient.expose_secret().into_inner()).expect(concat![
-            "φ(n) is never zero for n >= 1; n is strictly greater than 1 ",
-            "because it is (p-1)(q-1) and given that both p and q are prime ",
-            "they are both strictly greater than 1"
-        ]);
-        Box::new(p).into()
+    pub fn totient_wide_bounded(&self) -> SecretBox<Bounded<P::WideUint>> {
+        self.primes.totient_wide_bounded()
     }
 
     /// Returns $\phi(N)^{-1} \mod N$
-    pub fn inv_totient(&self) -> SecretBox<P::UintMod> {
-        Box::new(self.inv_totient).into()
+    pub fn inv_totient(&self) -> &SecretBox<P::UintMod> {
+        &self.inv_totient
     }
 
     /// Returns $N^{-1} \mod \phi(N)$
-    pub fn inv_modulus(&self) -> &Bounded<P::Uint> {
+    pub fn inv_modulus(&self) -> &SecretBox<Bounded<P::Uint>> {
         &self.inv_modulus
-    }
-
-    fn precomputed_mod_p(&self) -> &<P::HalfUintMod as Monty>::Params {
-        &self.precomputed_mod_p
-    }
-
-    fn precomputed_mod_q(&self) -> &<P::HalfUintMod as Monty>::Params {
-        &self.precomputed_mod_q
     }
 
     pub fn public_key(&self) -> &PublicKeyPaillierPrecomputed<P> {
@@ -237,33 +198,31 @@ where
     pub fn rns_split(&self, elem: &P::Uint) -> (P::HalfUintMod, P::HalfUintMod) {
         // May be some speed up potential here since we know p and q are small,
         // but it needs to be supported by `crypto-bigint`.
-        let mut p_rem = *elem % NonZero::new(self.sk.p.expose_secret().clone().into_wide()).expect("`p` is non-zero");
-        let mut q_rem = *elem % NonZero::new(self.sk.q.expose_secret().clone().into_wide()).expect("`q` is non-zero");
+        let p_rem = *elem % self.primes.p_nonzero().expose_secret();
+        let q_rem = *elem % self.primes.q_nonzero().expose_secret();
         let p_rem_half = P::HalfUint::try_from_wide(p_rem).expect("`p` fits into `HalfUint`");
         let q_rem_half = P::HalfUint::try_from_wide(q_rem).expect("`q` fits into `HalfUint`");
 
-        let p_rem_mod = p_rem_half.to_montgomery(self.precomputed_mod_p());
-        let q_rem_mod = q_rem_half.to_montgomery(self.precomputed_mod_q());
-
-        // crypto_bigint::Uint<LIMB> does not impl `ZeroizeOnDrop` (only
-        // `DefaultIsZeroes`) so we're stuck with this rather clunky way of zeroizing.
-        p_rem.zeroize();
-        q_rem.zeroize();
+        // NOTE: `monty_params_mod_q` is cloned here and can remain on the stack.
+        // See https://github.com/RustCrypto/crypto-bigint/issues/704
+        let p_rem_mod = p_rem_half.to_montgomery(&self.monty_params_mod_p);
+        let q_rem_mod = q_rem_half.to_montgomery(&self.monty_params_mod_q);
 
         (p_rem_mod, q_rem_mod)
     }
 
-    fn sqrt_part(&self, x: &P::HalfUintMod, modulus: &P::HalfUint) -> Option<P::HalfUintMod> {
+    fn sqrt_part(&self, x: &P::HalfUintMod, modulus: &SecretBox<P::HalfUint>) -> Option<P::HalfUintMod> {
         // Both `p` and `q` are safe primes, so they're 3 mod 4.
         // This means that if square root exists, it must be of the form `+/- x^((modulus+1)/4)`.
         // Also it means that `(modulus+1)/4 == modulus/4+1`
         // (this will help avoid a possible overflow).
-        let candidate = x.pow_bounded_exp(
-            &modulus
+        let power = SecretBox::init_with(|| {
+            modulus
+                .expose_secret()
                 .wrapping_shr_vartime(2)
-                .wrapping_add(&<P::HalfUint as Integer>::one()),
-            P::PRIME_BITS as u32 - 1,
-        );
+                .wrapping_add(&<P::HalfUint as Integer>::one())
+        });
+        let candidate = x.pow_bounded_exp(power.expose_secret(), P::PRIME_BITS as u32 - 1);
         if candidate.square() == *x {
             Some(candidate)
         } else {
@@ -271,12 +230,12 @@ where
         }
     }
 
-    pub fn sqrt(&self, rns: &(P::HalfUintMod, P::HalfUintMod)) -> Option<(P::HalfUintMod, P::HalfUintMod)> {
+    pub fn rns_sqrt(&self, rns: &(P::HalfUintMod, P::HalfUintMod)) -> Option<(P::HalfUintMod, P::HalfUintMod)> {
         // TODO (#73): when we can extract the modulus from `HalfUintMod`, this can be moved there.
         // For now we have to keep this a method of SecretKey to have access to `p` and `q`.
         let (p_part, q_part) = rns;
-        let p_res = self.sqrt_part(p_part, self.sk.p.expose_secret());
-        let q_res = self.sqrt_part(q_part, self.sk.q.expose_secret());
+        let p_res = self.sqrt_part(p_part, self.primes.p_half());
+        let q_res = self.sqrt_part(q_part, self.primes.q_half());
         match (p_res, q_res) {
             (Some(p), Some(q)) => Some((p, q)),
             _ => None,
@@ -291,35 +250,24 @@ where
         let (a_mod_p, b_mod_q) = rns;
 
         let a_half = a_mod_p.retrieve();
-        let a_mod_q = P::HalfUintMod::new(a_half.clone(), self.precomputed_mod_q.clone());
-        let x = ((b_mod_q.clone() - a_mod_q) * self.inv_p_mod_q.clone()).retrieve();
+        let a_mod_q = a_half.to_montgomery(&self.monty_params_mod_q);
+        let x = ((b_mod_q.clone() - a_mod_q) * self.inv_p_mod_q.expose_secret()).retrieve();
         let a = a_half.into_wide();
 
         // Will not overflow since 0 <= x < q, and 0 <= a < p.
-        a.checked_add(&self.sk.p.expose_secret().mul_wide(&x))
+        a.checked_add(&self.primes.p_half().expose_secret().mul_wide(&x))
             .expect("Will not overflow since 0 <= x < q, and 0 <= a < p.")
-    }
-
-    pub fn random_field_elem(&self, rng: &mut impl CryptoRngCore) -> Bounded<P::Uint> {
-        Bounded::new(
-            P::Uint::random_mod(rng, self.totient_nonzero().expose_secret()),
-            P::MODULUS_BITS as u32,
-        )
-        .expect(concat![
-            "the totient is smaller than the modulus, ",
-            "and thefore can be bounded by 2^MODULUS_BITS"
-        ])
     }
 
     /// Returns a random $w \in [0, N)$ such that $w$ is not a square modulo $N$,
     /// where $N$ is the public key
     /// (or, equivalently, such that the Jacobi symbol $(w|N) = -1$).
-    pub fn random_nonsquare(&self, rng: &mut impl CryptoRngCore) -> P::Uint {
+    pub fn random_nonsquare_group_elem(&self, rng: &mut impl CryptoRngCore) -> P::Uint {
         /*
         (The sampling method and the explanation by Thomas Pornin)
 
         Recall that `nonsquare_sampling_constant` $u$ is such that
-        $u = 1 \mod p$ and $u = -1 \mod q$, so $u^2 = 1 \mod N$.
+        $u = -1 \mod p$ and $u = 1 \mod q$, so $u^2 = 1 \mod N$.
 
         For an $x \in \mathbb{Z}_N^*$ (that is, an invertible element),
         consider the set $S_x = {x, -x, u x, -u x}$.
@@ -327,108 +275,108 @@ where
         are completely disjoint: the sets $S_x$ make a partition of $\mathbb{Z}_N^*$.
 
         Moreover, exactly two of the four elements of $S_x$ is a square modulo $N$.
-        If $x$ is the square in $S_x$, then the Jacobi symbols $(x|N)$ and $(-x|N)$
-        are both equal to 1, while the Jacobi symbols $(u x|N)$ and $(-u x|N)$
-        are both equal to -1.
+        If $x$ is the square in $S_x$, then the Jacobi symbols $(x|N)$ and $(-x|N)$ are both equal to 1,
+        while the Jacobi symbols $(u x|N)$ and $(-u x|N)$ are both equal to -1.
 
-        In order to get a uniform integer of Jacobi symbol -1,
-        we need to make a uniform selection of $S_x$,
+        In order to get a uniform integer of Jacobi symbol -1, we need to make a uniform selection of $S_x$,
         which we get by selecting $y$ uniformly from $\mathbb{Z}_N^*$ and taking $x = y^2 \mod N$.
         After that, we select uniformly between $u x$ and $-u x$.
         */
-        let y = self.public_key.random_invertible_group_elem(rng);
+        let y = self.public_key.modulus.random_invertible_group_elem(rng);
         let b = Choice::from(rng.next_u32() as u8 & 1);
-        let w = self.nonsquare_sampling_constant * y.square();
+        let w = y.square() * self.nonsquare_sampling_constant.expose_secret();
         P::UintMod::conditional_select(&w, &-w, b).retrieve()
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound(serialize = "PublicModulus<P>: Serialize"))]
+#[serde(bound(deserialize = "for<'x> PublicModulus<P>: Deserialize<'x>"))]
 pub(crate) struct PublicKeyPaillier<P: PaillierParams> {
-    modulus: P::Uint, // TODO (#104): wrap it in `crypto_bigint::Odd`
+    modulus: PublicModulus<P>,
 }
 
 impl<P: PaillierParams> PublicKeyPaillier<P> {
-    pub fn modulus(&self) -> &P::Uint {
-        &self.modulus
+    fn new(primes: &SecretPrimes<P>) -> Self {
+        Self {
+            modulus: primes.modulus(),
+        }
     }
 
-    pub fn to_precomputed(&self) -> PublicKeyPaillierPrecomputed<P> {
-        // Note that this ensures that `self.modulus` is odd,
-        // otherwise creating the Montgomery parameters fails.
-        let odd = Odd::new(self.modulus).expect("Assumed to  be odd");
-        let precomputed_modulus = P::UintMod::new_params_vartime(odd);
-        let precomputed_modulus_squared = P::WideUintMod::new_params_vartime(
-            Odd::new(self.modulus.square_wide()).expect("Square of odd number is odd"),
-        );
-
-        PublicKeyPaillierPrecomputed {
-            pk: self.clone(),
-            precomputed_modulus,
-            precomputed_modulus_squared,
-        }
+    pub fn into_precomputed(self) -> PublicKeyPaillierPrecomputed<P> {
+        PublicKeyPaillierPrecomputed::new(self.modulus.into_precomputed())
     }
 }
 
 #[derive(Debug, Clone)]
 pub(crate) struct PublicKeyPaillierPrecomputed<P: PaillierParams> {
-    pk: PublicKeyPaillier<P>,
-    precomputed_modulus: <P::UintMod as Monty>::Params,
-    precomputed_modulus_squared: <P::WideUintMod as Monty>::Params,
+    modulus: PublicModulusPrecomputed<P>,
+    monty_params_mod_n_squared: <P::WideUintMod as Monty>::Params,
+    /// The minimal public key (for hashing purposes)
+    public_key_minimal: PublicKeyPaillier<P>,
 }
 
 impl<P: PaillierParams> PublicKeyPaillierPrecomputed<P> {
-    pub fn as_minimal(&self) -> &PublicKeyPaillier<P> {
-        &self.pk
+    fn new(modulus: PublicModulusPrecomputed<P>) -> Self {
+        let monty_params_mod_n_squared = P::WideUintMod::new_params_vartime(
+            Odd::new(modulus.modulus().square_wide()).expect("Square of odd number is odd"),
+        );
+
+        let public_key_minimal = PublicKeyPaillier {
+            modulus: modulus.clone().into_minimal(),
+        };
+
+        PublicKeyPaillierPrecomputed {
+            modulus,
+            monty_params_mod_n_squared,
+            public_key_minimal,
+        }
     }
 
-    pub fn to_minimal(&self) -> PublicKeyPaillier<P> {
-        self.pk.clone()
+    pub fn as_minimal(&self) -> &PublicKeyPaillier<P> {
+        &self.public_key_minimal
+    }
+
+    pub fn into_minimal(self) -> PublicKeyPaillier<P> {
+        self.public_key_minimal.clone()
     }
 
     pub fn modulus(&self) -> &P::Uint {
-        self.pk.modulus()
+        self.modulus.modulus()
     }
 
     pub fn modulus_bounded(&self) -> Bounded<P::Uint> {
-        Bounded::new(*self.pk.modulus(), P::MODULUS_BITS as u32).expect("the modulus can be bounded by 2^MODULUS_BITS")
+        self.modulus.modulus_bounded()
     }
 
     pub fn modulus_nonzero(&self) -> NonZero<P::Uint> {
-        NonZero::new(*self.modulus()).expect("the modulus is non-zero")
+        self.modulus.modulus_nonzero()
     }
 
     pub fn modulus_wide_nonzero(&self) -> NonZero<P::WideUint> {
-        NonZero::new(self.pk.modulus().into_wide()).expect("the modulus is non-zero")
+        NonZero::new(self.modulus.modulus().into_wide()).expect("the modulus is non-zero")
     }
 
     /// Returns precomputed parameters for integers modulo N
-    pub fn precomputed_modulus(&self) -> &<P::UintMod as Monty>::Params {
-        &self.precomputed_modulus
+    pub fn monty_params_mod_n(&self) -> &<P::UintMod as Monty>::Params {
+        self.modulus.monty_params_mod_n()
     }
 
     /// Returns precomputed parameters for integers modulo N^2
-    pub fn precomputed_modulus_squared(&self) -> &<P::WideUintMod as Monty>::Params {
-        &self.precomputed_modulus_squared
+    pub fn monty_params_mod_n_squared(&self) -> &<P::WideUintMod as Monty>::Params {
+        &self.monty_params_mod_n_squared
     }
 
     /// Finds an invertible group element via rejection sampling. Returns the
     /// element in Montgomery form.
     pub fn random_invertible_group_elem(&self, rng: &mut impl CryptoRngCore) -> P::UintMod {
-        let modulus = self.modulus_nonzero();
-        loop {
-            let r = P::Uint::random_mod(rng, &modulus);
-            let r_m = P::UintMod::new(r, self.precomputed_modulus().clone());
-            if r_m.invert().is_some().into() {
-                return r_m;
-            }
-        }
+        self.modulus.random_invertible_group_elem(rng)
     }
 }
 
 impl<P: PaillierParams> PartialEq for PublicKeyPaillierPrecomputed<P> {
     fn eq(&self, other: &Self) -> bool {
-        self.pk.eq(&other.pk)
+        self.modulus.eq(&other.modulus)
     }
 }
 
@@ -445,7 +393,7 @@ mod tests {
 
     #[test]
     fn basics() {
-        let sk = SecretKeyPaillier::<PaillierTest>::random(&mut OsRng).to_precomputed();
+        let sk = SecretKeyPaillier::<PaillierTest>::random(&mut OsRng).into_precomputed();
         let _pk = sk.public_key();
     }
 
@@ -458,8 +406,8 @@ mod tests {
             debug_output,
             concat![
                 "Sikrit SecretKeyPaillier ",
-                "{ p: SecretBox<crypto_bigint::uint::Uint<8>>([REDACTED]), ",
-                "q: SecretBox<crypto_bigint::uint::Uint<8>>([REDACTED]) }"
+                "{ primes: SecretPrimes { p: Secret<crypto_bigint::uint::Uint<8>>(...), ",
+                "q: Secret<crypto_bigint::uint::Uint<8>>(...) } }",
             ]
         );
     }
@@ -472,27 +420,34 @@ mod tests {
         let serializer = serde_assert::Serializer::builder().build();
         let sk_ser = sk.serialize(&serializer).unwrap();
         let expected_tokens = [
-            Token::Tuple { len: 2 },
+            Token::Struct {
+                name: "SecretKeyPaillier",
+                len: 1,
+            },
+            Token::Field("primes"),
+            Token::Struct {
+                name: "SecretPrimes",
+                len: 2,
+            },
+            Token::Field("p"),
             Token::Str(
                 concat![
-                    "d30b226b6f3a29a048826fa4cf85f83a7aa03d097ec89aea7b1f35633f5719e1",
-                    "80b93af2508fc289c196078937d9d8a61af6d7768301d231bafdf87c10f28f8a"
+                    "cf4ee6be31dbfa5fe153ec138abb8a8d8271386e6e359dd18f0ef4b8f7301391",
+                    "2f58867d5d8fb0f30b1d96f215100ff97097b3baac10c8cc3aac969e7df3ac8e"
                 ]
-                .into(),
+                .to_string(),
             ),
+            Token::Field("q"),
             Token::Str(
                 concat![
-                    "7f0e0796291488cf87ed167109d9daf34e4ad5cc1399c9d034803b9536525989",
-                    "63abf19b9675653a51e619651f1ab15e66256829c250903fae3ab96683b5aff9"
+                    "732bbb2b9a150d2797ab52dde9dd00f467b6608d5c3161cca23711e754365752",
+                    "51f55e9c3b34412388f592f71c638c73edf68a6af97aab03faff8c42357a8cd0"
                 ]
-                .into(),
+                .to_string(),
             ),
-            Token::TupleEnd,
+            Token::StructEnd,
+            Token::StructEnd,
         ];
         assert_eq!(sk_ser, expected_tokens);
-
-        // Clone works
-        let clone = sk.clone();
-        assert_eq!(sk, clone);
     }
 }

--- a/synedrion/src/paillier/keys.rs
+++ b/synedrion/src/paillier/keys.rs
@@ -129,6 +129,8 @@ where
         let t = SecretBox::init_with(|| t_mod.expose_secret().retrieve());
 
         // Calculate $u$
+        // I am not entirely sure if it can be used to learn something about `p` and `q`,
+        // so just to be on the safe side it lives in the secret key.
 
         let u = SecretBox::init_with(|| t.expose_secret().mul_wide(primes.p_half().expose_secret()));
         let u = SecretBox::init_with(|| {
@@ -282,9 +284,9 @@ where
         which we get by selecting $y$ uniformly from $\mathbb{Z}_N^*$ and taking $x = y^2 \mod N$.
         After that, we select uniformly between $u x$ and $-u x$.
         */
-        let y = self.public_key.modulus.random_invertible_group_elem(rng);
+        let y = self.public_key.modulus.random_square_group_elem(rng);
         let b = Choice::from(rng.next_u32() as u8 & 1);
-        let w = y.square() * self.nonsquare_sampling_constant.expose_secret();
+        let w = y * self.nonsquare_sampling_constant.expose_secret();
         P::UintMod::conditional_select(&w, &-w, b).retrieve()
     }
 }

--- a/synedrion/src/paillier/params.rs
+++ b/synedrion/src/paillier/params.rs
@@ -1,7 +1,7 @@
 use crypto_bigint::{
     modular::Retrieve,
     subtle::{ConditionallyNegatable, ConditionallySelectable, CtOption},
-    Bounded, Encoding, Integer, InvMod, Invert, Monty, RandomMod,
+    Bounded, Encoding, Gcd, Integer, InvMod, Invert, Monty, RandomMod,
 };
 use crypto_primes::RandomPrimeWithRng;
 use serde::{Deserialize, Serialize};
@@ -40,6 +40,7 @@ pub trait PaillierParams: core::fmt::Debug + PartialEq + Eq + Clone + Send + Syn
     /// An integer that fits the RSA modulus.
     type Uint: Integer<Monty = Self::UintMod>
         + Bounded
+        + Gcd<Output = Self::Uint>
         + ConditionallySelectable
         + Encoding
         + Hashable

--- a/synedrion/src/paillier/params.rs
+++ b/synedrion/src/paillier/params.rs
@@ -5,7 +5,7 @@ use crypto_bigint::{
 };
 use crypto_primes::RandomPrimeWithRng;
 use serde::{Deserialize, Serialize};
-use zeroize::Zeroize;
+use zeroize::{DefaultIsZeroes, Zeroize};
 
 #[cfg(test)]
 use crate::uint::{U1024Mod, U2048Mod, U512Mod, U1024, U2048, U4096, U512};
@@ -28,7 +28,8 @@ pub trait PaillierParams: core::fmt::Debug + PartialEq + Eq + Clone + Send + Syn
         + for<'de> Deserialize<'de>
         + HasWide<Wide = Self::Uint>
         + ToMontgomery
-        + Zeroize;
+        + Zeroize
+        + DefaultIsZeroes;
 
     /// A modulo-residue counterpart of `HalfUint`.
     type HalfUintMod: Monty<Integer = Self::HalfUint>

--- a/synedrion/src/paillier/params.rs
+++ b/synedrion/src/paillier/params.rs
@@ -16,9 +16,9 @@ use crate::{
 
 pub trait PaillierParams: core::fmt::Debug + PartialEq + Eq + Clone + Send + Sync {
     /// The size of one of the pair of RSA primes.
-    const PRIME_BITS: usize;
+    const PRIME_BITS: u32;
     /// The size of the RSA modulus (a product of two primes).
-    const MODULUS_BITS: usize = Self::PRIME_BITS * 2;
+    const MODULUS_BITS: u32 = Self::PRIME_BITS * 2;
     /// An integer that fits a single RSA prime.
     type HalfUint: Integer<Monty = Self::HalfUintMod>
         + Bounded
@@ -103,7 +103,7 @@ pub(crate) struct PaillierTest;
 
 #[cfg(test)]
 impl PaillierParams for PaillierTest {
-    const PRIME_BITS: usize = 512;
+    const PRIME_BITS: u32 = 512;
     type HalfUint = U512;
     type HalfUintMod = U512Mod;
     type Uint = U1024;

--- a/synedrion/src/paillier/ring_pedersen.rs
+++ b/synedrion/src/paillier/ring_pedersen.rs
@@ -31,11 +31,8 @@ impl<P: PaillierParams> RPSecret<P> {
                 .expect("totient / 4 is still non-zero because p, q >= 5")
         });
         let lambda = SecretBox::init_with(|| {
-            Bounded::new(
-                P::Uint::random_mod(rng, bound.expose_secret()),
-                P::MODULUS_BITS as u32 - 2,
-            )
-            .expect("totient < N < 2^MODULUS_BITS, so totient / 4 < 2^(MODULUS_BITS - 2)")
+            Bounded::new(P::Uint::random_mod(rng, bound.expose_secret()), P::MODULUS_BITS - 2)
+                .expect("totient < N < 2^MODULUS_BITS, so totient / 4 < 2^(MODULUS_BITS - 2)")
         })
         .into();
 

--- a/synedrion/src/paillier/ring_pedersen.rs
+++ b/synedrion/src/paillier/ring_pedersen.rs
@@ -1,7 +1,7 @@
 /// Implements the Definition 3.3 from the CGGMP'21 paper and related operations.
 use core::ops::Mul;
 
-use crypto_bigint::{Monty, NonZero, RandomMod, ShrVartime, Square};
+use crypto_bigint::{Monty, NonZero, RandomMod, ShrVartime};
 use rand_core::CryptoRngCore;
 use secrecy::{ExposeSecret, SecretBox};
 use serde::{Deserialize, Serialize};
@@ -76,10 +76,9 @@ impl<P: PaillierParams> RPParamsMod<P> {
 
     pub fn random_with_secret(rng: &mut impl CryptoRngCore, secret: &RPSecret<P>) -> Self {
         let precomputed_modulus = secret.primes.modulus().into_precomputed();
-        let r = precomputed_modulus.random_invertible_group_elem(rng);
 
-        let base = r.square();
-        let power = base.pow_bounded(secret.lambda.expose_secret());
+        let base = precomputed_modulus.random_square_group_elem(rng); // $t$
+        let power = base.pow_bounded(secret.lambda.expose_secret()); // $s$
 
         Self {
             precomputed_modulus,

--- a/synedrion/src/paillier/ring_pedersen.rs
+++ b/synedrion/src/paillier/ring_pedersen.rs
@@ -43,8 +43,8 @@ impl<P: PaillierParams> RPSecret<P> {
         &self.lambda
     }
 
-    pub fn random_field_elem(&self, rng: &mut impl CryptoRngCore) -> Bounded<P::Uint> {
-        self.primes.random_field_elem(rng)
+    pub fn random_residue_mod_totient(&self, rng: &mut impl CryptoRngCore) -> Bounded<P::Uint> {
+        self.primes.random_residue_mod_totient(rng)
     }
 
     pub fn totient_nonzero(&self) -> SecretBox<NonZero<P::Uint>> {
@@ -74,7 +74,7 @@ impl<P: PaillierParams> RPParams<P> {
     pub fn random_with_secret(rng: &mut impl CryptoRngCore, secret: &RPSecret<P>) -> Self {
         let modulus = secret.primes.modulus_wire().into_precomputed();
 
-        let base = modulus.random_square_group_elem(rng); // $t$
+        let base = modulus.random_quadratic_residue(rng); // $t$
         let power = base.pow_bounded(secret.lambda.expose_secret()); // $s$
 
         Self { modulus, base, power }

--- a/synedrion/src/paillier/ring_pedersen.rs
+++ b/synedrion/src/paillier/ring_pedersen.rs
@@ -50,6 +50,10 @@ impl<P: PaillierParams> RPSecret<P> {
     pub fn totient_nonzero(&self) -> SecretBox<NonZero<P::Uint>> {
         self.primes.totient_nonzero()
     }
+
+    pub fn modulus(&self) -> P::Uint {
+        *self.primes.modulus_wire().modulus()
+    }
 }
 
 /// The expanded representation of ring-Pedersen parameters.
@@ -86,6 +90,10 @@ impl<P: PaillierParams> RPParams<P> {
 
     pub fn power(&self) -> &P::UintMod {
         &self.power
+    }
+
+    pub fn modulus(&self) -> &P::Uint {
+        self.modulus.modulus()
     }
 
     pub fn modulus_bounded(&self) -> Bounded<P::Uint> {

--- a/synedrion/src/paillier/ring_pedersen.rs
+++ b/synedrion/src/paillier/ring_pedersen.rs
@@ -1,64 +1,110 @@
+/// Implements the Definition 3.3 from the CGGMP'21 paper and related operations.
 use core::ops::Mul;
 
-use crypto_bigint::{PowBoundedExp, Square};
+use crypto_bigint::{Monty, NonZero, PowBoundedExp, RandomMod, ShrVartime, Square};
 use rand_core::CryptoRngCore;
 use secrecy::{ExposeSecret, SecretBox};
 use serde::{Deserialize, Serialize};
 
-use super::{PaillierParams, PublicKeyPaillierPrecomputed, SecretKeyPaillierPrecomputed};
-use crate::uint::{Bounded, Exponentiable, Retrieve, Signed, ToMontgomery};
+use super::{
+    rsa::{PublicModulus, PublicModulusPrecomputed, SecretPrimes, SecretPrimesPrecomputed},
+    PaillierParams,
+};
+use crate::{
+    tools::Secret,
+    uint::{Bounded, Exponentiable, Retrieve, Signed, ToMontgomery},
+};
 
-pub(crate) struct RPSecret<P: PaillierParams>(Bounded<P::Uint>);
+#[derive(Debug, Clone)]
+pub(crate) struct RPSecret<P: PaillierParams> {
+    primes: SecretPrimesPrecomputed<P>,
+    lambda: Secret<Bounded<P::Uint>>,
+}
 
 impl<P: PaillierParams> RPSecret<P> {
-    pub fn random(rng: &mut impl CryptoRngCore, sk: &SecretKeyPaillierPrecomputed<P>) -> Self {
+    pub fn random(rng: &mut impl CryptoRngCore) -> Self {
+        let primes = SecretPrimes::<P>::random_safe(rng).into_precomputed();
+
         // The random value will be reduced modulo `phi(N)` implicitly
         // when used as an exponent modulo N later.
         // So we are sampling it from this range to begin with.
-        Self(sk.random_field_elem(rng))
-    }
-}
 
-impl<P: PaillierParams> AsRef<Bounded<P::Uint>> for RPSecret<P> {
-    fn as_ref(&self) -> &Bounded<P::Uint> {
-        &self.0
+        let bound = SecretBox::init_with(|| {
+            NonZero::new(primes.totient().expose_secret().wrapping_shr_vartime(2))
+                .expect("totient / 4 is still non-zero because p, q >= 5")
+        });
+        let lambda = SecretBox::init_with(|| {
+            Bounded::new(
+                P::Uint::random_mod(rng, bound.expose_secret()),
+                P::MODULUS_BITS as u32 - 2,
+            )
+            .expect("totient < N < 2^MODULUS_BITS, so totient / 4 < 2^(MODULUS_BITS - 2)")
+        })
+        .into();
+
+        Self { primes, lambda }
+    }
+
+    pub fn lambda(&self) -> &SecretBox<Bounded<P::Uint>> {
+        &self.lambda
+    }
+
+    pub fn random_field_elem(&self, rng: &mut impl CryptoRngCore) -> Bounded<P::Uint> {
+        self.primes.random_field_elem(rng)
+    }
+
+    pub fn totient_nonzero(&self) -> SecretBox<NonZero<P::Uint>> {
+        self.primes.totient_nonzero()
     }
 }
 
 #[derive(Debug, Clone)]
 pub(crate) struct RPParamsMod<P: PaillierParams> {
-    pub(crate) pk: PublicKeyPaillierPrecomputed<P>,
+    /// The public modulus $\hat{N}$
+    precomputed_modulus: PublicModulusPrecomputed<P>,
     /// The ring-Pedersen base.
-    pub(crate) base: P::UintMod, // $t$
+    base: P::UintMod, // $t$
     /// The ring-Pedersen power (a number belonging to the group produced by the base).
-    pub(crate) power: P::UintMod, // $s$
+    power: P::UintMod, // $s = t^\lambda$, where $\lambda$ is the secret
 }
 
 impl<P: PaillierParams> RPParamsMod<P> {
-    pub fn random(rng: &mut impl CryptoRngCore, sk: &SecretKeyPaillierPrecomputed<P>) -> Self {
-        let secret = RPSecret::random(rng, sk);
-        Self::random_with_secret(rng, &secret, sk.public_key())
+    pub fn random(rng: &mut impl CryptoRngCore) -> Self {
+        let secret = RPSecret::random(rng);
+        Self::random_with_secret(rng, &secret)
     }
 
-    pub fn public_key(&self) -> &PublicKeyPaillierPrecomputed<P> {
-        &self.pk
-    }
-
-    pub fn random_with_secret(
-        rng: &mut impl CryptoRngCore,
-        secret: &RPSecret<P>,
-        pk: &PublicKeyPaillierPrecomputed<P>,
-    ) -> Self {
-        let r = pk.random_invertible_group_elem(rng);
+    pub fn random_with_secret(rng: &mut impl CryptoRngCore, secret: &RPSecret<P>) -> Self {
+        let precomputed_modulus = secret.primes.modulus().into_precomputed();
+        let r = precomputed_modulus.random_invertible_group_elem(rng);
 
         let base = r.square();
-        let power = base.pow_bounded_exp(secret.0.as_ref(), secret.0.bound());
+        let power = base.pow_bounded_exp(
+            secret.lambda.expose_secret().as_ref(),
+            secret.lambda.expose_secret().bound(),
+        );
 
         Self {
-            pk: pk.clone(),
+            precomputed_modulus,
             base,
             power,
         }
+    }
+
+    pub fn base(&self) -> &P::UintMod {
+        &self.base
+    }
+
+    pub fn power(&self) -> &P::UintMod {
+        &self.power
+    }
+
+    pub fn modulus_bounded(&self) -> Bounded<P::Uint> {
+        self.precomputed_modulus.modulus_bounded()
+    }
+
+    pub fn monty_params_mod_n(&self) -> &<P::UintMod as Monty>::Params {
+        self.precomputed_modulus.monty_params_mod_n()
     }
 
     /// Creates a commitment for `secret` with the randomizer `randomizer`.
@@ -99,6 +145,7 @@ impl<P: PaillierParams> RPParamsMod<P> {
 
     pub fn retrieve(&self) -> RPParams<P> {
         RPParams {
+            modulus: self.precomputed_modulus.modulus().clone(),
             base: self.base.retrieve(),
             power: self.power.retrieve(),
         }
@@ -106,19 +153,26 @@ impl<P: PaillierParams> RPParamsMod<P> {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(bound(serialize = "PublicModulus<P>: Serialize"))]
+#[serde(bound(deserialize = "for<'x> PublicModulus<P>: Deserialize<'x>"))]
 pub(crate) struct RPParams<P: PaillierParams> {
+    /// The public modulus $\hat{N}$
+    modulus: PublicModulus<P>,
     /// The ring-Pedersen base.
-    pub(crate) base: P::Uint, // $t$
+    base: P::Uint, // $t$
     /// The ring-Pedersen power (a number belonging to the group produced by the base).
-    pub(crate) power: P::Uint, // $s$
+    power: P::Uint, // $s$
 }
 
 impl<P: PaillierParams> RPParams<P> {
-    pub fn to_mod(&self, pk: &PublicKeyPaillierPrecomputed<P>) -> RPParamsMod<P> {
+    pub fn to_mod(&self) -> RPParamsMod<P> {
+        let precomputed_modulus = self.modulus.clone().into_precomputed();
+        let base = self.base.to_montgomery(precomputed_modulus.monty_params_mod_n());
+        let power = self.power.to_montgomery(precomputed_modulus.monty_params_mod_n());
         RPParamsMod {
-            pk: pk.clone(),
-            base: self.base.to_montgomery(pk.precomputed_modulus()),
-            power: self.power.to_montgomery(pk.precomputed_modulus()),
+            precomputed_modulus,
+            base,
+            power,
         }
     }
 }
@@ -155,7 +209,7 @@ impl<'a, P: PaillierParams> Mul<&'a RPCommitmentMod<P>> for &'a RPCommitmentMod<
 pub(crate) struct RPCommitment<P: PaillierParams>(P::Uint);
 
 impl<P: PaillierParams> RPCommitment<P> {
-    pub fn to_mod(&self, pk: &PublicKeyPaillierPrecomputed<P>) -> RPCommitmentMod<P> {
-        RPCommitmentMod(self.0.to_montgomery(pk.precomputed_modulus()))
+    pub fn to_mod(&self, params: &RPParamsMod<P>) -> RPCommitmentMod<P> {
+        RPCommitmentMod(self.0.to_montgomery(params.precomputed_modulus.monty_params_mod_n()))
     }
 }

--- a/synedrion/src/paillier/ring_pedersen.rs
+++ b/synedrion/src/paillier/ring_pedersen.rs
@@ -1,7 +1,7 @@
 /// Implements the Definition 3.3 from the CGGMP'21 paper and related operations.
 use core::ops::Mul;
 
-use crypto_bigint::{Monty, NonZero, PowBoundedExp, RandomMod, ShrVartime, Square};
+use crypto_bigint::{Monty, NonZero, RandomMod, ShrVartime, Square};
 use rand_core::CryptoRngCore;
 use secrecy::{ExposeSecret, SecretBox};
 use serde::{Deserialize, Serialize};
@@ -79,10 +79,7 @@ impl<P: PaillierParams> RPParamsMod<P> {
         let r = precomputed_modulus.random_invertible_group_elem(rng);
 
         let base = r.square();
-        let power = base.pow_bounded_exp(
-            secret.lambda.expose_secret().as_ref(),
-            secret.lambda.expose_secret().bound(),
-        );
+        let power = base.pow_bounded(secret.lambda.expose_secret());
 
         Self {
             precomputed_modulus,
@@ -130,12 +127,7 @@ impl<P: PaillierParams> RPParamsMod<P> {
         randomizer: &Signed<P::ExtraWideUint>,
     ) -> RPCommitmentMod<P> {
         // $t^\rho * s^m mod N$ where $\rho$ is the randomizer and $m$ is the secret.
-        RPCommitmentMod(
-            self.base.pow_signed_extra_wide(randomizer)
-                * self
-                    .power
-                    .pow_bounded_exp(secret.expose_secret().as_ref(), secret.expose_secret().bound()),
-        )
+        RPCommitmentMod(self.base.pow_signed_extra_wide(randomizer) * self.power.pow_bounded(secret.expose_secret()))
     }
 
     pub fn commit_base_xwide(&self, randomizer: &Signed<P::ExtraWideUint>) -> RPCommitmentMod<P> {

--- a/synedrion/src/paillier/ring_pedersen.rs
+++ b/synedrion/src/paillier/ring_pedersen.rs
@@ -7,7 +7,7 @@ use secrecy::{ExposeSecret, SecretBox};
 use serde::{Deserialize, Serialize};
 
 use super::{
-    rsa::{PublicModulus, PublicModulusPrecomputed, SecretPrimes, SecretPrimesPrecomputed},
+    rsa::{PublicModulus, PublicModulusWire, SecretPrimes, SecretPrimesWire},
     PaillierParams,
 };
 use crate::{
@@ -15,19 +15,16 @@ use crate::{
     uint::{Bounded, Exponentiable, Retrieve, Signed, ToMontgomery},
 };
 
+/// Ring-Pedersen secret.
 #[derive(Debug, Clone)]
 pub(crate) struct RPSecret<P: PaillierParams> {
-    primes: SecretPrimesPrecomputed<P>,
+    primes: SecretPrimes<P>,
     lambda: Secret<Bounded<P::Uint>>,
 }
 
 impl<P: PaillierParams> RPSecret<P> {
     pub fn random(rng: &mut impl CryptoRngCore) -> Self {
-        let primes = SecretPrimes::<P>::random_safe(rng).into_precomputed();
-
-        // The random value will be reduced modulo `phi(N)` implicitly
-        // when used as an exponent modulo N later.
-        // So we are sampling it from this range to begin with.
+        let primes = SecretPrimesWire::<P>::random_safe(rng).into_precomputed();
 
         let bound = SecretBox::init_with(|| {
             NonZero::new(primes.totient().expose_secret().wrapping_shr_vartime(2))
@@ -58,33 +55,32 @@ impl<P: PaillierParams> RPSecret<P> {
     }
 }
 
+/// The expanded representation of ring-Pedersen parameters.
+///
+/// All the necessary constants precomputed, suitable for usage in ZK proofs.
 #[derive(Debug, Clone)]
-pub(crate) struct RPParamsMod<P: PaillierParams> {
+pub(crate) struct RPParams<P: PaillierParams> {
     /// The public modulus $\hat{N}$
-    precomputed_modulus: PublicModulusPrecomputed<P>,
+    modulus: PublicModulus<P>,
     /// The ring-Pedersen base.
     base: P::UintMod, // $t$
     /// The ring-Pedersen power (a number belonging to the group produced by the base).
     power: P::UintMod, // $s = t^\lambda$, where $\lambda$ is the secret
 }
 
-impl<P: PaillierParams> RPParamsMod<P> {
+impl<P: PaillierParams> RPParams<P> {
     pub fn random(rng: &mut impl CryptoRngCore) -> Self {
         let secret = RPSecret::random(rng);
         Self::random_with_secret(rng, &secret)
     }
 
     pub fn random_with_secret(rng: &mut impl CryptoRngCore, secret: &RPSecret<P>) -> Self {
-        let precomputed_modulus = secret.primes.modulus().into_precomputed();
+        let modulus = secret.primes.modulus_wire().into_precomputed();
 
-        let base = precomputed_modulus.random_square_group_elem(rng); // $t$
+        let base = modulus.random_square_group_elem(rng); // $t$
         let power = base.pow_bounded(secret.lambda.expose_secret()); // $s$
 
-        Self {
-            precomputed_modulus,
-            base,
-            power,
-        }
+        Self { modulus, base, power }
     }
 
     pub fn base(&self) -> &P::UintMod {
@@ -96,84 +92,78 @@ impl<P: PaillierParams> RPParamsMod<P> {
     }
 
     pub fn modulus_bounded(&self) -> Bounded<P::Uint> {
-        self.precomputed_modulus.modulus_bounded()
+        self.modulus.modulus_bounded()
     }
 
     pub fn monty_params_mod_n(&self) -> &<P::UintMod as Monty>::Params {
-        self.precomputed_modulus.monty_params_mod_n()
+        self.modulus.monty_params_mod_n()
     }
 
     /// Creates a commitment for `secret` with the randomizer `randomizer`.
     ///
     /// Both will be effectively reduced modulo `totient(N)`
     /// (that is, commitments produced for `x` and `x + totient(N)` are equal).
-    // TODO (#81): swap randomizer and secret?
-    // - this will match the order for Ciphertext,
-    // - this will match the order in the paper
-    pub fn commit(&self, secret: &Signed<P::Uint>, randomizer: &Signed<P::WideUint>) -> RPCommitmentMod<P> {
+    pub fn commit(&self, secret: &Signed<P::Uint>, randomizer: &Signed<P::WideUint>) -> RPCommitment<P> {
         // $t^\rho * s^m mod N$ where $\rho$ is the randomizer and $m$ is the secret.
-        RPCommitmentMod(self.base.pow_signed_wide(randomizer) * self.power.pow_signed(secret))
+        RPCommitment(self.base.pow_signed_wide(randomizer) * self.power.pow_signed(secret))
     }
 
-    pub fn commit_wide(&self, secret: &Signed<P::WideUint>, randomizer: &Signed<P::WideUint>) -> RPCommitmentMod<P> {
+    pub fn commit_wide(&self, secret: &Signed<P::WideUint>, randomizer: &Signed<P::WideUint>) -> RPCommitment<P> {
         // $t^\rho * s^m mod N$ where $\rho$ is the randomizer and $m$ is the secret.
-        RPCommitmentMod(self.base.pow_signed_wide(randomizer) * self.power.pow_signed_wide(secret))
+        RPCommitment(self.base.pow_signed_wide(randomizer) * self.power.pow_signed_wide(secret))
     }
 
     pub fn commit_xwide(
         &self,
         secret: &SecretBox<Bounded<P::Uint>>,
         randomizer: &Signed<P::ExtraWideUint>,
-    ) -> RPCommitmentMod<P> {
+    ) -> RPCommitment<P> {
         // $t^\rho * s^m mod N$ where $\rho$ is the randomizer and $m$ is the secret.
-        RPCommitmentMod(self.base.pow_signed_extra_wide(randomizer) * self.power.pow_bounded(secret.expose_secret()))
+        RPCommitment(self.base.pow_signed_extra_wide(randomizer) * self.power.pow_bounded(secret.expose_secret()))
     }
 
-    pub fn commit_base_xwide(&self, randomizer: &Signed<P::ExtraWideUint>) -> RPCommitmentMod<P> {
+    pub fn commit_base_xwide(&self, randomizer: &Signed<P::ExtraWideUint>) -> RPCommitment<P> {
         // $t^\rho mod N$ where $\rho$ is the randomizer.
-        RPCommitmentMod(self.base.pow_signed_extra_wide(randomizer))
+        RPCommitment(self.base.pow_signed_extra_wide(randomizer))
     }
 
-    pub fn retrieve(&self) -> RPParams<P> {
-        RPParams {
-            modulus: self.precomputed_modulus.modulus().clone(),
+    pub fn to_wire(&self) -> RPParamsWire<P> {
+        RPParamsWire {
+            modulus: self.modulus.to_wire(),
             base: self.base.retrieve(),
             power: self.power.retrieve(),
         }
     }
 }
 
+/// Minimal public ring-Pedersen parameters suitable for serialization and transmission.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "PublicModulus<P>: Serialize"))]
-#[serde(bound(deserialize = "for<'x> PublicModulus<P>: Deserialize<'x>"))]
-pub(crate) struct RPParams<P: PaillierParams> {
+#[serde(bound(serialize = "PublicModulusWire<P>: Serialize"))]
+#[serde(bound(deserialize = "for<'x> PublicModulusWire<P>: Deserialize<'x>"))]
+pub(crate) struct RPParamsWire<P: PaillierParams> {
     /// The public modulus $\hat{N}$
-    modulus: PublicModulus<P>,
+    modulus: PublicModulusWire<P>,
     /// The ring-Pedersen base.
     base: P::Uint, // $t$
     /// The ring-Pedersen power (a number belonging to the group produced by the base).
     power: P::Uint, // $s$
 }
 
-impl<P: PaillierParams> RPParams<P> {
-    pub fn to_mod(&self) -> RPParamsMod<P> {
-        let precomputed_modulus = self.modulus.clone().into_precomputed();
-        let base = self.base.to_montgomery(precomputed_modulus.monty_params_mod_n());
-        let power = self.power.to_montgomery(precomputed_modulus.monty_params_mod_n());
-        RPParamsMod {
-            precomputed_modulus,
-            base,
-            power,
-        }
+impl<P: PaillierParams> RPParamsWire<P> {
+    pub fn to_precomputed(&self) -> RPParams<P> {
+        let modulus = self.modulus.clone().into_precomputed();
+        let base = self.base.to_montgomery(modulus.monty_params_mod_n());
+        let power = self.power.to_montgomery(modulus.monty_params_mod_n());
+        RPParams { modulus, base, power }
     }
 }
 
 #[derive(PartialEq, Eq)]
-pub(crate) struct RPCommitmentMod<P: PaillierParams>(P::UintMod);
+pub(crate) struct RPCommitment<P: PaillierParams>(P::UintMod);
 
-impl<P: PaillierParams> RPCommitmentMod<P> {
-    pub fn retrieve(&self) -> RPCommitment<P> {
-        RPCommitment(self.0.retrieve())
+impl<P: PaillierParams> RPCommitment<P> {
+    pub fn to_wire(&self) -> RPCommitmentWire<P> {
+        RPCommitmentWire(self.0.retrieve())
     }
 
     /// Raise to the power of `exponent`.
@@ -189,18 +179,18 @@ impl<P: PaillierParams> RPCommitmentMod<P> {
     }
 }
 
-impl<'a, P: PaillierParams> Mul<&'a RPCommitmentMod<P>> for &'a RPCommitmentMod<P> {
-    type Output = RPCommitmentMod<P>;
-    fn mul(self, rhs: &RPCommitmentMod<P>) -> Self::Output {
-        RPCommitmentMod(self.0 * rhs.0)
+impl<'a, P: PaillierParams> Mul<&'a RPCommitment<P>> for &'a RPCommitment<P> {
+    type Output = RPCommitment<P>;
+    fn mul(self, rhs: &RPCommitment<P>) -> Self::Output {
+        RPCommitment(self.0 * rhs.0)
     }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct RPCommitment<P: PaillierParams>(P::Uint);
+pub(crate) struct RPCommitmentWire<P: PaillierParams>(P::Uint);
 
-impl<P: PaillierParams> RPCommitment<P> {
-    pub fn to_mod(&self, params: &RPParamsMod<P>) -> RPCommitmentMod<P> {
-        RPCommitmentMod(self.0.to_montgomery(params.precomputed_modulus.monty_params_mod_n()))
+impl<P: PaillierParams> RPCommitmentWire<P> {
+    pub fn to_precomputed(&self, params: &RPParams<P>) -> RPCommitment<P> {
+        RPCommitment(self.0.to_montgomery(params.monty_params_mod_n()))
     }
 }

--- a/synedrion/src/paillier/rsa.rs
+++ b/synedrion/src/paillier/rsa.rs
@@ -188,7 +188,7 @@ impl<P: PaillierParams> SecretPrimes<P> {
     }
 
     /// Returns a random in range `[0, \phi(N))`.
-    pub fn random_field_elem(&self, rng: &mut impl CryptoRngCore) -> Bounded<P::Uint> {
+    pub fn random_residue_mod_totient(&self, rng: &mut impl CryptoRngCore) -> Bounded<P::Uint> {
         Bounded::new(
             P::Uint::random_mod(rng, self.totient_nonzero().expose_secret()),
             P::MODULUS_BITS,
@@ -264,7 +264,7 @@ impl<P: PaillierParams> PublicModulus<P> {
     }
 
     /// Returns a uniformly chosen number in range $[0, N)$ such that it is invertible modulo $N$, in Montgomery form.
-    pub fn random_invertible_group_elem(&self, rng: &mut impl CryptoRngCore) -> P::UintMod {
+    pub fn random_invertible_residue(&self, rng: &mut impl CryptoRngCore) -> P::UintMod {
         let modulus = self.modulus_nonzero();
         loop {
             let r = P::Uint::random_mod(rng, &modulus);
@@ -276,7 +276,7 @@ impl<P: PaillierParams> PublicModulus<P> {
     }
 
     /// Returns a uniformly chosen quadratic residue modulo $N$, in Montgomery form.
-    pub fn random_square_group_elem(&self, rng: &mut impl CryptoRngCore) -> P::UintMod {
-        self.random_invertible_group_elem(rng).square()
+    pub fn random_quadratic_residue(&self, rng: &mut impl CryptoRngCore) -> P::UintMod {
+        self.random_invertible_residue(rng).square()
     }
 }

--- a/synedrion/src/paillier/rsa.rs
+++ b/synedrion/src/paillier/rsa.rs
@@ -1,4 +1,4 @@
-use crypto_bigint::{CheckedSub, Integer, Invert, Monty, NonZero, Odd, RandomMod, Square};
+use crypto_bigint::{CheckedSub, Gcd, Integer, Monty, NonZero, Odd, RandomMod, Square};
 use crypto_primes::RandomPrimeWithRng;
 use rand_core::CryptoRngCore;
 use secrecy::{ExposeSecret, SecretBox};
@@ -268,9 +268,8 @@ impl<P: PaillierParams> PublicModulus<P> {
         let modulus = self.modulus_nonzero();
         loop {
             let r = P::Uint::random_mod(rng, &modulus);
-            let r_m = P::UintMod::new(r, self.monty_params_mod_n.clone());
-            if r_m.invert().is_some().into() {
-                return r_m;
+            if r.gcd(&self.modulus.0) == P::Uint::one() {
+                return P::UintMod::new(r, self.monty_params_mod_n.clone());
             }
         }
     }

--- a/synedrion/src/paillier/rsa.rs
+++ b/synedrion/src/paillier/rsa.rs
@@ -1,6 +1,6 @@
 use core::ops::Deref;
 
-use crypto_bigint::{Monty, NonZero, Odd, RandomMod};
+use crypto_bigint::{Monty, NonZero, Odd, RandomMod, Square};
 use crypto_primes::RandomPrimeWithRng;
 use rand_core::CryptoRngCore;
 use secrecy::{ExposeSecret, SecretBox};
@@ -252,6 +252,10 @@ impl<P: PaillierParams> PublicModulusPrecomputed<P> {
         Bounded::new(*self.modulus, P::MODULUS_BITS as u32).expect("the modulus can be bounded by 2^MODULUS_BITS")
     }
 
+    pub fn monty_params_mod_n(&self) -> &<P::UintMod as Monty>::Params {
+        &self.monty_params_mod_n
+    }
+
     /// Finds an invertible group element via rejection sampling. Returns the
     /// element in Montgomery form.
     pub fn random_invertible_group_elem(&self, rng: &mut impl CryptoRngCore) -> P::UintMod {
@@ -265,7 +269,8 @@ impl<P: PaillierParams> PublicModulusPrecomputed<P> {
         }
     }
 
-    pub fn monty_params_mod_n(&self) -> &<P::UintMod as Monty>::Params {
-        &self.monty_params_mod_n
+    /// Returns a uniformly chosen quadratic residue modulo $N$.
+    pub fn random_square_group_elem(&self, rng: &mut impl CryptoRngCore) -> P::UintMod {
+        self.random_invertible_group_elem(rng).square()
     }
 }

--- a/synedrion/src/paillier/rsa.rs
+++ b/synedrion/src/paillier/rsa.rs
@@ -211,6 +211,10 @@ impl<P: PaillierParams> PublicModulusWire<P> {
         Self(primes.p.expose_secret().mul_wide(primes.q.expose_secret()))
     }
 
+    pub fn modulus(&self) -> &P::Uint {
+        &self.0
+    }
+
     pub fn into_precomputed(self) -> PublicModulus<P> {
         PublicModulus::new(self)
     }

--- a/synedrion/src/paillier/rsa.rs
+++ b/synedrion/src/paillier/rsa.rs
@@ -34,8 +34,8 @@ pub(crate) struct SecretPrimesWire<P: PaillierParams> {
 impl<P: PaillierParams> SecretPrimesWire<P> {
     /// A single constructor to check the invariants
     fn new(p: Secret<P::HalfUint>, q: Secret<P::HalfUint>) -> Self {
-        debug_assert!(p.expose_secret().as_ref()[0].0 & 3 == 3);
-        debug_assert!(q.expose_secret().as_ref()[0].0 & 3 == 3);
+        debug_assert!(p.expose_secret().as_ref()[0].0 & 3 == 3, "p must be 3 mod 4");
+        debug_assert!(q.expose_secret().as_ref()[0].0 & 3 == 3, "q must be 3 mod 4");
         Self { p, q }
     }
 

--- a/synedrion/src/paillier/rsa.rs
+++ b/synedrion/src/paillier/rsa.rs
@@ -13,7 +13,7 @@ use crate::{
 
 fn random_paillier_blum_prime<P: PaillierParams>(rng: &mut impl CryptoRngCore) -> P::HalfUint {
     loop {
-        let prime = P::HalfUint::generate_prime_with_rng(rng, P::PRIME_BITS as u32);
+        let prime = P::HalfUint::generate_prime_with_rng(rng, P::PRIME_BITS);
         if prime.as_ref()[0].0 & 3 == 3 {
             return prime;
         }
@@ -51,8 +51,8 @@ impl<P: PaillierParams> SecretPrimesWire<P> {
     /// Creates a pair of safe primes.
     pub fn random_safe(rng: &mut impl CryptoRngCore) -> Self {
         Self::new(
-            SecretBox::init_with(|| P::HalfUint::generate_safe_prime_with_rng(rng, P::PRIME_BITS as u32)).into(),
-            SecretBox::init_with(|| P::HalfUint::generate_safe_prime_with_rng(rng, P::PRIME_BITS as u32)).into(),
+            SecretBox::init_with(|| P::HalfUint::generate_safe_prime_with_rng(rng, P::PRIME_BITS)).into(),
+            SecretBox::init_with(|| P::HalfUint::generate_safe_prime_with_rng(rng, P::PRIME_BITS)).into(),
         )
     }
 
@@ -141,13 +141,13 @@ impl<P: PaillierParams> SecretPrimes<P> {
 
     pub fn p_signed(&self) -> SecretBox<Signed<P::Uint>> {
         SecretBox::init_with(|| {
-            Signed::new_positive(*self.p().expose_secret(), P::PRIME_BITS as u32).expect("`P::PRIME_BITS` is valid")
+            Signed::new_positive(*self.p().expose_secret(), P::PRIME_BITS).expect("`P::PRIME_BITS` is valid")
         })
     }
 
     pub fn q_signed(&self) -> SecretBox<Signed<P::Uint>> {
         SecretBox::init_with(|| {
-            Signed::new_positive(*self.q().expose_secret(), P::PRIME_BITS as u32).expect("`P::PRIME_BITS` is valid")
+            Signed::new_positive(*self.q().expose_secret(), P::PRIME_BITS).expect("`P::PRIME_BITS` is valid")
         })
     }
 
@@ -169,7 +169,7 @@ impl<P: PaillierParams> SecretPrimes<P> {
 
     pub fn totient_bounded(&self) -> SecretBox<Bounded<P::Uint>> {
         SecretBox::init_with(|| {
-            Bounded::new(*self.totient.expose_secret(), P::MODULUS_BITS as u32).expect("`P::MODULUS_BITS` is valid")
+            Bounded::new(*self.totient.expose_secret(), P::MODULUS_BITS).expect("`P::MODULUS_BITS` is valid")
         })
     }
 
@@ -191,7 +191,7 @@ impl<P: PaillierParams> SecretPrimes<P> {
     pub fn random_field_elem(&self, rng: &mut impl CryptoRngCore) -> Bounded<P::Uint> {
         Bounded::new(
             P::Uint::random_mod(rng, self.totient_nonzero().expose_secret()),
-            P::MODULUS_BITS as u32,
+            P::MODULUS_BITS,
         )
         .expect(concat![
             "the totient is smaller than the modulus, ",
@@ -256,7 +256,7 @@ impl<P: PaillierParams> PublicModulus<P> {
     }
 
     pub fn modulus_bounded(&self) -> Bounded<P::Uint> {
-        Bounded::new(self.modulus.0, P::MODULUS_BITS as u32).expect("the modulus can be bounded by 2^MODULUS_BITS")
+        Bounded::new(self.modulus.0, P::MODULUS_BITS).expect("the modulus can be bounded by 2^MODULUS_BITS")
     }
 
     pub fn monty_params_mod_n(&self) -> &<P::UintMod as Monty>::Params {

--- a/synedrion/src/paillier/rsa.rs
+++ b/synedrion/src/paillier/rsa.rs
@@ -1,0 +1,271 @@
+use core::ops::Deref;
+
+use crypto_bigint::{Monty, NonZero, Odd, RandomMod};
+use crypto_primes::RandomPrimeWithRng;
+use rand_core::CryptoRngCore;
+use secrecy::{ExposeSecret, SecretBox};
+use serde::{Deserialize, Serialize};
+use zeroize::Zeroize;
+
+use super::params::PaillierParams;
+use crate::{
+    tools::Secret,
+    uint::{Bounded, CheckedSub, HasWide, Integer, Invert, Signed},
+};
+
+fn random_paillier_blum_prime<P: PaillierParams>(rng: &mut impl CryptoRngCore) -> P::HalfUint {
+    loop {
+        let prime = P::HalfUint::generate_prime_with_rng(rng, P::PRIME_BITS as u32);
+        if prime.as_ref()[0].0 & 3 == 3 {
+            return prime;
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct SecretPrimes<P: PaillierParams> {
+    p: Secret<P::HalfUint>,
+    q: Secret<P::HalfUint>,
+}
+
+impl<P: PaillierParams> SecretPrimes<P> {
+    /// Creates the primes for a Paillier-Blum modulus,
+    /// that is `p` and `q` are regular primes with an additional condition `p, q mod 3 = 4`.
+    pub fn random_paillier_blum(rng: &mut impl CryptoRngCore) -> Self {
+        Self {
+            p: SecretBox::init_with(|| random_paillier_blum_prime::<P>(rng)).into(),
+            q: SecretBox::init_with(|| random_paillier_blum_prime::<P>(rng)).into(),
+        }
+    }
+
+    /// Creates a pair of safe primes.
+    pub fn random_safe(rng: &mut impl CryptoRngCore) -> Self {
+        Self {
+            p: SecretBox::init_with(|| P::HalfUint::generate_safe_prime_with_rng(rng, P::PRIME_BITS as u32)).into(),
+            q: SecretBox::init_with(|| P::HalfUint::generate_safe_prime_with_rng(rng, P::PRIME_BITS as u32)).into(),
+        }
+    }
+
+    pub fn modulus(&self) -> PublicModulus<P> {
+        PublicModulus::new(self)
+    }
+
+    pub fn into_precomputed(self) -> SecretPrimesPrecomputed<P> {
+        SecretPrimesPrecomputed::new(self)
+    }
+}
+
+// TODO: this should be ZeroizeOnDrop, but that needs support in crypto-bigint - Monty::Params are not Zeroize.
+#[derive(Debug, Clone)]
+pub(crate) struct SecretPrimesPrecomputed<P: PaillierParams> {
+    /// The base RSA primes corresponding to a modulus $N$.
+    primes: SecretPrimes<P>,
+    /// Euler's totient function of the modulus ($\phi(N)$).
+    totient: Secret<P::Uint>,
+}
+
+impl<P: PaillierParams> SecretPrimesPrecomputed<P> {
+    pub fn new(primes: SecretPrimes<P>) -> Self {
+        let one = <P::HalfUint as Integer>::one();
+
+        let p_minus_one = primes
+            .p
+            .expose_secret()
+            .checked_sub(&one)
+            .expect("`p` is prime, so greater than one");
+        let q_minus_one = primes
+            .q
+            .expose_secret()
+            .checked_sub(&one)
+            .expect("`q` is prime, so greater than one");
+
+        // Euler's totient function of $N = p q$ - the number of positive integers up to $N$
+        // that are relatively prime to it.
+        // Since $p$ and $q$ are primes, $\phi(N) = (p - 1) (q - 1)$.
+        let totient = SecretBox::init_with(|| p_minus_one.mul_wide(&q_minus_one)).into();
+
+        Self { primes, totient }
+    }
+
+    pub fn into_minimal(self) -> SecretPrimes<P> {
+        self.primes
+    }
+
+    pub fn p_half(&self) -> &SecretBox<P::HalfUint> {
+        &self.primes.p
+    }
+
+    pub fn q_half(&self) -> &SecretBox<P::HalfUint> {
+        &self.primes.q
+    }
+
+    pub fn p_half_odd(&self) -> SecretBox<Odd<P::HalfUint>> {
+        SecretBox::init_with(|| Odd::new(*self.primes.p.expose_secret()).expect("`p` is an odd prime"))
+    }
+
+    pub fn q_half_odd(&self) -> SecretBox<Odd<P::HalfUint>> {
+        SecretBox::init_with(|| Odd::new(*self.primes.q.expose_secret()).expect("`q` is an odd prime"))
+    }
+
+    pub fn p(&self) -> SecretBox<P::Uint> {
+        SecretBox::init_with(|| {
+            let mut p = *self.primes.p.expose_secret();
+            let p_wide = p.into_wide();
+            p.zeroize();
+            p_wide
+        })
+    }
+
+    pub fn q(&self) -> SecretBox<P::Uint> {
+        SecretBox::init_with(|| {
+            let mut q = *self.primes.q.expose_secret();
+            let q_wide = q.into_wide();
+            q.zeroize();
+            q_wide
+        })
+    }
+
+    pub fn p_signed(&self) -> SecretBox<Signed<P::Uint>> {
+        SecretBox::init_with(|| {
+            Signed::new_positive(*self.p().expose_secret(), P::PRIME_BITS as u32).expect("`P::PRIME_BITS` is valid")
+        })
+    }
+
+    pub fn q_signed(&self) -> SecretBox<Signed<P::Uint>> {
+        SecretBox::init_with(|| {
+            Signed::new_positive(*self.q().expose_secret(), P::PRIME_BITS as u32).expect("`P::PRIME_BITS` is valid")
+        })
+    }
+
+    pub fn p_nonzero(&self) -> SecretBox<NonZero<P::Uint>> {
+        SecretBox::init_with(|| NonZero::new(*self.p().expose_secret()).expect("`p` is non-zero"))
+    }
+
+    pub fn q_nonzero(&self) -> SecretBox<NonZero<P::Uint>> {
+        SecretBox::init_with(|| NonZero::new(*self.q().expose_secret()).expect("`q` is non-zero"))
+    }
+
+    pub fn p_wide_signed(&self) -> SecretBox<Signed<P::WideUint>> {
+        SecretBox::init_with(|| self.p_signed().expose_secret().into_wide())
+    }
+
+    pub fn modulus(&self) -> PublicModulus<P> {
+        PublicModulus::new(&self.primes)
+    }
+
+    pub fn totient(&self) -> &SecretBox<P::Uint> {
+        &self.totient
+    }
+
+    pub fn totient_bounded(&self) -> SecretBox<Bounded<P::Uint>> {
+        SecretBox::init_with(|| {
+            Bounded::new(*self.totient.expose_secret(), P::MODULUS_BITS as u32).expect("`P::MODULUS_BITS` is valid")
+        })
+    }
+
+    pub fn totient_wide_bounded(&self) -> SecretBox<Bounded<P::WideUint>> {
+        SecretBox::init_with(|| self.totient_bounded().expose_secret().into_wide())
+    }
+
+    /// Returns Euler's totient function (`φ(n)`) of the modulus as a [`NonZero`].
+    pub fn totient_nonzero(&self) -> SecretBox<NonZero<P::Uint>> {
+        SecretBox::init_with(|| {
+            NonZero::new(*self.totient.expose_secret()).expect(concat![
+                "φ(n) is never zero for n >= 1; n is strictly greater than 1 ",
+                "because it is (p-1)(q-1) and given that both p and q are prime ",
+                "they are both strictly greater than 1"
+            ])
+        })
+    }
+
+    pub fn random_field_elem(&self, rng: &mut impl CryptoRngCore) -> Bounded<P::Uint> {
+        Bounded::new(
+            P::Uint::random_mod(rng, self.totient_nonzero().expose_secret()),
+            P::MODULUS_BITS as u32,
+        )
+        .expect(concat![
+            "the totient is smaller than the modulus, ",
+            "and thefore can be bounded by 2^MODULUS_BITS"
+        ])
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct PublicModulus<P: PaillierParams>(P::Uint);
+
+impl<P: PaillierParams> PublicModulus<P> {
+    pub fn new(primes: &SecretPrimes<P>) -> Self {
+        Self(primes.p.expose_secret().mul_wide(primes.q.expose_secret()))
+    }
+
+    pub fn into_precomputed(self) -> PublicModulusPrecomputed<P> {
+        PublicModulusPrecomputed::new(self)
+    }
+}
+
+impl<P: PaillierParams> Deref for PublicModulus<P> {
+    type Target = P::Uint;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PublicModulusPrecomputed<P: PaillierParams> {
+    /// The base RSA modulus $N$.
+    modulus: PublicModulus<P>,
+    /// Montgomery representation parameters for modulo $N$.
+    monty_params_mod_n: <P::UintMod as Monty>::Params,
+}
+
+impl<P: PaillierParams> PartialEq for PublicModulusPrecomputed<P> {
+    fn eq(&self, other: &PublicModulusPrecomputed<P>) -> bool {
+        self.modulus.eq(&other.modulus)
+    }
+}
+
+impl<P: PaillierParams> Eq for PublicModulusPrecomputed<P> {}
+
+impl<P: PaillierParams> PublicModulusPrecomputed<P> {
+    pub fn new(modulus: PublicModulus<P>) -> Self {
+        let odd_modulus = Odd::new(*modulus).expect("the RSA modulus is odd");
+        let monty_params_mod_n = P::UintMod::new_params_vartime(odd_modulus);
+        Self {
+            modulus,
+            monty_params_mod_n,
+        }
+    }
+
+    pub fn into_minimal(self) -> PublicModulus<P> {
+        self.modulus
+    }
+
+    pub fn modulus(&self) -> &PublicModulus<P> {
+        &self.modulus
+    }
+
+    pub fn modulus_nonzero(&self) -> NonZero<P::Uint> {
+        NonZero::new(*self.modulus).expect("the modulus is non-zero")
+    }
+
+    pub fn modulus_bounded(&self) -> Bounded<P::Uint> {
+        Bounded::new(*self.modulus, P::MODULUS_BITS as u32).expect("the modulus can be bounded by 2^MODULUS_BITS")
+    }
+
+    /// Finds an invertible group element via rejection sampling. Returns the
+    /// element in Montgomery form.
+    pub fn random_invertible_group_elem(&self, rng: &mut impl CryptoRngCore) -> P::UintMod {
+        let modulus = self.modulus_nonzero();
+        loop {
+            let r = P::Uint::random_mod(rng, &modulus);
+            let r_m = P::UintMod::new(r, self.monty_params_mod_n.clone());
+            if r_m.invert().is_some().into() {
+                return r_m;
+            }
+        }
+    }
+
+    pub fn monty_params_mod_n(&self) -> &<P::UintMod as Monty>::Params {
+        &self.monty_params_mod_n
+    }
+}

--- a/synedrion/src/tools.rs
+++ b/synedrion/src/tools.rs
@@ -3,9 +3,11 @@ use alloc::collections::{BTreeMap, BTreeSet};
 pub(crate) mod bitvec;
 pub(crate) mod hashing;
 mod hide_debug;
+mod secret;
 pub(crate) mod sss;
 
-pub(crate) use hide_debug::{HideDebug, Secret};
+pub(crate) use hide_debug::HideDebug;
+pub(crate) use secret::Secret;
 
 use manul::protocol::{Artifact, LocalError, Payload};
 

--- a/synedrion/src/tools.rs
+++ b/synedrion/src/tools.rs
@@ -5,7 +5,7 @@ pub(crate) mod hashing;
 mod hide_debug;
 pub(crate) mod sss;
 
-pub(crate) use hide_debug::HideDebug;
+pub(crate) use hide_debug::{HideDebug, Secret};
 
 use manul::protocol::{Artifact, LocalError, Payload};
 

--- a/synedrion/src/tools/hide_debug.rs
+++ b/synedrion/src/tools/hide_debug.rs
@@ -3,9 +3,7 @@ use core::{
     ops::{Deref, DerefMut},
 };
 
-use secrecy::{ExposeSecret, SecretBox};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use zeroize::Zeroize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Serialize, Deserialize)]
 pub(crate) struct HideDebug<T>(T);
@@ -31,52 +29,6 @@ impl<T> Deref for HideDebug<T> {
 }
 
 impl<T> DerefMut for HideDebug<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-pub(crate) struct Secret<T: Zeroize>(SecretBox<T>);
-
-impl<T: Zeroize + Clone> Clone for Secret<T> {
-    fn clone(&self) -> Self {
-        Self(SecretBox::init_with(|| self.0.expose_secret().clone()))
-    }
-}
-
-impl<T: Zeroize + Serialize> Serialize for Secret<T> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        self.0.expose_secret().serialize(serializer)
-    }
-}
-
-impl<'de, T: Zeroize + Clone + Deserialize<'de>> Deserialize<'de> for Secret<T> {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Ok(Self(SecretBox::try_init_with(|| T::deserialize(deserializer))?))
-    }
-}
-
-impl<T: Zeroize> Debug for Secret<T> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "Secret<{}>(...)", core::any::type_name::<T>())
-    }
-}
-
-impl<T: Zeroize> From<SecretBox<T>> for Secret<T> {
-    fn from(value: SecretBox<T>) -> Self {
-        Self(value)
-    }
-}
-
-impl<T: Zeroize> Deref for Secret<T> {
-    type Target = SecretBox<T>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<T: Zeroize> DerefMut for Secret<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }

--- a/synedrion/src/tools/hide_debug.rs
+++ b/synedrion/src/tools/hide_debug.rs
@@ -3,7 +3,9 @@ use core::{
     ops::{Deref, DerefMut},
 };
 
-use serde::{Deserialize, Serialize};
+use secrecy::{ExposeSecret, SecretBox};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use zeroize::Zeroize;
 
 #[derive(Clone, Copy, Serialize, Deserialize)]
 pub(crate) struct HideDebug<T>(T);
@@ -29,6 +31,52 @@ impl<T> Deref for HideDebug<T> {
 }
 
 impl<T> DerefMut for HideDebug<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+pub(crate) struct Secret<T: Zeroize>(SecretBox<T>);
+
+impl<T: Zeroize + Clone> Clone for Secret<T> {
+    fn clone(&self) -> Self {
+        Self(SecretBox::init_with(|| self.0.expose_secret().clone()))
+    }
+}
+
+impl<T: Zeroize + Serialize> Serialize for Secret<T> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.expose_secret().serialize(serializer)
+    }
+}
+
+impl<'de, T: Zeroize + Clone + Deserialize<'de>> Deserialize<'de> for Secret<T> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Ok(Self(SecretBox::try_init_with(|| T::deserialize(deserializer))?))
+    }
+}
+
+impl<T: Zeroize> Debug for Secret<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "Secret<{}>(...)", core::any::type_name::<T>())
+    }
+}
+
+impl<T: Zeroize> From<SecretBox<T>> for Secret<T> {
+    fn from(value: SecretBox<T>) -> Self {
+        Self(value)
+    }
+}
+
+impl<T: Zeroize> Deref for Secret<T> {
+    type Target = SecretBox<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T: Zeroize> DerefMut for Secret<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }

--- a/synedrion/src/tools/secret.rs
+++ b/synedrion/src/tools/secret.rs
@@ -1,0 +1,60 @@
+use core::{
+    fmt::Debug,
+    ops::{Deref, DerefMut},
+};
+
+use secrecy::{ExposeSecret, SecretBox};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use zeroize::Zeroize;
+
+/// A helper wrapper for managing secret values.
+///
+/// On top of `secrecy::SecretBox` functionality, it provides:
+/// - Safe `Clone` implementation (without needing to impl `CloneableSecret`)
+/// - Safe `Debug` implementation
+/// - Safe serialization/deserialization (down to `serde` API; what happens there we cannot control)
+pub(crate) struct Secret<T: Zeroize>(SecretBox<T>);
+
+impl<T: Zeroize + Clone> Clone for Secret<T> {
+    fn clone(&self) -> Self {
+        Self(SecretBox::init_with(|| self.0.expose_secret().clone()))
+    }
+}
+
+impl<T: Zeroize + Serialize> Serialize for Secret<T> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.expose_secret().serialize(serializer)
+    }
+}
+
+impl<'de, T: Zeroize + Clone + Deserialize<'de>> Deserialize<'de> for Secret<T> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Ok(Self(SecretBox::try_init_with(|| T::deserialize(deserializer))?))
+    }
+}
+
+impl<T: Zeroize> Debug for Secret<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "Secret<{}>(...)", core::any::type_name::<T>())
+    }
+}
+
+impl<T: Zeroize> From<SecretBox<T>> for Secret<T> {
+    fn from(value: SecretBox<T>) -> Self {
+        Self(value)
+    }
+}
+
+impl<T: Zeroize> Deref for Secret<T> {
+    type Target = SecretBox<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T: Zeroize> DerefMut for Secret<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}

--- a/synedrion/src/uint/bounded.rs
+++ b/synedrion/src/uint/bounded.rs
@@ -79,11 +79,6 @@ where
         self.bound
     }
 
-    pub fn bound_usize(&self) -> usize {
-        // Extracted into a method to localize the conversion
-        self.bound as usize
-    }
-
     /// Creates a new [`Bounded`] wrapper around `T`, restricted to `bound`.
     ///
     /// Returns `None` if the bound is invalid, i.e.:

--- a/synedrion/src/uint/traits.rs
+++ b/synedrion/src/uint/traits.rs
@@ -10,9 +10,9 @@ use crate::uint::Signed;
 pub trait ToMontgomery: Integer {
     fn to_montgomery(
         self,
-        precomputed: &<<Self as Integer>::Monty as crypto_bigint::Monty>::Params,
+        params: &<<Self as Integer>::Monty as crypto_bigint::Monty>::Params,
     ) -> <Self as Integer>::Monty {
-        <<Self as Integer>::Monty as crypto_bigint::Monty>::new(self, precomputed.clone())
+        <<Self as Integer>::Monty as crypto_bigint::Monty>::new(self, params.clone())
     }
 }
 


### PR DESCRIPTION
Part of #157

- Split Paillier keys and ring-Pedersen secrets, with the underlying `SecretPrimes`/`PublicModulus`. Note that according to the new version of the paper Paillier only needs `mod 3 = 4` primes, while ring-Pedersen needs safe primes.
- Use `Exponentiable` where approriate
- Normalize naming for "wire" and "expanded" structures in `paillier`. Namely: the wire ones have the "Wire" postfix, the expanded ones have no postfixes. The conversion methods are `to_wire()` and `to_precomputed()`.
- Changed the type of various Uint bit size arguments to `u32` to match `crypto-bigint`

The new `Secret` will be properly used throughout the codebase in a follow-up PR, this one is getting pretty big already.

