### PR TITLE
Don't use a PublicSigned for PrmProof

### DIFF
--- a/synedrion/src/cggmp21/sigma/prm.rs
+++ b/synedrion/src/cggmp21/sigma/prm.rs
@@ -126,7 +126,6 @@ impl<P: SchemeParams> PrmProof<P> {
             let pwr = setup.base_randomizer().pow_bounded_exp(z, z.bits_vartime());
             let test = if *e { pwr == a * setup.base_value() } else { pwr == a };
             if !test {
-                // TODO(dp): Should we make this CT perhaps?
                 return false;
             }
         }


### PR DESCRIPTION
Removes the `PublicSigned` wrapper from the `proof` member of `PrmProof`. When using production-sized parameters, the totient is often a 2048 bit number and so doesn't fit in a signed number type.

The Prm proof components are all positive and reduced modulo the totient, hence guaranteed to fit in a totient-sized number type (i.e. 2048 bits), so wrapping them is unnessecary.

Fixes #174. 
