### PR TITLE
Prefer the Pow trait

### DIFF
--- a/synedrion/src/cggmp21/sigma/mod_.rs
+++ b/synedrion/src/cggmp21/sigma/mod_.rs
@@ -117,7 +117,7 @@ impl<P: SchemeParams> ModProof<P> {
 
                 let y = y.to_montgomery(pk.monty_params_mod_n());
                 let sk_inv_modulus = sk.inv_modulus();
-                let z = y.pow(sk_inv_modulus);
+                let z = y.pppow(sk_inv_modulus);
 
                 ModProofElem {
                     x: y_4th,
@@ -164,7 +164,7 @@ impl<P: SchemeParams> ModProof<P> {
             let z_m = elem.z.to_montgomery(monty_params);
             let mut y_m = y.to_montgomery(monty_params);
             let pk_modulus = pk.modulus_signed();
-            if z_m.pow(&pk_modulus) != y_m {
+            if z_m.pppow(&pk_modulus) != y_m {
                 return false;
             }
 

--- a/synedrion/src/cggmp21/sigma/mod_.rs
+++ b/synedrion/src/cggmp21/sigma/mod_.rs
@@ -2,7 +2,7 @@
 
 use alloc::vec::Vec;
 
-use crypto_bigint::{modular::Retrieve, Square};
+use crypto_bigint::{modular::Retrieve, Pow, Square};
 use crypto_primes::RandomPrimeWithRng;
 use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
@@ -11,7 +11,7 @@ use super::super::SchemeParams;
 use crate::{
     paillier::{PaillierParams, PublicKeyPaillier, SecretKeyPaillier},
     tools::hashing::{uint_from_xof, Chain, Hashable, XofHasher},
-    uint::{Exponentiable, ToMontgomery},
+    uint::ToMontgomery,
 };
 
 const HASH_TAG: &[u8] = b"P_mod";
@@ -117,7 +117,7 @@ impl<P: SchemeParams> ModProof<P> {
 
                 let y = y.to_montgomery(pk.monty_params_mod_n());
                 let sk_inv_modulus = sk.inv_modulus();
-                let z = y.pppow(sk_inv_modulus);
+                let z = y.pow(sk_inv_modulus);
 
                 ModProofElem {
                     x: y_4th,
@@ -164,7 +164,7 @@ impl<P: SchemeParams> ModProof<P> {
             let z_m = elem.z.to_montgomery(monty_params);
             let mut y_m = y.to_montgomery(monty_params);
             let pk_modulus = pk.modulus_signed();
-            if z_m.pppow(&pk_modulus) != y_m {
+            if z_m.pow(&pk_modulus) != y_m {
                 return false;
             }
 

--- a/synedrion/src/cggmp21/sigma/prm.rs
+++ b/synedrion/src/cggmp21/sigma/prm.rs
@@ -5,7 +5,7 @@
 
 use alloc::{vec, vec::Vec};
 
-use crypto_bigint::{modular::Retrieve, BitOps, PowBoundedExp};
+use crypto_bigint::{modular::Retrieve, BitOps, Pow, PowBoundedExp};
 use digest::XofReader;
 use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
@@ -14,7 +14,7 @@ use super::super::SchemeParams;
 use crate::{
     paillier::{PaillierParams, RPParams, RPSecret},
     tools::hashing::{Chain, Hashable, XofHasher},
-    uint::{Exponentiable, SecretUnsigned, ToMontgomery},
+    uint::{SecretUnsigned, ToMontgomery},
 };
 
 const HASH_TAG: &[u8] = b"P_prm";

--- a/synedrion/src/paillier/params.rs
+++ b/synedrion/src/paillier/params.rs
@@ -1,7 +1,7 @@
 use crypto_bigint::{
     modular::Retrieve,
     subtle::{ConditionallyNegatable, ConditionallySelectable, ConstantTimeGreater, CtOption},
-    Bounded, Encoding, Gcd, Integer, InvMod, Invert, Monty, PowBoundedExp, RandomMod,
+    Bounded, Encoding, Gcd, Integer, InvMod, Invert, Monty, Pow, PowBoundedExp, RandomMod,
 };
 use crypto_primes::RandomPrimeWithRng;
 use serde::{Deserialize, Serialize};
@@ -9,7 +9,7 @@ use zeroize::Zeroize;
 
 use crate::{
     tools::hashing::Hashable,
-    uint::{HasWide, ToMontgomery},
+    uint::{HasWide, PublicSigned, SecretSigned, SecretUnsigned, ToMontgomery},
 };
 
 #[cfg(test)]
@@ -64,6 +64,13 @@ pub trait PaillierParams: core::fmt::Debug + PartialEq + Eq + Clone + Send + Syn
         + PowBoundedExp<Self::Uint>
         + PowBoundedExp<Self::WideUint>
         + PowBoundedExp<Self::ExtraWideUint>
+        + Pow<SecretUnsigned<Self::Uint>>
+        + Pow<PublicSigned<Self::Uint>>
+        + Pow<PublicSigned<Self::WideUint>>
+        + Pow<PublicSigned<Self::ExtraWideUint>>
+        + Pow<SecretSigned<Self::Uint>>
+        + Pow<SecretSigned<Self::WideUint>>
+        + Pow<SecretSigned<Self::ExtraWideUint>>
         + Monty<Integer = Self::Uint>
         + Retrieve<Output = Self::Uint>
         + Invert<Output = CtOption<Self::UintMod>>
@@ -87,6 +94,11 @@ pub trait PaillierParams: core::fmt::Debug + PartialEq + Eq + Clone + Send + Syn
     type WideUintMod: Monty<Integer = Self::WideUint>
         + PowBoundedExp<Self::Uint>
         + PowBoundedExp<Self::WideUint>
+        + Pow<SecretSigned<Self::Uint>>
+        + Pow<PublicSigned<Self::Uint>>
+        + Pow<PublicSigned<Self::WideUint>>
+        + Pow<SecretUnsigned<Self::Uint>>
+        + Pow<SecretUnsigned<Self::WideUint>>
         + ConditionallyNegatable
         + ConditionallySelectable
         + Invert<Output = CtOption<Self::WideUintMod>>

--- a/synedrion/src/paillier/ring_pedersen.rs
+++ b/synedrion/src/paillier/ring_pedersen.rs
@@ -1,7 +1,7 @@
 /// Implements the Definition 3.3 from the CGGMP'21 paper and related operations.
 use core::ops::Mul;
 
-use crypto_bigint::{modular::Retrieve, Monty, NonZero, RandomMod, ShrVartime};
+use crypto_bigint::{modular::Retrieve, Monty, NonZero, Pow, RandomMod, ShrVartime};
 use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
 
@@ -11,7 +11,7 @@ use super::{
 };
 use crate::{
     tools::Secret,
-    uint::{Exponentiable, SecretUnsigned, ToMontgomery},
+    uint::{SecretUnsigned, ToMontgomery},
 };
 
 /// Ring-Pedersen secret.
@@ -107,7 +107,7 @@ impl<P: PaillierParams> RPParams<P> {
     /// Creates a commitment for a secret `value` with a secret `randomizer`.
     pub fn commit<V, R>(&self, value: &V, randomizer: &R) -> RPCommitment<P>
     where
-        P::UintMod: Exponentiable<V> + Exponentiable<R>,
+        P::UintMod: Pow<V> + Pow<R>,
     {
         RPCommitment(self.base_value.pow(value) * self.base_randomizer.pow(randomizer))
     }
@@ -115,7 +115,7 @@ impl<P: PaillierParams> RPParams<P> {
     /// Creates a commitment for a secret `randomizer` and the value 0.
     pub fn commit_zero<R>(&self, randomizer: &R) -> RPCommitment<P>
     where
-        P::UintMod: Exponentiable<R>,
+        P::UintMod: Pow<R>,
     {
         RPCommitment(self.base_randomizer.pow(randomizer))
     }
@@ -167,7 +167,7 @@ impl<P: PaillierParams> RPCommitment<P> {
     /// Raise to the power of `exponent`.
     pub fn pow<V>(&self, exponent: &V) -> Self
     where
-        P::UintMod: Exponentiable<V>,
+        P::UintMod: Pow<V>,
     {
         Self(self.0.pow(exponent))
     }

--- a/synedrion/src/tools/secret.rs
+++ b/synedrion/src/tools/secret.rs
@@ -6,7 +6,7 @@ use core::{
 use crypto_bigint::{
     modular::Retrieve,
     subtle::{Choice, ConditionallyNegatable, ConditionallySelectable},
-    Integer, Monty, NonZero, WrappingAdd, WrappingMul, WrappingNeg, WrappingSub,
+    Integer, Monty, NonZero, Pow, WrappingAdd, WrappingMul, WrappingNeg, WrappingSub,
 };
 use secrecy::{ExposeSecret, ExposeSecretMut, SecretBox};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -14,7 +14,7 @@ use zeroize::Zeroize;
 
 use crate::{
     curve::{Point, Scalar},
-    uint::{Exponentiable, HasWide},
+    uint::HasWide,
 };
 
 /// A helper wrapper for managing secret values.
@@ -23,7 +23,7 @@ use crate::{
 /// - Safe `Clone` implementation (without needing to impl `CloneableSecret`)
 /// - Safe `Debug` implementation
 /// - Safe serialization/deserialization (down to `serde` API; what happens there we cannot control)
-pub(crate) struct Secret<T: Zeroize>(SecretBox<T>);
+pub struct Secret<T: Zeroize>(SecretBox<T>);
 
 impl<T: Zeroize> Secret<T> {
     pub fn expose_secret(&self) -> &T {
@@ -278,7 +278,7 @@ impl<T: Zeroize + Retrieve<Output: Zeroize + Clone>> Retrieve for Secret<T> {
 impl<T: Zeroize + Clone> Secret<T> {
     pub fn pow<V>(&self, exponent: &V) -> Self
     where
-        T: Exponentiable<V>,
+        T: Pow<V>,
     {
         // TODO: do we need to implement our own windowed exponentiation to hide the secret?
         // The exponent will be put in a stack array when it's decomposed with a small radix

--- a/synedrion/src/uint.rs
+++ b/synedrion/src/uint.rs
@@ -6,4 +6,4 @@ mod traits;
 pub(crate) use public_signed::PublicSigned;
 pub(crate) use secret_signed::SecretSigned;
 pub(crate) use secret_unsigned::SecretUnsigned;
-pub(crate) use traits::{Exponentiable, HasWide, ToMontgomery, U1024Mod, U2048Mod, U4096Mod, U512Mod};
+pub(crate) use traits::{HasWide, ToMontgomery, U1024Mod, U2048Mod, U4096Mod, U512Mod};

--- a/synedrion/src/uint/public_signed.rs
+++ b/synedrion/src/uint/public_signed.rs
@@ -75,7 +75,7 @@ where
     into = "PackedSigned",
     bound = "T: Integer + Encoding + Bounded"
 )]
-pub(crate) struct PublicSigned<T> {
+pub struct PublicSigned<T> {
     /// bound on the bit size of the absolute value
     bound: u32,
     value: T,

--- a/synedrion/src/uint/secret_signed.rs
+++ b/synedrion/src/uint/secret_signed.rs
@@ -13,7 +13,7 @@ use crate::tools::Secret;
 
 /// A wrapper over secret unsigned integers that treats two's complement numbers as negative.
 #[derive(Debug, Clone)]
-pub(crate) struct SecretSigned<T: Zeroize> {
+pub struct SecretSigned<T: Zeroize> {
     /// Bound on the bit size of the absolute value (that is, `abs(value) < 2^bound`).
     bound: u32,
     value: Secret<T>,

--- a/synedrion/src/uint/secret_unsigned.rs
+++ b/synedrion/src/uint/secret_unsigned.rs
@@ -8,7 +8,7 @@ use crate::tools::Secret;
 
 /// A bounded unsigned integer with sensitive data.
 #[derive(Debug, Clone)]
-pub(crate) struct SecretUnsigned<T: Zeroize> {
+pub struct SecretUnsigned<T: Zeroize> {
     /// Bound on the bit size of the value (that is, `value < 2^bound`).
     bound: u32,
     value: Secret<T>,

--- a/synedrion/src/uint/traits.rs
+++ b/synedrion/src/uint/traits.rs
@@ -1,8 +1,6 @@
 use crypto_bigint::{
-    modular::MontyForm,
-    subtle::{ConditionallySelectable, CtOption},
-    Bounded, ConcatMixed, Encoding, Integer, Invert, Limb, Pow, PowBoundedExp, RandomMod, SplitMixed, WideningMul,
-    Zero, U1024, U2048, U4096, U512, U8192,
+    modular::MontyForm, subtle::ConditionallySelectable, Bounded, ConcatMixed, Encoding, Integer, Invert, Limb, Pow,
+    PowBoundedExp, RandomMod, SplitMixed, WideningMul, Zero, U1024, U2048, U4096, U512, U8192,
 };
 use zeroize::Zeroize;
 
@@ -17,167 +15,65 @@ pub trait ToMontgomery: Integer {
     }
 }
 
-impl<V> Pow<SecretSigned<V>> for U1024Mod
-where
-    Self: PowBoundedExp<V>,
-    V: ConditionallySelectable + Zeroize + Integer + Bounded,
-{
-    fn pow(&self, exp: &SecretSigned<V>) -> Self {
-        let abs_exp = exp.abs();
-        let abs_result = <Self as PowBoundedExp<V>>::pow_bounded_exp(self, abs_exp.expose_secret(), exp.bound());
-        let inv_result = abs_result.invert().expect("`self` is assumed to be invertible");
-        Self::conditional_select(&abs_result, &inv_result, exp.is_negative())
-    }
-}
-
-impl<V> Pow<SecretSigned<V>> for U2048Mod
-where
-    Self: PowBoundedExp<V>,
-    V: ConditionallySelectable + Zeroize + Integer + Bounded,
-{
-    fn pow(&self, exp: &SecretSigned<V>) -> Self {
-        let abs_exp = exp.abs();
-        let abs_result = <Self as PowBoundedExp<V>>::pow_bounded_exp(self, abs_exp.expose_secret(), exp.bound());
-        let inv_result = abs_result.invert().expect("`self` is assumed to be invertible");
-        Self::conditional_select(&abs_result, &inv_result, exp.is_negative())
-    }
-}
-impl<V> Pow<SecretSigned<V>> for U4096Mod
-where
-    Self: PowBoundedExp<V>,
-    V: ConditionallySelectable + Zeroize + Integer + Bounded,
-{
-    fn pow(&self, exp: &SecretSigned<V>) -> Self {
-        let abs_exp = exp.abs();
-        let abs_result = <Self as PowBoundedExp<V>>::pow_bounded_exp(self, abs_exp.expose_secret(), exp.bound());
-        let inv_result = abs_result.invert().expect("`self` is assumed to be invertible");
-        Self::conditional_select(&abs_result, &inv_result, exp.is_negative())
-    }
-}
-
-impl<V> Pow<SecretUnsigned<V>> for U1024Mod
-where
-    Self: PowBoundedExp<V>,
-    V: Zeroize + Integer + Bounded,
-{
-    fn pow(&self, exp: &SecretUnsigned<V>) -> Self {
-        <Self as PowBoundedExp<V>>::pow_bounded_exp(self, exp.expose_secret(), exp.bound())
-    }
-}
-impl<V> Pow<SecretUnsigned<V>> for U2048Mod
-where
-    Self: PowBoundedExp<V>,
-    V: Zeroize + Integer + Bounded,
-{
-    fn pow(&self, exp: &SecretUnsigned<V>) -> Self {
-        <Self as PowBoundedExp<V>>::pow_bounded_exp(self, exp.expose_secret(), exp.bound())
-    }
-}
-impl<V> Pow<SecretUnsigned<V>> for U4096Mod
-where
-    Self: PowBoundedExp<V>,
-    V: Zeroize + Integer + Bounded,
-{
-    fn pow(&self, exp: &SecretUnsigned<V>) -> Self {
-        <Self as PowBoundedExp<V>>::pow_bounded_exp(self, exp.expose_secret(), exp.bound())
-    }
-}
-
-impl<V> Pow<PublicSigned<V>> for U1024Mod
-where
-    Self: PowBoundedExp<V>,
-    V: Integer + Bounded,
-{
-    fn pow(&self, exp: &PublicSigned<V>) -> Self {
-        let abs_exp = exp.abs();
-        let abs_result = <Self as PowBoundedExp<V>>::pow_bounded_exp(self, &abs_exp, exp.bound());
-        if exp.is_negative() {
-            abs_result.invert().expect("`self` is assumed invertible")
-        } else {
-            abs_result
+macro_rules! impl_pow {
+    ($uintmod:ident) => {
+        /// Exponentiation to the power of secret signed integers.
+        ///
+        /// Constant-time for secret exponents, although not constant-time wrt the bound.
+        ///
+        /// Assumes that the result exists, panics otherwise (e.g., when trying to raise 0 to a negative power).
+        impl<V> Pow<SecretSigned<V>> for $uintmod
+        where
+            Self: PowBoundedExp<V>,
+            V: ConditionallySelectable + Zeroize + Integer + Bounded,
+        {
+            fn pow(&self, exp: &SecretSigned<V>) -> Self {
+                let abs_exp = exp.abs();
+                let abs_result =
+                    <Self as PowBoundedExp<V>>::pow_bounded_exp(self, abs_exp.expose_secret(), exp.bound());
+                let inv_result = abs_result.invert().expect("`self` is assumed to be invertible");
+                Self::conditional_select(&abs_result, &inv_result, exp.is_negative())
+            }
         }
-    }
-}
-impl<V> Pow<PublicSigned<V>> for U2048Mod
-where
-    Self: PowBoundedExp<V>,
-    V: Integer + Bounded,
-{
-    fn pow(&self, exp: &PublicSigned<V>) -> Self {
-        let abs_exp = exp.abs();
-        let abs_result = <Self as PowBoundedExp<V>>::pow_bounded_exp(self, &abs_exp, exp.bound());
-        if exp.is_negative() {
-            abs_result.invert().expect("`self` is assumed invertible")
-        } else {
-            abs_result
+
+        /// Exponentiation to the power of secret unsigned integers.
+        ///
+        /// Constant-time for secret exponents, although not constant-time wrt the bound.
+        impl<V> Pow<SecretUnsigned<V>> for $uintmod
+        where
+            Self: PowBoundedExp<V>,
+            V: Zeroize + Integer + Bounded,
+        {
+            fn pow(&self, exp: &SecretUnsigned<V>) -> Self {
+                <Self as PowBoundedExp<V>>::pow_bounded_exp(self, exp.expose_secret(), exp.bound())
+            }
         }
-    }
-}
-impl<V> Pow<PublicSigned<V>> for U4096Mod
-where
-    Self: PowBoundedExp<V>,
-    V: Integer + Bounded,
-{
-    fn pow(&self, exp: &PublicSigned<V>) -> Self {
-        let abs_exp = exp.abs();
-        let abs_result = <Self as PowBoundedExp<V>>::pow_bounded_exp(self, &abs_exp, exp.bound());
-        if exp.is_negative() {
-            abs_result.invert().expect("`self` is assumed invertible")
-        } else {
-            abs_result
+
+        /// Exponentiation to the power of public signed integers.
+        impl<V> Pow<PublicSigned<V>> for $uintmod
+        where
+            Self: PowBoundedExp<V>,
+            V: Integer + Bounded,
+        {
+            fn pow(&self, exp: &PublicSigned<V>) -> Self {
+                let abs_exp = exp.abs();
+                let abs_result = <Self as PowBoundedExp<V>>::pow_bounded_exp(self, &abs_exp, exp.bound());
+                if exp.is_negative() {
+                    abs_result.invert().expect("`self` is assumed invertible")
+                } else {
+                    abs_result
+                }
+            }
         }
-    }
-}
 
-/// Exponentiation to the power of bounded integers.
-///
-/// Constant-time for secret exponents, although not constant-time wrt the bound.
-///
-/// Assumes that the result exists, panics otherwise (e.g., when trying to raise 0 to a negative power).
-// We cannot use the `crypto_bigint::Pow` trait since we cannot implement it for the foreign types
-// (namely, `crypto_bigint::modular::MontyForm`).
-pub trait Exponentiable<Exponent> {
-    fn pppow(&self, exp: &Exponent) -> Self;
+    };
+    ([ $($uintmod:ident), + ]) => {
+        $(
+            impl_pow!($uintmod);
+        )+
+    };
 }
-
-impl<T, V> Exponentiable<SecretSigned<V>> for T
-where
-    T: ConditionallySelectable + PowBoundedExp<V> + Invert<Output = CtOption<T>>,
-    V: ConditionallySelectable + Zeroize + Integer + Bounded,
-{
-    fn pppow(&self, exp: &SecretSigned<V>) -> Self {
-        let abs_exp = exp.abs();
-        let abs_result = self.pow_bounded_exp(abs_exp.expose_secret(), exp.bound());
-        let inv_result = abs_result.invert().expect("`self` is assumed to be invertible");
-        Self::conditional_select(&abs_result, &inv_result, exp.is_negative())
-    }
-}
-
-impl<T, V> Exponentiable<SecretUnsigned<V>> for T
-where
-    T: PowBoundedExp<V> + Invert<Output = CtOption<T>>,
-    V: ConditionallySelectable + Zeroize + Integer + Bounded,
-{
-    fn pppow(&self, exp: &SecretUnsigned<V>) -> Self {
-        self.pow_bounded_exp(exp.expose_secret(), exp.bound())
-    }
-}
-
-impl<T, V> Exponentiable<PublicSigned<V>> for T
-where
-    T: PowBoundedExp<V> + Invert<Output = CtOption<T>>,
-    V: Integer + Bounded,
-{
-    fn pppow(&self, exp: &PublicSigned<V>) -> Self {
-        let abs_exp = exp.abs();
-        let abs_result = self.pow_bounded_exp(&abs_exp, exp.bound());
-        if exp.is_negative() {
-            abs_result.invert().expect("`self` is assumed invertible")
-        } else {
-            abs_result
-        }
-    }
-}
+impl_pow!([U1024Mod, U2048Mod, U4096Mod]);
 
 pub trait HasWide:
     Sized + Zero + Integer + for<'a> WideningMul<&'a Self, Output = Self::Wide> + ConcatMixed<MixedOutput = Self::Wide>


### PR DESCRIPTION
This PR removes the `Exponentiable` trait and its implementations for `SecretSigned`, `SecretUnsigned` and `PublicSigned`. It's up for debate whether this is actually better, but I think it's a little bit cleaner and may be helpful for tricks like "exponentiation with known totient"? The downside is that now the wrapper types are public.
