### PR TITLE
Simplify ZK proof benches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1159,12 +1159,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
-
-[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1223,7 +1217,6 @@ dependencies = [
  "tiny-curve",
  "tokio",
  "tracing",
- "tracing-subscriber",
  "zeroize",
 ]
 
@@ -1338,18 +1331,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
 ]
 
 [[package]]
@@ -1363,11 +1344,9 @@ dependencies = [
  "once_cell",
  "regex",
  "sharded-slab",
- "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -1393,12 +1372,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "valuable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"

--- a/synedrion/Cargo.toml
+++ b/synedrion/Cargo.toml
@@ -39,7 +39,6 @@ serde = { version = "1", default-features = false, features = ["derive"] }
 serde-encoded-bytes = { version = "0.1", default-features = false, features = ["hex", "base64"] }
 bincode = { version = "2.0.0-rc.3", default-features = false, features = ["serde", "alloc"] }
 displaydoc = { version = "0.2", default-features = false }
-criterion = { version = "0.5", optional = true }
 
 [dev-dependencies]
 manul = { git = "https://github.com/entropyxyz/manul.git", rev = "9810d0188d64d4fca3c95efd75e3b565c5db4233", features = [
@@ -53,10 +52,9 @@ k256 = { version = "0.13", default-features = false, features = ["ecdsa", "arith
 impls = "1"
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 test-log = { version = "0.2.16", default-features = false, features = ["trace", "color"] }
-tracing-subscriber = "0.3.19"
 
 [features]
-private_benches = ["criterion"]
+private_benches = []
 
 [[bench]]
 bench = true

--- a/synedrion/benches/zk_proofs.rs
+++ b/synedrion/benches/zk_proofs.rs
@@ -1,158 +1,144 @@
-#[cfg(feature = "private_benches")]
-mod bench {
-    use criterion::{criterion_group, Criterion};
-    use rand::SeedableRng;
-    use synedrion::private_benches::*;
-    use tracing_subscriber::EnvFilter;
+use std::sync::LazyLock;
 
-    fn bench_aff_g(c: &mut Criterion) {
-        use aff_g_proof::*;
-        let _ = tracing_subscriber::fmt()
-            .with_env_filter(EnvFilter::from_default_env())
-            .try_init();
-        let mut group = c.benchmark_group("AffG proof");
-        group.sample_size(10);
+use criterion::{criterion_group, criterion_main, Criterion};
+use rand_core::OsRng;
+use synedrion::{private_benches::*, ProductionParams112};
 
-        let rng = rand_chacha::ChaCha8Rng::seed_from_u64(1234567890);
-        group.bench_function("prove", aff_g_proof_prove(rng));
+static KEY0: LazyLock<PreparedKey<ProductionParams112>> = LazyLock::new(|| PreparedKey::new(&mut OsRng));
 
-        let rng = rand_chacha::ChaCha8Rng::seed_from_u64(1234567890);
-        group.bench_function("verify", aff_g_proof_verify(rng));
-    }
+static KEY1: LazyLock<PreparedKey<ProductionParams112>> = LazyLock::new(|| PreparedKey::new(&mut OsRng));
 
-    fn bench_aff_g_star(c: &mut Criterion) {
-        use aff_g_star_proof::*;
-        let _ = tracing_subscriber::fmt()
-            .with_env_filter(EnvFilter::from_default_env())
-            .try_init();
-        let mut group = c.benchmark_group("AffG* proof");
-        group.sample_size(10);
+fn bench_aff_g(c: &mut Criterion) {
+    let mut group = c.benchmark_group("AffG proof");
+    group.sample_size(20);
 
-        let rng = rand_chacha::ChaCha8Rng::seed_from_u64(1234567890);
-        group.bench_function("prove", aff_g_star_proof_prove(rng));
+    LazyLock::force(&KEY0);
+    LazyLock::force(&KEY1);
 
-        let rng = rand_chacha::ChaCha8Rng::seed_from_u64(1234567890);
-        group.bench_function("verify", aff_g_star_proof_verify(rng));
-    }
-
-    fn bench_dec(c: &mut Criterion) {
-        use dec_proof::*;
-        let _ = tracing_subscriber::fmt()
-            .with_env_filter(EnvFilter::from_default_env())
-            .try_init();
-        let mut group = c.benchmark_group("Dec proof");
-        group.sample_size(10);
-
-        let rng = rand_chacha::ChaCha8Rng::seed_from_u64(1234567890);
-        group.bench_function("prove", dec_proof_prove(rng));
-
-        let rng = rand_chacha::ChaCha8Rng::seed_from_u64(1234567890);
-        group.bench_function("verify", dec_proof_verify(rng));
-    }
-
-    fn bench_elog(c: &mut Criterion) {
-        use elog_proof::*;
-        let _ = tracing_subscriber::fmt()
-            .with_env_filter(EnvFilter::from_default_env())
-            .try_init();
-        let mut group = c.benchmark_group("Elog proof");
-        group.sample_size(10);
-
-        let rng = rand_chacha::ChaCha8Rng::seed_from_u64(1234567890);
-        group.bench_function("prove", elog_proof_prove(rng));
-
-        let rng = rand_chacha::ChaCha8Rng::seed_from_u64(1234567890);
-        group.bench_function("verify", elog_proof_verify(rng));
-    }
-
-    fn bench_enc_elg(c: &mut Criterion) {
-        use enc_elg_proof::*;
-        let _ = tracing_subscriber::fmt()
-            .with_env_filter(EnvFilter::from_default_env())
-            .try_init();
-        let mut group = c.benchmark_group("EncElg proof");
-        group.sample_size(10);
-
-        let rng = rand_chacha::ChaCha8Rng::seed_from_u64(1234567890);
-        group.bench_function("prove", enc_elg_proof_prove(rng));
-
-        let rng = rand_chacha::ChaCha8Rng::seed_from_u64(1234567890);
-        group.bench_function("verify", enc_elg_proof_verify(rng));
-    }
-
-    fn bench_fac(c: &mut Criterion) {
-        use fac_proof::*;
-        let _ = tracing_subscriber::fmt()
-            .with_env_filter(EnvFilter::from_default_env())
-            .try_init();
-
-        let mut group = c.benchmark_group("Fac proof");
-        group.sample_size(10);
-
-        let rng = rand_chacha::ChaCha8Rng::seed_from_u64(1234567890);
-        group.bench_function("prove", fac_proof_prove(rng));
-
-        let rng = rand_chacha::ChaCha8Rng::seed_from_u64(1234567890);
-        group.bench_function("verify", fac_proof_verify(rng));
-    }
-
-    fn bench_paillier_blum_modulus(c: &mut Criterion) {
-        use paillier_blum_modulus_proof::*;
-        let _ = tracing_subscriber::fmt()
-            .with_env_filter(EnvFilter::from_default_env())
-            .try_init();
-        let mut group = c.benchmark_group("Paillier-Blum modulus proof");
-        group.sample_size(10);
-
-        let rng = rand_chacha::ChaCha8Rng::seed_from_u64(1234567890);
-        group.bench_function("prove", paillier_blum_modulus_proof_prove(rng));
-
-        let rng = rand_chacha::ChaCha8Rng::seed_from_u64(1234567890);
-        group.bench_function("verify", paillier_blum_modulus_proof_verify(rng));
-    }
-
-    fn bench_prm(c: &mut Criterion) {
-        use prm_proof::*;
-        let _ = tracing_subscriber::fmt()
-            .with_env_filter(EnvFilter::from_default_env())
-            .try_init();
-        let mut group = c.benchmark_group("Pedersen Ring params (prm) proof");
-        group.sample_size(10);
-
-        let rng = rand_chacha::ChaCha8Rng::seed_from_u64(1234567890);
-        group.bench_function("prove", prm_proof_prove(rng));
-
-        let rng = rand_chacha::ChaCha8Rng::seed_from_u64(1234567890);
-        group.bench_function("verify", prm_proof_verify(rng));
-    }
-
-    fn bench_sch(c: &mut Criterion) {
-        use sch_proof::*;
-        let _ = tracing_subscriber::fmt()
-            .with_env_filter(EnvFilter::from_default_env())
-            .try_init();
-        let mut group = c.benchmark_group("Schnorr (sch) proof");
-        group.sample_size(10);
-
-        let rng = rand_chacha::ChaCha8Rng::seed_from_u64(1234567890);
-        group.bench_function("prove", sch_proof_prove(rng));
-
-        let rng = rand_chacha::ChaCha8Rng::seed_from_u64(1234567890);
-        group.bench_function("verify", sch_proof_verify(rng));
-    }
-
-    criterion_group!(
-        benches,
-        bench_aff_g,
-        bench_aff_g_star,
-        bench_dec,
-        bench_elog,
-        bench_enc_elg,
-        bench_fac,
-        bench_paillier_blum_modulus,
-        bench_prm,
-        bench_sch
-    );
+    group.bench_function("prove", |b| {
+        b.iter_custom(|iters| measure_aff_g(&mut OsRng, &KEY0, &KEY1, iters, Measure::Creation))
+    });
+    group.bench_function("verify", |b| {
+        b.iter_custom(|iters| measure_aff_g(&mut OsRng, &KEY0, &KEY1, iters, Measure::Verification))
+    });
 }
 
-criterion::criterion_main!(bench::benches);
+fn bench_aff_g_star(c: &mut Criterion) {
+    let mut group = c.benchmark_group("AffG* proof");
+    group.sample_size(10);
+
+    LazyLock::force(&KEY0);
+    LazyLock::force(&KEY1);
+
+    group.bench_function("prove", |b| {
+        b.iter_custom(|iters| measure_aff_g_star(&mut OsRng, &KEY0, &KEY1, iters, Measure::Creation))
+    });
+    group.bench_function("verify", |b| {
+        b.iter_custom(|iters| measure_aff_g_star(&mut OsRng, &KEY0, &KEY1, iters, Measure::Verification))
+    });
+}
+
+fn bench_dec(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Dec proof");
+    group.sample_size(10);
+
+    LazyLock::force(&KEY0);
+
+    group.bench_function("prove", |b| {
+        b.iter_custom(|iters| measure_dec(&mut OsRng, &KEY0, iters, Measure::Creation))
+    });
+    group.bench_function("verify", |b| {
+        b.iter_custom(|iters| measure_dec(&mut OsRng, &KEY0, iters, Measure::Verification))
+    });
+}
+
+fn bench_elog(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Elog proof");
+
+    group.bench_function("prove", |b| {
+        b.iter_custom(|iters| measure_elog(&mut OsRng, iters, Measure::Creation))
+    });
+    group.bench_function("verify", |b| {
+        b.iter_custom(|iters| measure_elog(&mut OsRng, iters, Measure::Verification))
+    });
+}
+
+fn bench_enc_elg(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Enc-Elg proof");
+
+    LazyLock::force(&KEY0);
+
+    group.bench_function("prove", |b| {
+        b.iter_custom(|iters| measure_enc_elg(&mut OsRng, &KEY0, iters, Measure::Creation))
+    });
+    group.bench_function("verify", |b| {
+        b.iter_custom(|iters| measure_enc_elg(&mut OsRng, &KEY0, iters, Measure::Verification))
+    });
+}
+
+fn bench_fac(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Fac proof");
+
+    LazyLock::force(&KEY0);
+
+    group.bench_function("prove", |b| {
+        b.iter_custom(|iters| measure_fac(&mut OsRng, &KEY0, iters, Measure::Creation))
+    });
+    group.bench_function("verify", |b| {
+        b.iter_custom(|iters| measure_fac(&mut OsRng, &KEY0, iters, Measure::Verification))
+    });
+}
+
+fn bench_mod(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Mod proof");
+    group.sample_size(10);
+
+    LazyLock::force(&KEY0);
+
+    group.bench_function("prove", |b| {
+        b.iter_custom(|iters| measure_mod(&mut OsRng, &KEY0, iters, Measure::Creation))
+    });
+    group.bench_function("verify", |b| {
+        b.iter_custom(|iters| measure_mod(&mut OsRng, &KEY0, iters, Measure::Verification))
+    });
+}
+
+fn bench_prm(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Prm proof");
+    group.sample_size(20);
+
+    LazyLock::force(&KEY0);
+
+    group.bench_function("prove", |b| {
+        b.iter_custom(|iters| measure_prm(&mut OsRng, &KEY0, iters, Measure::Creation))
+    });
+    group.bench_function("verify", |b| {
+        b.iter_custom(|iters| measure_prm(&mut OsRng, &KEY0, iters, Measure::Verification))
+    });
+}
+
+fn bench_sch(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Sch proof");
+
+    group.bench_function("prove", |b| {
+        b.iter_custom(|iters| measure_sch(&mut OsRng, iters, Measure::Creation))
+    });
+    group.bench_function("verify", |b| {
+        b.iter_custom(|iters| measure_sch(&mut OsRng, iters, Measure::Verification))
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_aff_g,
+    bench_aff_g_star,
+    bench_dec,
+    bench_elog,
+    bench_enc_elg,
+    bench_fac,
+    bench_mod,
+    bench_prm,
+    bench_sch
+);
+
+criterion_main!(benches);

--- a/synedrion/src/cggmp21.rs
+++ b/synedrion/src/cggmp21.rs
@@ -37,6 +37,3 @@ pub use interactive_signing::{
 pub use key_init::{KeyInit, KeyInitAssociatedData, KeyInitProtocol};
 pub use key_refresh::{KeyRefresh, KeyRefreshAssociatedData, KeyRefreshProtocol};
 pub use params::{ProductionParams112, SchemeParams, TestParams};
-
-#[cfg(feature = "private_benches")]
-pub(crate) use params::PaillierProduction112;

--- a/synedrion/src/cggmp21/sigma/aff_g.rs
+++ b/synedrion/src/cggmp21/sigma/aff_g.rs
@@ -315,13 +315,9 @@ mod tests {
 
         let proof = AffGProof::<Params>::new(&mut OsRng, secret, public, &rp_params, &aux);
 
-        // Roundtrip works
-        let res = BinaryFormat::serialize(proof);
-        assert!(res.is_ok());
-        let payload = res.unwrap();
-        let proof: AffGProof<Params> = BinaryFormat::deserialize(&payload).unwrap();
-
-        let rp_params = rp_params.to_wire().to_precomputed();
+        // Serialization roundtrip
+        let serialized = BinaryFormat::serialize(proof).unwrap();
+        let proof = BinaryFormat::deserialize::<AffGProof<Params>>(&serialized).unwrap();
 
         assert!(proof.verify(public, &rp_params, &aux));
     }

--- a/synedrion/src/cggmp21/sigma/aff_g_star.rs
+++ b/synedrion/src/cggmp21/sigma/aff_g_star.rs
@@ -268,6 +268,7 @@ impl<P: SchemeParams> AffGStarProof<P> {
 
 #[cfg(test)]
 mod tests {
+    use manul::{dev::BinaryFormat, session::WireFormat};
     use rand_core::OsRng;
 
     use super::{AffGStarProof, AffGStarPublicInputs, AffGStarSecretInputs};
@@ -318,6 +319,11 @@ mod tests {
         };
 
         let proof = AffGStarProof::<Params>::new(&mut OsRng, secret, public, &aux);
+
+        // Serialization roundtrip
+        let serialized = BinaryFormat::serialize(proof).unwrap();
+        let proof = BinaryFormat::deserialize::<AffGStarProof<Params>>(&serialized).unwrap();
+
         assert!(proof.verify(public, &aux));
     }
 }

--- a/synedrion/src/cggmp21/sigma/aff_g_star.rs
+++ b/synedrion/src/cggmp21/sigma/aff_g_star.rs
@@ -32,6 +32,7 @@ pub(crate) struct AffGStarSecretInputs<'a, P: SchemeParams> {
     pub mu: &'a Randomizer<P::Paillier>,
 }
 
+#[derive(Clone, Copy)]
 pub(crate) struct AffGStarPublicInputs<'a, P: SchemeParams> {
     /// Paillier public keys $N_0$.
     pub pk0: &'a PublicKeyPaillier<P::Paillier>,
@@ -301,34 +302,22 @@ mod tests {
         let cap_y = Ciphertext::new_with_randomizer(pk1, &y, &mu);
         let cap_x = secret_scalar_from_signed::<Params>(&x).mul_by_generator();
 
-        let proof = AffGStarProof::<Params>::new(
-            &mut OsRng,
-            AffGStarSecretInputs {
-                x: &x,
-                y: &y,
-                rho: &rho,
-                mu: &mu,
-            },
-            AffGStarPublicInputs {
-                pk0,
-                pk1,
-                cap_c: &cap_c,
-                cap_d: &cap_d,
-                cap_y: &cap_y,
-                cap_x: &cap_x,
-            },
-            &aux,
-        );
-        assert!(proof.verify(
-            AffGStarPublicInputs {
-                pk0,
-                pk1,
-                cap_c: &cap_c,
-                cap_d: &cap_d,
-                cap_y: &cap_y,
-                cap_x: &cap_x,
-            },
-            &aux
-        ));
+        let secret = AffGStarSecretInputs {
+            x: &x,
+            y: &y,
+            rho: &rho,
+            mu: &mu,
+        };
+        let public = AffGStarPublicInputs {
+            pk0,
+            pk1,
+            cap_c: &cap_c,
+            cap_d: &cap_d,
+            cap_y: &cap_y,
+            cap_x: &cap_x,
+        };
+
+        let proof = AffGStarProof::<Params>::new(&mut OsRng, secret, public, &aux);
+        assert!(proof.verify(public, &aux));
     }
 }

--- a/synedrion/src/cggmp21/sigma/dec.rs
+++ b/synedrion/src/cggmp21/sigma/dec.rs
@@ -35,6 +35,7 @@ pub(crate) struct DecSecretInputs<'a, P: SchemeParams> {
     pub rho: &'a Randomizer<P::Paillier>,
 }
 
+#[derive(Clone, Copy)]
 pub(crate) struct DecPublicInputs<'a, P: SchemeParams> {
     /// Paillier public key $N_0$.
     pub pk0: &'a PublicKeyPaillier<P::Paillier>,
@@ -323,25 +324,22 @@ mod tests {
         let cap_g = Scalar::random(&mut OsRng).mul_by_generator();
         let cap_s = cap_g * secret_scalar_from_signed::<Params>(&y);
 
-        let proof = DecProof::<Params>::new(
-            &mut OsRng,
-            DecSecretInputs {
-                x: &x,
-                y: &y,
-                rho: &rho,
-            },
-            DecPublicInputs {
-                pk0: pk,
-                cap_k: &cap_k,
-                cap_x: &cap_x,
-                cap_d: &cap_d,
-                cap_s: &cap_s,
-                cap_g: &cap_g,
-                num_parties,
-            },
-            &setup,
-            &aux,
-        );
+        let secret = DecSecretInputs {
+            x: &x,
+            y: &y,
+            rho: &rho,
+        };
+        let public = DecPublicInputs {
+            pk0: pk,
+            cap_k: &cap_k,
+            cap_x: &cap_x,
+            cap_d: &cap_d,
+            cap_s: &cap_s,
+            cap_g: &cap_g,
+            num_parties,
+        };
+
+        let proof = DecProof::<Params>::new(&mut OsRng, secret, public, &setup, &aux);
 
         // Roundtrip works
         let res = BinaryFormat::serialize(proof);
@@ -350,18 +348,6 @@ mod tests {
         let proof: DecProof<Params> = BinaryFormat::deserialize(&payload).unwrap();
         let rp_params = setup.to_wire().to_precomputed();
 
-        assert!(proof.verify(
-            DecPublicInputs {
-                pk0: pk,
-                cap_k: &cap_k,
-                cap_x: &cap_x,
-                cap_d: &cap_d,
-                cap_s: &cap_s,
-                cap_g: &cap_g,
-                num_parties,
-            },
-            &rp_params,
-            &aux
-        ));
+        assert!(proof.verify(public, &rp_params, &aux));
     }
 }

--- a/synedrion/src/cggmp21/sigma/dec.rs
+++ b/synedrion/src/cggmp21/sigma/dec.rs
@@ -341,13 +341,10 @@ mod tests {
 
         let proof = DecProof::<Params>::new(&mut OsRng, secret, public, &setup, &aux);
 
-        // Roundtrip works
-        let res = BinaryFormat::serialize(proof);
-        assert!(res.is_ok());
-        let payload = res.unwrap();
-        let proof: DecProof<Params> = BinaryFormat::deserialize(&payload).unwrap();
-        let rp_params = setup.to_wire().to_precomputed();
+        // Serialization roundtrip
+        let serialized = BinaryFormat::serialize(proof).unwrap();
+        let proof = BinaryFormat::deserialize::<DecProof<Params>>(&serialized).unwrap();
 
-        assert!(proof.verify(public, &rp_params, &aux));
+        assert!(proof.verify(public, &setup, &aux));
     }
 }

--- a/synedrion/src/cggmp21/sigma/elog.rs
+++ b/synedrion/src/cggmp21/sigma/elog.rs
@@ -135,6 +135,7 @@ impl<P: SchemeParams> ElogProof<P> {
 
 #[cfg(test)]
 mod tests {
+    use manul::{dev::BinaryFormat, session::WireFormat};
     use rand_core::OsRng;
 
     use super::{ElogProof, ElogPublicInputs, ElogSecretInputs};
@@ -165,6 +166,11 @@ mod tests {
         };
 
         let proof = ElogProof::<Params>::new(&mut OsRng, secret, public, &aux);
+
+        // Serialization roundtrip
+        let serialized = BinaryFormat::serialize(proof).unwrap();
+        let proof = BinaryFormat::deserialize::<ElogProof<Params>>(&serialized).unwrap();
+
         assert!(proof.verify(public, &aux));
     }
 }

--- a/synedrion/src/cggmp21/sigma/elog.rs
+++ b/synedrion/src/cggmp21/sigma/elog.rs
@@ -19,6 +19,7 @@ pub(crate) struct ElogSecretInputs<'a, P: SchemeParams> {
     pub lambda: &'a Secret<Scalar<P>>,
 }
 
+#[derive(Clone, Copy)]
 pub(crate) struct ElogPublicInputs<'a, P: SchemeParams> {
     /// Point $L = g * \lambda$, where $g$ is the curve generator.
     pub cap_l: &'a Point<P>,
@@ -154,27 +155,16 @@ mod tests {
         let h = Scalar::random(&mut OsRng).mul_by_generator();
         let cap_y = h * &y;
 
-        let proof = ElogProof::<Params>::new(
-            &mut OsRng,
-            ElogSecretInputs { y: &y, lambda: &lambda },
-            ElogPublicInputs {
-                cap_l: &cap_l,
-                cap_m: &cap_m,
-                cap_x: &cap_x,
-                cap_y: &cap_y,
-                h: &h,
-            },
-            &aux,
-        );
-        assert!(proof.verify(
-            ElogPublicInputs {
-                cap_l: &cap_l,
-                cap_m: &cap_m,
-                cap_x: &cap_x,
-                cap_y: &cap_y,
-                h: &h
-            },
-            &aux
-        ));
+        let secret = ElogSecretInputs { y: &y, lambda: &lambda };
+        let public = ElogPublicInputs {
+            cap_l: &cap_l,
+            cap_m: &cap_m,
+            cap_x: &cap_x,
+            cap_y: &cap_y,
+            h: &h,
+        };
+
+        let proof = ElogProof::<Params>::new(&mut OsRng, secret, public, &aux);
+        assert!(proof.verify(public, &aux));
     }
 }

--- a/synedrion/src/cggmp21/sigma/enc_elg.rs
+++ b/synedrion/src/cggmp21/sigma/enc_elg.rs
@@ -31,6 +31,7 @@ pub struct EncElgSecretInputs<'a, P: SchemeParams> {
     pub b: &'a Secret<Scalar<P>>,
 }
 
+#[derive(Clone, Copy)]
 pub struct EncElgPublicInputs<'a, P: SchemeParams> {
     /// Paillier public key $N_0$.
     pub pk0: &'a PublicKeyPaillier<P::Paillier>,
@@ -231,33 +232,20 @@ mod tests {
         let cap_b = b.mul_by_generator();
         let cap_x = (&a * &b + secret_scalar_from_signed::<Params>(&x)).mul_by_generator();
 
-        let proof = EncElgProof::<Params>::new(
-            &mut OsRng,
-            EncElgSecretInputs {
-                x: &x,
-                rho: &rho,
-                b: &b,
-            },
-            EncElgPublicInputs {
-                pk0: pk,
-                cap_c: &cap_c,
-                cap_a: &cap_a,
-                cap_b: &cap_b,
-                cap_x: &cap_x,
-            },
-            &setup,
-            &aux,
-        );
-        assert!(proof.verify(
-            EncElgPublicInputs {
-                pk0: pk,
-                cap_c: &cap_c,
-                cap_a: &cap_a,
-                cap_b: &cap_b,
-                cap_x: &cap_x,
-            },
-            &setup,
-            &aux
-        ));
+        let secret = EncElgSecretInputs {
+            x: &x,
+            rho: &rho,
+            b: &b,
+        };
+        let public = EncElgPublicInputs {
+            pk0: pk,
+            cap_c: &cap_c,
+            cap_a: &cap_a,
+            cap_b: &cap_b,
+            cap_x: &cap_x,
+        };
+
+        let proof = EncElgProof::<Params>::new(&mut OsRng, secret, public, &setup, &aux);
+        assert!(proof.verify(public, &setup, &aux));
     }
 }

--- a/synedrion/src/cggmp21/sigma/enc_elg.rs
+++ b/synedrion/src/cggmp21/sigma/enc_elg.rs
@@ -199,6 +199,7 @@ impl<P: SchemeParams> EncElgProof<P> {
 
 #[cfg(test)]
 mod tests {
+    use manul::{dev::BinaryFormat, session::WireFormat};
     use rand_core::OsRng;
 
     use super::{EncElgProof, EncElgPublicInputs, EncElgSecretInputs};
@@ -246,6 +247,11 @@ mod tests {
         };
 
         let proof = EncElgProof::<Params>::new(&mut OsRng, secret, public, &setup, &aux);
+
+        // Serialization roundtrip
+        let serialized = BinaryFormat::serialize(proof).unwrap();
+        let proof = BinaryFormat::deserialize::<EncElgProof<Params>>(&serialized).unwrap();
+
         assert!(proof.verify(public, &setup, &aux));
     }
 }

--- a/synedrion/src/cggmp21/sigma/fac.rs
+++ b/synedrion/src/cggmp21/sigma/fac.rs
@@ -223,14 +223,10 @@ mod tests {
 
         let proof = FacProof::<Params>::new(&mut OsRng, &sk, &setup, &aux);
 
-        // Roundtrip works
-        let res = BinaryFormat::serialize(proof);
-        assert!(res.is_ok());
-        let payload = res.unwrap();
-        let proof: FacProof<Params> = BinaryFormat::deserialize(&payload).unwrap();
+        // Serialization roundtrip
+        let serialized = BinaryFormat::serialize(proof).unwrap();
+        let proof = BinaryFormat::deserialize::<FacProof<Params>>(&serialized).unwrap();
 
-        let rp_params = setup.to_wire().to_precomputed();
-        let pubkey = pk.clone().into_wire().into_precomputed();
-        assert!(proof.verify(&pubkey, &rp_params, &aux));
+        assert!(proof.verify(pk, &setup, &aux));
     }
 }

--- a/synedrion/src/cggmp21/sigma/mod_.rs
+++ b/synedrion/src/cggmp21/sigma/mod_.rs
@@ -222,11 +222,9 @@ mod tests {
 
         let proof = ModProof::<Params>::new(&mut OsRng, &sk, &aux);
 
-        // Roundtrip works
-        let res = BinaryFormat::serialize(proof);
-        assert!(res.is_ok());
-        let payload = res.unwrap();
-        let proof: ModProof<Params> = BinaryFormat::deserialize(&payload).unwrap();
+        // Serialization roundtrip
+        let serialized = BinaryFormat::serialize(proof).unwrap();
+        let proof = BinaryFormat::deserialize::<ModProof<Params>>(&serialized).unwrap();
 
         assert!(proof.verify(pk, &aux));
     }

--- a/synedrion/src/cggmp21/sigma/prm.rs
+++ b/synedrion/src/cggmp21/sigma/prm.rs
@@ -151,11 +151,9 @@ mod tests {
 
         let proof = PrmProof::<Params>::new(&mut OsRng, &secret, &setup, &aux);
 
-        // Roundtrip works
-        let res = BinaryFormat::serialize(proof);
-        assert!(res.is_ok());
-        let payload = res.unwrap();
-        let proof: PrmProof<Params> = BinaryFormat::deserialize(&payload).unwrap();
+        // Serialization roundtrip
+        let serialized = BinaryFormat::serialize(proof).unwrap();
+        let proof = BinaryFormat::deserialize::<PrmProof<Params>>(&serialized).unwrap();
 
         assert!(proof.verify(&setup, &aux));
     }

--- a/synedrion/src/cggmp21/sigma/sch.rs
+++ b/synedrion/src/cggmp21/sigma/sch.rs
@@ -93,7 +93,9 @@ mod tests {
 
     #[test]
     fn prove_and_verify() {
-        let secret = Secret::init_with(|| Scalar::<TestParams>::random(&mut OsRng));
+        type Params = TestParams;
+
+        let secret = Secret::init_with(|| Scalar::<Params>::random(&mut OsRng));
         let public = secret.mul_by_generator();
         let aux: &[u8] = b"abcde";
 
@@ -101,11 +103,9 @@ mod tests {
         let commitment = SchCommitment::new(&proof_secret);
         let proof = SchProof::new(&proof_secret, &secret, &commitment, &public, &aux);
 
-        // Roundtrip works
-        let res = BinaryFormat::serialize(proof);
-        assert!(res.is_ok());
-        let payload = res.unwrap();
-        let proof: SchProof<TestParams> = BinaryFormat::deserialize(&payload).unwrap();
+        // Serialization roundtrip
+        let serialized = BinaryFormat::serialize(proof).unwrap();
+        let proof = BinaryFormat::deserialize::<SchProof<Params>>(&serialized).unwrap();
 
         assert!(proof.verify(&commitment, &public, &aux));
     }

--- a/synedrion/src/lib.rs
+++ b/synedrion/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(any(test, feature = "private_benches")), no_std)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![deny(unsafe_code)]

--- a/synedrion/src/private_benches.rs
+++ b/synedrion/src/private_benches.rs
@@ -1,17 +1,19 @@
-use criterion::{black_box, BatchSize, Bencher};
+use std::time::{Duration, Instant};
+
 use rand_core::CryptoRngCore;
 
 use crate::{
     cggmp21::{
         conversion::secret_scalar_from_signed,
         sigma::{
-            AffGProof, AffGPublicInputs, AffGSecretInputs, DecProof, DecPublicInputs, DecSecretInputs, FacProof,
-            ModProof, PrmProof, SchCommitment, SchProof, SchSecret,
+            AffGProof, AffGPublicInputs, AffGSecretInputs, AffGStarProof, AffGStarPublicInputs, AffGStarSecretInputs,
+            DecProof, DecPublicInputs, DecSecretInputs, ElogProof, ElogPublicInputs, ElogSecretInputs, EncElgProof,
+            EncElgPublicInputs, EncElgSecretInputs, FacProof, ModProof, PrmProof, SchCommitment, SchProof, SchSecret,
         },
-        PaillierProduction112, ProductionParams112,
+        ProductionParams112,
     },
-    curve::{Point, Scalar},
-    paillier::{Ciphertext, PaillierParams, PublicKeyPaillier, RPParams, RPSecret, Randomizer, SecretKeyPaillierWire},
+    curve::Scalar,
+    paillier::{Ciphertext, PaillierParams, RPParams, RPSecret, Randomizer, SecretKeyPaillier, SecretKeyPaillierWire},
     tools::Secret,
     uint::SecretSigned,
     SchemeParams,
@@ -19,776 +21,383 @@ use crate::{
 
 type Params = ProductionParams112;
 type Paillier = <Params as SchemeParams>::Paillier;
-type PUint = <<Params as SchemeParams>::Paillier as PaillierParams>::Uint;
 
-pub mod fac_proof {
-    use super::*;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Measure {
+    Creation,
+    Verification,
+}
 
-    /// Benchmark Fac-proof construction
-    pub fn fac_proof_prove<R: CryptoRngCore + Clone + 'static>(mut rng: R) -> impl FnMut(&mut Bencher<'_>) {
-        let mut rng2 = rng.clone();
-        move |b: &mut Bencher<'_>| {
-            b.iter_batched(
-                || {
-                    let sk = SecretKeyPaillierWire::<Paillier>::random(&mut rng).into_precomputed();
+pub struct PreparedKey<P: SchemeParams> {
+    sk: SecretKeyPaillier<P::Paillier>,
+    rp_secret: RPSecret<P::Paillier>,
+    rp_params: RPParams<P::Paillier>,
+}
 
-                    let setup = RPParams::random(&mut rng);
+impl<P: SchemeParams> PreparedKey<P> {
+    pub fn new(rng: &mut impl CryptoRngCore) -> Self {
+        let sk = SecretKeyPaillierWire::<P::Paillier>::random(rng).into_precomputed();
 
-                    let aux: &[u8] = b"abcde";
-                    (sk, setup, aux)
-                },
-                |(sk, setup, aux)| black_box(FacProof::<Params>::new(&mut rng2, &sk, &setup, &aux)),
-                BatchSize::SmallInput,
-            );
-        }
-    }
+        let rp_secret = RPSecret::random(rng);
+        let rp_params = RPParams::random_with_secret(rng, &rp_secret);
 
-    /// Benchmark Fac-proof verification
-    pub fn fac_proof_verify<R: CryptoRngCore + Clone + 'static>(mut rng: R) -> impl FnMut(&mut Bencher<'_>) {
-        move |b: &mut Bencher<'_>| {
-            b.iter_batched(
-                || {
-                    let sk = SecretKeyPaillierWire::<Paillier>::random(&mut rng).into_precomputed();
-
-                    let setup = RPParams::random(&mut rng);
-
-                    let aux: &[u8] = b"abcde";
-                    let proof = FacProof::<Params>::new(&mut rng, &sk, &setup, &aux);
-                    (proof, sk.public_key().clone(), setup, aux)
-                },
-                |(proof, pk0, setup, aux): (
-                    FacProof<Params>,
-                    PublicKeyPaillier<PaillierProduction112>,
-                    RPParams<PaillierProduction112>,
-                    &[u8],
-                )| {
-                    proof.verify(&pk0, &setup, &aux);
-                },
-                BatchSize::SmallInput,
-            );
+        Self {
+            sk,
+            rp_secret,
+            rp_params,
         }
     }
 }
 
-pub mod aff_g_proof {
-    use super::*;
+pub fn measure_aff_g(
+    rng: &mut impl CryptoRngCore,
+    key0: &PreparedKey<Params>,
+    key1: &PreparedKey<Params>,
+    iters: u64,
+    measure: Measure,
+) -> Duration {
+    let sk0 = &key0.sk;
+    let pk0 = sk0.public_key();
 
-    #[allow(clippy::type_complexity)]
-    fn proof_inputs(
-        mut rng: impl CryptoRngCore + 'static,
-    ) -> (
-        (impl CryptoRngCore + 'static),
-        SecretSigned<PUint>,
-        SecretSigned<PUint>,
-        Randomizer<Paillier>,
-        Randomizer<Paillier>,
-        PublicKeyPaillier<Paillier>,
-        PublicKeyPaillier<Paillier>,
-        Ciphertext<Paillier>,
-        Ciphertext<Paillier>,
-        Ciphertext<Paillier>,
-        Point<Params>,
-        RPParams<Paillier>,
-        &'static [u8],
-    ) {
-        let sk0 = SecretKeyPaillierWire::<Paillier>::random(&mut rng).into_precomputed();
-        let pk0 = sk0.public_key().clone();
+    let sk1 = &key1.sk;
+    let pk1 = sk1.public_key();
 
-        let sk1 = SecretKeyPaillierWire::<Paillier>::random(&mut rng).into_precomputed();
-        let pk1 = sk1.public_key().clone();
+    let rp_params = &key0.rp_params;
 
-        let rp_params = RPParams::random(&mut rng);
-
+    let mut total = Duration::ZERO;
+    for _ in 0..iters {
         let aux: &[u8] = b"abcde";
 
-        let x = SecretSigned::random_in_exponent_range(&mut rng, Params::L_BOUND);
-        let y = SecretSigned::random_in_exponent_range(&mut rng, Params::LP_BOUND);
+        let x = SecretSigned::random_in_exponent_range(rng, Params::L_BOUND);
+        let y = SecretSigned::random_in_exponent_range(rng, Params::LP_BOUND);
 
-        let rho = Randomizer::random(&mut rng, &pk0);
-        let rho_y = Randomizer::random(&mut rng, &pk1);
-        let secret = SecretSigned::random_in_exponent_range(&mut rng, Params::L_BOUND);
-        let cap_c = Ciphertext::new_with_randomizer(&pk0, &secret, &Randomizer::random(&mut rng, &pk0));
-        let cap_d = &cap_c * &x + Ciphertext::new_with_randomizer(&pk0, &-&y, &rho);
-        let cap_y = Ciphertext::new_with_randomizer(&pk1, &y, &rho_y);
+        let rho = Randomizer::random(rng, pk0);
+        let rho_y = Randomizer::random(rng, pk1);
+        let secret = SecretSigned::random_in_exponent_range(rng, Params::L_BOUND);
+        let cap_c = Ciphertext::new_with_randomizer(pk0, &secret, &Randomizer::random(rng, pk0));
+        let cap_d = &cap_c * &x + Ciphertext::new_with_randomizer(pk0, &-&y, &rho);
+        let cap_y = Ciphertext::new_with_randomizer(pk1, &y, &rho_y);
         let cap_x = secret_scalar_from_signed::<Params>(&x).mul_by_generator();
 
-        (
-            rng, x, y, rho, rho_y, pk0, pk1, cap_c, cap_d, cap_y, cap_x, rp_params, aux,
-        )
-    }
+        let secret = AffGSecretInputs {
+            x: &x,
+            y: &y,
+            rho: &rho,
+            rho_y: &rho_y,
+        };
+        let public = AffGPublicInputs {
+            pk0,
+            pk1,
+            cap_c: &cap_c,
+            cap_d: &cap_d,
+            cap_y: &cap_y,
+            cap_x: &cap_x,
+        };
 
-    pub fn aff_g_proof_prove<R: CryptoRngCore + Clone + 'static>(rng: R) -> impl FnMut(&mut Bencher<'_>) {
-        move |b: &mut Bencher<'_>| {
-            b.iter_batched(
-                || {
-                    let rng2 = rng.clone();
-                    proof_inputs(rng2)
-                },
-                |(mut rng, x, y, rho, rho_y, pk0, pk1, cap_c, cap_d, cap_y, cap_x, rp_params, aux)| {
-                    black_box(AffGProof::<Params>::new(
-                        &mut rng,
-                        AffGSecretInputs {
-                            x: &x,
-                            y: &y,
-                            rho: &rho,
-                            rho_y: &rho_y,
-                        },
-                        AffGPublicInputs {
-                            pk0: &pk0,
-                            pk1: &pk1,
-                            cap_c: &cap_c,
-                            cap_d: &cap_d,
-                            cap_y: &cap_y,
-                            cap_x: &cap_x,
-                        },
-                        &rp_params,
-                        &aux,
-                    ))
-                },
-                BatchSize::SmallInput,
-            );
+        let start = Instant::now();
+        let proof = AffGProof::<Params>::new(rng, secret, public, rp_params, &aux);
+        match measure {
+            Measure::Creation => total += start.elapsed(),
+            Measure::Verification => {
+                let start = Instant::now();
+                assert!(proof.verify(public, rp_params, &aux));
+                total += start.elapsed();
+            }
         }
     }
-    pub fn aff_g_proof_verify<R: CryptoRngCore + Clone + 'static>(mut rng: R) -> impl FnMut(&mut Bencher<'_>) {
-        move |b: &mut Bencher<'_>| {
-            b.iter_batched(
-                || {
-                    let (_, x, y, rho, rho_y, pk0, pk1, cap_c, cap_d, cap_y, cap_x, rp_params, aux) =
-                        proof_inputs(rng.clone());
-
-                    let pub_inputs = AffGPublicInputs {
-                        pk0: &pk0,
-                        pk1: &pk1,
-                        cap_c: &cap_c,
-                        cap_d: &cap_d,
-                        cap_y: &cap_y,
-                        cap_x: &cap_x,
-                    };
-
-                    let proof = AffGProof::<Params>::new(
-                        &mut rng,
-                        AffGSecretInputs {
-                            x: &x,
-                            y: &y,
-                            rho: &rho,
-                            rho_y: &rho_y,
-                        },
-                        pub_inputs,
-                        &rp_params,
-                        b"abcde",
-                    );
-
-                    let inputs = (
-                        pk0.clone(),
-                        pk1.clone(),
-                        cap_c.clone(),
-                        cap_d.clone(),
-                        cap_y.clone(),
-                        cap_x,
-                    );
-                    let rp_params2 = rp_params.clone();
-                    (proof, inputs, rp_params2, aux)
-                },
-                |(proof, inputs, rp_params, aux)| {
-                    let pub_inputs = AffGPublicInputs {
-                        pk0: &inputs.0,
-                        pk1: &inputs.1,
-                        cap_c: &inputs.2,
-                        cap_d: &inputs.3,
-                        cap_y: &inputs.4,
-                        cap_x: &inputs.5,
-                    };
-
-                    black_box(proof.verify(pub_inputs, &rp_params, &aux))
-                },
-                BatchSize::SmallInput,
-            );
-        }
-    }
+    total
 }
 
-pub mod aff_g_star_proof {
-    use crate::cggmp21::sigma::{AffGStarProof, AffGStarPublicInputs, AffGStarSecretInputs};
+pub fn measure_aff_g_star(
+    rng: &mut impl CryptoRngCore,
+    key0: &PreparedKey<Params>,
+    key1: &PreparedKey<Params>,
+    iters: u64,
+    measure: Measure,
+) -> Duration {
+    let sk0 = &key0.sk;
+    let pk0 = sk0.public_key();
 
-    use super::*;
+    let sk1 = &key1.sk;
+    let pk1 = sk1.public_key();
 
-    #[allow(clippy::type_complexity)]
-    fn proof_input(
-        mut rng: impl CryptoRngCore,
-    ) -> (
-        impl CryptoRngCore,
-        SecretSigned<PUint>,
-        SecretSigned<PUint>,
-        Randomizer<Paillier>,
-        Randomizer<Paillier>,
-        PublicKeyPaillier<Paillier>,
-        PublicKeyPaillier<Paillier>,
-        Ciphertext<Paillier>,
-        Ciphertext<Paillier>,
-        Ciphertext<Paillier>,
-        Point<Params>,
-        &'static [u8],
-    ) {
-        let sk0 = SecretKeyPaillierWire::<Paillier>::random(&mut rng).into_precomputed();
-        let pk0 = sk0.public_key();
+    let mut total = Duration::ZERO;
+    for _ in 0..iters {
+        let aux: &[u8] = b"abcde";
 
-        let sk1 = SecretKeyPaillierWire::<Paillier>::random(&mut rng).into_precomputed();
-        let pk1 = sk1.public_key();
+        let x = SecretSigned::random_in_exponent_range(rng, Params::L_BOUND);
+        let y = SecretSigned::random_in_exponent_range(rng, Params::LP_BOUND);
+        let rho = Randomizer::random(rng, pk0);
+        let mu = Randomizer::random(rng, pk1);
 
-        let x = SecretSigned::random_in_exponent_range(&mut rng, Params::L_BOUND);
-        let y = SecretSigned::random_in_exponent_range(&mut rng, Params::LP_BOUND);
-        let rho = Randomizer::random(&mut rng, pk0);
-        let mu = Randomizer::random(&mut rng, pk1);
-
-        let secret = SecretSigned::random_in_exponent_range(&mut rng, Params::L_BOUND);
-        let cap_c = Ciphertext::new(&mut rng, pk0, &secret);
+        let secret = SecretSigned::random_in_exponent_range(rng, Params::L_BOUND);
+        let cap_c = Ciphertext::new(rng, pk0, &secret);
 
         let cap_d = &cap_c * &x + Ciphertext::new_with_randomizer(pk0, &-&y, &rho);
         let cap_y = Ciphertext::new_with_randomizer(pk1, &y, &mu);
         let cap_x = secret_scalar_from_signed::<Params>(&x).mul_by_generator();
 
-        (
-            rng,
-            x,
-            y,
-            rho,
-            mu,
-            pk0.clone(),
-            pk1.clone(),
-            cap_c,
-            cap_d,
-            cap_y,
-            cap_x,
-            b"abcde",
-        )
-    }
+        let secret = AffGStarSecretInputs {
+            x: &x,
+            y: &y,
+            rho: &rho,
+            mu: &mu,
+        };
+        let public = AffGStarPublicInputs {
+            pk0,
+            pk1,
+            cap_c: &cap_c,
+            cap_d: &cap_d,
+            cap_y: &cap_y,
+            cap_x: &cap_x,
+        };
 
-    pub fn aff_g_star_proof_prove<R: CryptoRngCore + Clone + 'static>(rng: R) -> impl FnMut(&mut Bencher<'_>) {
-        move |b: &mut Bencher<'_>| {
-            b.iter_batched(
-                || proof_input(rng.clone()),
-                |(mut rng, x, y, rho, mu, pk0, pk1, cap_c, cap_d, cap_y, cap_x, aux)| {
-                    black_box(AffGStarProof::<Params>::new(
-                        &mut rng,
-                        AffGStarSecretInputs {
-                            x: &x,
-                            y: &y,
-                            rho: &rho,
-                            mu: &mu,
-                        },
-                        AffGStarPublicInputs {
-                            pk0: &pk0,
-                            pk1: &pk1,
-                            cap_c: &cap_c,
-                            cap_d: &cap_d,
-                            cap_y: &cap_y,
-                            cap_x: &cap_x,
-                        },
-                        &aux,
-                    ))
-                },
-                BatchSize::SmallInput,
-            );
+        let start = Instant::now();
+        let proof = AffGStarProof::<Params>::new(rng, secret, public, &aux);
+        match measure {
+            Measure::Creation => total += start.elapsed(),
+            Measure::Verification => {
+                let start = Instant::now();
+                assert!(proof.verify(public, &aux));
+                total += start.elapsed();
+            }
         }
     }
-    pub fn aff_g_star_proof_verify<R: CryptoRngCore + Clone + 'static>(rng: R) -> impl FnMut(&mut Bencher<'_>) {
-        move |b: &mut Bencher<'_>| {
-            b.iter_batched(
-                || {
-                    let (mut rng, x, y, rho, mu, pk0, pk1, cap_c, cap_d, cap_y, cap_x, aux) = proof_input(rng.clone());
-                    let proof = AffGStarProof::<Params>::new(
-                        &mut rng,
-                        AffGStarSecretInputs {
-                            x: &x,
-                            y: &y,
-                            rho: &rho,
-                            mu: &mu,
-                        },
-                        AffGStarPublicInputs {
-                            pk0: &pk0,
-                            pk1: &pk1,
-                            cap_c: &cap_c,
-                            cap_d: &cap_d,
-                            cap_y: &cap_y,
-                            cap_x: &cap_x,
-                        },
-                        &aux,
-                    );
-                    (proof, pk0, pk1, cap_c, cap_d, cap_y, cap_x, aux)
-                },
-                |(proof, pk0, pk1, cap_c, cap_d, cap_y, cap_x, aux)| {
-                    black_box(proof.verify(
-                        AffGStarPublicInputs {
-                            pk0: &pk0,
-                            pk1: &pk1,
-                            cap_c: &cap_c,
-                            cap_d: &cap_d,
-                            cap_y: &cap_y,
-                            cap_x: &cap_x,
-                        },
-                        &aux,
-                    ))
-                },
-                BatchSize::SmallInput,
-            );
-        }
-    }
+    total
 }
 
-pub mod dec_proof {
-    use super::*;
+pub fn measure_dec(rng: &mut impl CryptoRngCore, key: &PreparedKey<Params>, iters: u64, measure: Measure) -> Duration {
+    let sk = &key.sk;
+    let pk = sk.public_key();
+    let rp_params = &key.rp_params;
 
-    #[allow(clippy::type_complexity)]
-    fn proof_input(
-        mut rng: impl CryptoRngCore,
-    ) -> (
-        impl CryptoRngCore,
-        SecretSigned<PUint>,
-        SecretSigned<PUint>,
-        Randomizer<Paillier>,
-        PublicKeyPaillier<Paillier>,
-        Ciphertext<Paillier>,
-        Point<Params>,
-        Ciphertext<Paillier>,
-        Point<Params>,
-        Point<Params>,
-        usize,
-        RPParams<Paillier>,
-        &'static [u8],
-    ) {
-        let sk = SecretKeyPaillierWire::<Paillier>::random(&mut rng).into_precomputed();
-        let pk = sk.public_key();
+    let num_parties: usize = 10;
+    let ceil_log2_num_parties = (num_parties - 1).ilog2() + 1;
 
-        let setup = RPParams::random(&mut rng);
+    let mut total = Duration::ZERO;
+    for _ in 0..iters {
         let aux: &[u8] = b"abcde";
 
-        let num_parties: usize = 10;
-        let ceil_log2_num_parties = (num_parties - 1).ilog2() + 1;
-
-        let x = SecretSigned::random_in_exponent_range(&mut rng, Params::L_BOUND);
+        let x = SecretSigned::random_in_exponent_range(rng, Params::L_BOUND);
         let y = SecretSigned::random_in_exponent_range(
-            &mut rng,
+            rng,
             Params::LP_BOUND + Params::EPS_BOUND + 1 + ceil_log2_num_parties,
         );
-        let rho = Randomizer::random(&mut rng, pk);
+        let rho = Randomizer::random(rng, pk);
 
-        let k = SecretSigned::random_in_exponent_range(&mut rng, Paillier::PRIME_BITS * 2 - 1);
-        let cap_k = Ciphertext::new(&mut rng, pk, &k);
+        let k = SecretSigned::random_in_exponent_range(rng, Paillier::PRIME_BITS * 2 - 1);
+        let cap_k = Ciphertext::new(rng, pk, &k);
         let cap_d = Ciphertext::new_with_randomizer(pk, &y, &rho) + &cap_k * &-&x;
 
         let cap_x = secret_scalar_from_signed::<Params>(&x).mul_by_generator();
 
-        let cap_g = Scalar::random(&mut rng).mul_by_generator();
+        let cap_g = Scalar::random(rng).mul_by_generator();
         let cap_s = cap_g * secret_scalar_from_signed::<Params>(&y);
 
-        (
-            rng,
-            x,
-            y,
-            rho,
-            pk.clone(),
-            cap_k,
-            cap_x,
-            cap_d,
-            cap_s,
-            cap_g,
+        let secret = DecSecretInputs {
+            x: &x,
+            y: &y,
+            rho: &rho,
+        };
+        let public = DecPublicInputs {
+            pk0: pk,
+            cap_k: &cap_k,
+            cap_x: &cap_x,
+            cap_d: &cap_d,
+            cap_s: &cap_s,
+            cap_g: &cap_g,
             num_parties,
-            setup,
-            aux,
-        )
-    }
+        };
 
-    pub fn dec_proof_prove<R: CryptoRngCore + Clone + 'static>(rng: R) -> impl FnMut(&mut Bencher<'_>) {
-        move |b: &mut Bencher<'_>| {
-            b.iter_batched(
-                || proof_input(rng.clone()),
-                |(mut rng, x, y, rho, pk, cap_k, cap_x, cap_d, cap_s, cap_g, num_parties, setup, aux)| {
-                    black_box(DecProof::<Params>::new(
-                        &mut rng,
-                        DecSecretInputs {
-                            x: &x,
-                            y: &y,
-                            rho: &rho,
-                        },
-                        DecPublicInputs {
-                            pk0: &pk,
-                            cap_k: &cap_k,
-                            cap_x: &cap_x,
-                            cap_d: &cap_d,
-                            cap_s: &cap_s,
-                            cap_g: &cap_g,
-                            num_parties,
-                        },
-                        &setup,
-                        &aux,
-                    ))
-                },
-                BatchSize::SmallInput,
-            );
+        let start = Instant::now();
+        let proof = DecProof::<Params>::new(rng, secret, public, rp_params, &aux);
+        match measure {
+            Measure::Creation => total += start.elapsed(),
+            Measure::Verification => {
+                let start = Instant::now();
+                assert!(proof.verify(public, rp_params, &aux));
+                total += start.elapsed();
+            }
         }
     }
-
-    pub fn dec_proof_verify<R: CryptoRngCore + Clone + 'static>(rng: R) -> impl FnMut(&mut Bencher<'_>) {
-        move |b: &mut Bencher<'_>| {
-            b.iter_batched(
-                || {
-                    let (mut rng, x, y, rho, pk, cap_k, cap_x, cap_d, cap_s, cap_g, num_parties, setup, aux) =
-                        proof_input(rng.clone());
-
-                    let proof = DecProof::<Params>::new(
-                        &mut rng,
-                        DecSecretInputs {
-                            x: &x,
-                            y: &y,
-                            rho: &rho,
-                        },
-                        DecPublicInputs {
-                            pk0: &pk,
-                            cap_k: &cap_k,
-                            cap_x: &cap_x,
-                            cap_d: &cap_d,
-                            cap_s: &cap_s,
-                            cap_g: &cap_g,
-                            num_parties,
-                        },
-                        &setup,
-                        &aux,
-                    );
-                    (proof, pk, cap_k, cap_x, cap_d, cap_s, cap_g, num_parties, setup)
-                },
-                |(proof, pk, cap_k, cap_x, cap_d, cap_s, cap_g, num_parties, rp_params)| {
-                    let pub_inputs = DecPublicInputs {
-                        pk0: &pk,
-                        cap_k: &cap_k,
-                        cap_x: &cap_x,
-                        cap_d: &cap_d,
-                        cap_s: &cap_s,
-                        cap_g: &cap_g,
-                        num_parties,
-                    };
-                    black_box(proof.verify(pub_inputs, &rp_params, b"abcde"));
-                },
-                BatchSize::SmallInput,
-            );
-        }
-    }
+    total
 }
 
-pub mod elog_proof {
-    use crate::cggmp21::sigma::{ElogProof, ElogPublicInputs, ElogSecretInputs};
+pub fn measure_elog(rng: &mut impl CryptoRngCore, iters: u64, measure: Measure) -> Duration {
+    let mut total = Duration::ZERO;
+    for _ in 0..iters {
+        let aux: &[u8] = b"abcde";
 
-    use super::*;
-    pub fn elog_proof_prove<R: CryptoRngCore + Clone + 'static>(mut rng: R) -> impl FnMut(&mut Bencher<'_>) {
-        move |b: &mut Bencher<'_>| {
-            b.iter_batched(
-                || {
-                    let y = Secret::init_with(|| Scalar::random(&mut rng));
-                    let lambda = Secret::init_with(|| Scalar::random(&mut rng));
+        let y = Secret::init_with(|| Scalar::random(rng));
+        let lambda = Secret::init_with(|| Scalar::random(rng));
 
-                    let cap_l = lambda.mul_by_generator();
-                    let cap_x = Scalar::random(&mut rng).mul_by_generator();
-                    let cap_m = y.mul_by_generator() + cap_x * &lambda;
-                    let h = Scalar::random(&mut rng).mul_by_generator();
-                    let cap_y = h * &y;
-                    (rng.clone(), y, lambda, cap_l, cap_m, cap_x, cap_y, h, b"abcde")
-                },
-                |(mut rng, y, lambda, cap_l, cap_m, cap_x, cap_y, h, aux)| {
-                    black_box(ElogProof::<Params>::new(
-                        &mut rng,
-                        ElogSecretInputs { y: &y, lambda: &lambda },
-                        ElogPublicInputs {
-                            cap_l: &cap_l,
-                            cap_m: &cap_m,
-                            cap_x: &cap_x,
-                            cap_y: &cap_y,
-                            h: &h,
-                        },
-                        &aux,
-                    ))
-                },
-                BatchSize::SmallInput,
-            );
+        let cap_l = lambda.mul_by_generator();
+        let cap_x = Scalar::random(rng).mul_by_generator();
+        let cap_m = y.mul_by_generator() + cap_x * &lambda;
+        let h = Scalar::random(rng).mul_by_generator();
+        let cap_y = h * &y;
+
+        let secret = ElogSecretInputs { y: &y, lambda: &lambda };
+        let public = ElogPublicInputs {
+            cap_l: &cap_l,
+            cap_m: &cap_m,
+            cap_x: &cap_x,
+            cap_y: &cap_y,
+            h: &h,
+        };
+
+        let start = Instant::now();
+        let proof = ElogProof::<Params>::new(rng, secret, public, &aux);
+        match measure {
+            Measure::Creation => total += start.elapsed(),
+            Measure::Verification => {
+                let start = Instant::now();
+                assert!(proof.verify(public, &aux));
+                total += start.elapsed();
+            }
         }
     }
-    pub fn elog_proof_verify<R: CryptoRngCore + Clone + 'static>(mut rng: R) -> impl FnMut(&mut Bencher<'_>) {
-        move |b: &mut Bencher<'_>| {
-            b.iter_batched(
-                || {
-                    let y = Secret::init_with(|| Scalar::random(&mut rng));
-                    let lambda = Secret::init_with(|| Scalar::random(&mut rng));
-
-                    let cap_l = lambda.mul_by_generator();
-                    let cap_x = Scalar::random(&mut rng).mul_by_generator();
-                    let cap_m = y.mul_by_generator() + cap_x * &lambda;
-                    let h = Scalar::random(&mut rng).mul_by_generator();
-                    let cap_y = h * &y;
-                    let proof = ElogProof::<Params>::new(
-                        &mut rng,
-                        ElogSecretInputs { y: &y, lambda: &lambda },
-                        ElogPublicInputs {
-                            cap_l: &cap_l,
-                            cap_m: &cap_m,
-                            cap_x: &cap_x,
-                            cap_y: &cap_y,
-                            h: &h,
-                        },
-                        b"abcde",
-                    );
-                    (proof, cap_l, cap_m, cap_x, cap_y, h, b"abcde")
-                },
-                |(proof, cap_l, cap_m, cap_x, cap_y, h, aux)| {
-                    black_box(proof.verify(
-                        ElogPublicInputs {
-                            cap_l: &cap_l,
-                            cap_m: &cap_m,
-                            cap_x: &cap_x,
-                            cap_y: &cap_y,
-                            h: &h,
-                        },
-                        &aux,
-                    ))
-                },
-                BatchSize::SmallInput,
-            );
-        }
-    }
+    total
 }
 
-pub mod enc_elg_proof {
-    use crate::cggmp21::sigma::{EncElgProof, EncElgPublicInputs, EncElgSecretInputs};
+pub fn measure_enc_elg(
+    rng: &mut impl CryptoRngCore,
+    key: &PreparedKey<Params>,
+    iters: u64,
+    measure: Measure,
+) -> Duration {
+    let sk = &key.sk;
+    let pk = sk.public_key();
+    let rp_params = &key.rp_params;
 
-    use super::*;
-    pub fn enc_elg_proof_prove<R: CryptoRngCore + Clone + 'static>(mut rng: R) -> impl FnMut(&mut Bencher<'_>) {
-        move |b: &mut Bencher<'_>| {
-            b.iter_batched(
-                || {
-                    let sk = SecretKeyPaillierWire::<Paillier>::random(&mut rng).into_precomputed();
-                    let pk = sk.public_key();
+    let mut total = Duration::ZERO;
+    for _ in 0..iters {
+        let aux: &[u8] = b"abcde";
 
-                    let setup = RPParams::random(&mut rng);
+        let x = SecretSigned::random_in_exponent_range(rng, Params::L_BOUND);
+        let rho = Randomizer::random(rng, pk);
+        let a = Secret::init_with(|| Scalar::random(rng));
+        let b = Secret::init_with(|| Scalar::random(rng));
 
-                    let aux: &[u8] = b"abcde";
+        let cap_c = Ciphertext::new_with_randomizer(pk, &x, &rho);
+        let cap_a = a.mul_by_generator();
+        let cap_b = b.mul_by_generator();
+        let cap_x = (&a * &b + secret_scalar_from_signed::<Params>(&x)).mul_by_generator();
 
-                    let x = SecretSigned::random_in_exponent_range(&mut rng, Params::L_BOUND);
-                    let rho = Randomizer::random(&mut rng, pk);
-                    let a = Secret::init_with(|| Scalar::random(&mut rng));
-                    let b = Secret::init_with(|| Scalar::random(&mut rng));
+        let secret = EncElgSecretInputs {
+            x: &x,
+            rho: &rho,
+            b: &b,
+        };
+        let public = EncElgPublicInputs {
+            pk0: pk,
+            cap_c: &cap_c,
+            cap_a: &cap_a,
+            cap_b: &cap_b,
+            cap_x: &cap_x,
+        };
 
-                    let cap_c = Ciphertext::new_with_randomizer(pk, &x, &rho);
-                    let cap_a = a.mul_by_generator();
-                    let cap_b = b.mul_by_generator();
-                    let cap_x = (&a * &b + secret_scalar_from_signed::<Params>(&x)).mul_by_generator();
-
-                    (
-                        rng.clone(),
-                        x,
-                        rho,
-                        b,
-                        pk.clone(),
-                        cap_c,
-                        cap_a,
-                        cap_b,
-                        cap_x,
-                        setup,
-                        aux,
-                    )
-                },
-                |(mut rng, x, rho, b, pk, cap_c, cap_a, cap_b, cap_x, setup, aux)| {
-                    black_box(EncElgProof::<Params>::new(
-                        &mut rng,
-                        EncElgSecretInputs {
-                            x: &x,
-                            rho: &rho,
-                            b: &b,
-                        },
-                        EncElgPublicInputs {
-                            pk0: &pk,
-                            cap_c: &cap_c,
-                            cap_a: &cap_a,
-                            cap_b: &cap_b,
-                            cap_x: &cap_x,
-                        },
-                        &setup,
-                        &aux,
-                    ))
-                },
-                BatchSize::SmallInput,
-            );
+        let start = Instant::now();
+        let proof = EncElgProof::<Params>::new(rng, secret, public, rp_params, &aux);
+        match measure {
+            Measure::Creation => total += start.elapsed(),
+            Measure::Verification => {
+                let start = Instant::now();
+                assert!(proof.verify(public, rp_params, &aux));
+                total += start.elapsed();
+            }
         }
     }
-    pub fn enc_elg_proof_verify<R: CryptoRngCore + Clone + 'static>(mut rng: R) -> impl FnMut(&mut Bencher<'_>) {
-        move |b: &mut Bencher<'_>| {
-            b.iter_batched(
-                || {
-                    let sk = SecretKeyPaillierWire::<Paillier>::random(&mut rng).into_precomputed();
-                    let pk = sk.public_key();
-
-                    let setup = RPParams::random(&mut rng);
-
-                    let aux: &[u8] = b"abcde";
-
-                    let x = SecretSigned::random_in_exponent_range(&mut rng, Params::L_BOUND);
-                    let rho = Randomizer::random(&mut rng, pk);
-                    let a = Secret::init_with(|| Scalar::random(&mut rng));
-                    let b = Secret::init_with(|| Scalar::random(&mut rng));
-
-                    let cap_c = Ciphertext::new_with_randomizer(pk, &x, &rho);
-                    let cap_a = a.mul_by_generator();
-                    let cap_b = b.mul_by_generator();
-                    let cap_x = (&a * &b + secret_scalar_from_signed::<Params>(&x)).mul_by_generator();
-
-                    let proof = EncElgProof::<Params>::new(
-                        &mut rng,
-                        EncElgSecretInputs {
-                            x: &x,
-                            rho: &rho,
-                            b: &b,
-                        },
-                        EncElgPublicInputs {
-                            pk0: pk,
-                            cap_c: &cap_c,
-                            cap_a: &cap_a,
-                            cap_b: &cap_b,
-                            cap_x: &cap_x,
-                        },
-                        &setup,
-                        &aux,
-                    );
-                    (proof, pk.clone(), cap_c, cap_a, cap_b, cap_x, setup, aux)
-                },
-                |(proof, pk, cap_c, cap_a, cap_b, cap_x, setup, aux)| {
-                    black_box(proof.verify(
-                        EncElgPublicInputs {
-                            pk0: &pk,
-                            cap_c: &cap_c,
-                            cap_a: &cap_a,
-                            cap_b: &cap_b,
-                            cap_x: &cap_x,
-                        },
-                        &setup,
-                        &aux,
-                    ))
-                },
-                BatchSize::SmallInput,
-            );
-        }
-    }
+    total
 }
 
-pub mod paillier_blum_modulus_proof {
-    use super::*;
-    pub fn paillier_blum_modulus_proof_prove<R: CryptoRngCore + Clone + 'static>(
-        mut rng: R,
-    ) -> impl FnMut(&mut Bencher<'_>) {
-        move |b: &mut Bencher<'_>| {
-            b.iter_batched(
-                || {
-                    let sk = SecretKeyPaillierWire::<Paillier>::random(&mut rng).into_precomputed();
-                    let aux: &[u8] = b"abcde";
+pub fn measure_fac(rng: &mut impl CryptoRngCore, key: &PreparedKey<Params>, iters: u64, measure: Measure) -> Duration {
+    let sk = &key.sk;
+    let pk = sk.public_key();
+    let rp_params = &key.rp_params;
 
-                    (rng.clone(), sk, aux)
-                },
-                |(mut rng, sk, aux)| black_box(ModProof::<Params>::new(&mut rng, &sk, &aux)),
-                BatchSize::SmallInput,
-            );
+    let mut total = Duration::ZERO;
+    for _ in 0..iters {
+        let aux: &[u8] = b"abcde";
+
+        let start = Instant::now();
+        let proof = FacProof::<Params>::new(rng, sk, rp_params, &aux);
+        match measure {
+            Measure::Creation => total += start.elapsed(),
+            Measure::Verification => {
+                let start = Instant::now();
+                assert!(proof.verify(pk, rp_params, &aux));
+                total += start.elapsed();
+            }
         }
     }
-
-    pub fn paillier_blum_modulus_proof_verify<R: CryptoRngCore + Clone + 'static>(
-        mut rng: R,
-    ) -> impl FnMut(&mut Bencher<'_>) {
-        move |b: &mut Bencher<'_>| {
-            b.iter_batched(
-                || {
-                    let sk = SecretKeyPaillierWire::<Paillier>::random(&mut rng).into_precomputed();
-                    let aux: &[u8] = b"abcde";
-                    let proof = ModProof::<Params>::new(&mut rng, &sk, &aux);
-                    (proof, sk.public_key().clone(), aux)
-                },
-                |(proof, pk, aux)| black_box(proof.verify(&pk, &aux)),
-                BatchSize::SmallInput,
-            );
-        }
-    }
+    total
 }
 
-pub mod prm_proof {
-    use super::*;
+pub fn measure_mod(rng: &mut impl CryptoRngCore, key: &PreparedKey<Params>, iters: u64, measure: Measure) -> Duration {
+    let sk = &key.sk;
+    let pk = sk.public_key();
 
-    pub fn prm_proof_prove<R: CryptoRngCore + Clone + 'static>(mut rng: R) -> impl FnMut(&mut Bencher<'_>) {
-        move |b: &mut Bencher<'_>| {
-            b.iter_batched(
-                || {
-                    let secret = RPSecret::random(&mut rng);
-                    let setup = RPParams::random_with_secret(&mut rng, &secret);
+    let mut total = Duration::ZERO;
+    for _ in 0..iters {
+        let aux: &[u8] = b"abcde";
 
-                    let aux: &[u8] = b"abcde";
-
-                    (rng.clone(), secret, setup, aux)
-                },
-                |(mut rng, secret, setup, aux)| black_box(PrmProof::<Params>::new(&mut rng, &secret, &setup, &aux)),
-                BatchSize::SmallInput,
-            );
+        let start = Instant::now();
+        let proof = ModProof::<Params>::new(rng, sk, &aux);
+        match measure {
+            Measure::Creation => total += start.elapsed(),
+            Measure::Verification => {
+                let start = Instant::now();
+                assert!(proof.verify(pk, &aux));
+                total += start.elapsed();
+            }
         }
     }
-
-    pub fn prm_proof_verify<R: CryptoRngCore + Clone + 'static>(mut rng: R) -> impl FnMut(&mut Bencher<'_>) {
-        move |b: &mut Bencher<'_>| {
-            b.iter_batched(
-                || {
-                    let secret = RPSecret::random(&mut rng);
-                    let setup = RPParams::random_with_secret(&mut rng, &secret);
-
-                    let aux: &[u8] = b"abcde";
-                    let proof = PrmProof::<Params>::new(&mut rng, &secret, &setup, &aux);
-                    (proof, setup, aux)
-                },
-                |(proof, setup, aux)| black_box(proof.verify(&setup, &aux)),
-                BatchSize::SmallInput,
-            );
-        }
-    }
+    total
 }
 
-pub mod sch_proof {
-    use super::*;
+pub fn measure_prm(rng: &mut impl CryptoRngCore, key: &PreparedKey<Params>, iters: u64, measure: Measure) -> Duration {
+    let rp_secret = &key.rp_secret;
+    let rp_params = &key.rp_params;
 
-    pub fn sch_proof_prove<R: CryptoRngCore + Clone + 'static>(mut rng: R) -> impl FnMut(&mut Bencher<'_>) {
-        move |b: &mut Bencher<'_>| {
-            b.iter_batched(
-                || {
-                    let secret = Secret::init_with(|| Scalar::<Params>::random(&mut rng));
-                    let public = secret.mul_by_generator();
-                    let aux: &[u8] = b"abcde";
+    let mut total = Duration::ZERO;
+    for _ in 0..iters {
+        let aux: &[u8] = b"abcde";
 
-                    let proof_secret = SchSecret::random(&mut rng);
-                    let commitment = SchCommitment::new(&proof_secret);
-                    (proof_secret, secret, commitment, public, aux)
-                },
-                |(proof_secret, secret, commitment, public, aux)| {
-                    black_box(SchProof::new(&proof_secret, &secret, &commitment, &public, &aux))
-                },
-                BatchSize::SmallInput,
-            );
+        let start = Instant::now();
+        let proof = PrmProof::<Params>::new(rng, rp_secret, rp_params, &aux);
+        match measure {
+            Measure::Creation => total += start.elapsed(),
+            Measure::Verification => {
+                let start = Instant::now();
+                assert!(proof.verify(rp_params, &aux));
+                total += start.elapsed();
+            }
         }
     }
+    total
+}
 
-    pub fn sch_proof_verify<R: CryptoRngCore + Clone + 'static>(mut rng: R) -> impl FnMut(&mut Bencher<'_>) {
-        move |b: &mut Bencher<'_>| {
-            b.iter_batched(
-                || {
-                    let secret = Secret::init_with(|| Scalar::<Params>::random(&mut rng));
-                    let public = secret.mul_by_generator();
-                    let aux: &[u8] = b"abcde";
+pub fn measure_sch(rng: &mut impl CryptoRngCore, iters: u64, measure: Measure) -> Duration {
+    let mut total = Duration::ZERO;
+    for _ in 0..iters {
+        let aux: &[u8] = b"abcde";
 
-                    let proof_secret = SchSecret::random(&mut rng);
-                    let commitment = SchCommitment::new(&proof_secret);
-                    let proof = SchProof::new(&proof_secret, &secret, &commitment, &public, &aux);
-                    (proof, commitment, public, aux)
-                },
-                |(proof, commitment, public, aux)| black_box(proof.verify(&commitment, &public, &aux)),
-                BatchSize::SmallInput,
-            );
+        let secret = Secret::init_with(|| Scalar::<Params>::random(rng));
+        let public = secret.mul_by_generator();
+        let proof_secret = SchSecret::random(rng);
+        let commitment = SchCommitment::new(&proof_secret);
+
+        let start = Instant::now();
+        let proof = SchProof::new(&proof_secret, &secret, &commitment, &public, &aux);
+        match measure {
+            Measure::Creation => total += start.elapsed(),
+            Measure::Verification => {
+                let start = Instant::now();
+                assert!(proof.verify(&commitment, &public, &aux));
+                total += start.elapsed();
+            }
         }
     }
+    total
 }


### PR DESCRIPTION
Flatten out the code and reduce repetitions in ZK proof benches, and also keep the `criterion` dependency in `dev-dependencies` only. Using the `iter_custom()` approach for now since `iter_batched()` requires either returning closures, or introducing additional structures holding prepared parameters for each ZK proof which seems more complicated. 

Note: I pre-calculate two Paillier keys and two RP params and save them in a `LazyLock` (since that's generally the slowest part of the setup). This means that tests lose a bit of variation, but I don't expect much variation on the Paillier key, since that would mean timing attacks are possible.

It would be nice to somehow merge the code in these benchmarks with the test code in ZK proof modules, but that is left for a follow-up PR. 