### PR TITLE
TestParams use TinyCurve32

### DIFF
--- a/synedrion/src/cggmp21/params.rs
+++ b/synedrion/src/cggmp21/params.rs
@@ -5,6 +5,7 @@ use core::{fmt::Debug, ops::Add};
 // So as long as that is the case, `k256` `Uint` is separate
 // from the one used throughout the crate.
 use crypto_bigint::{BitOps, NonZero, Uint, U1024, U2048, U4096, U512, U8192};
+use crypto_bigint::{U128, U256};
 use digest::generic_array::{ArrayLength, GenericArray};
 use ecdsa::hazmat::{DigestPrimitive, SignPrimitive, VerifyPrimitive};
 use primeorder::elliptic_curve::{
@@ -15,12 +16,12 @@ use primeorder::elliptic_curve::{
 };
 use serde::{Deserialize, Serialize};
 
-use tiny_curve::TinyCurve64;
+use tiny_curve::TinyCurve32;
 
 use crate::{
     paillier::PaillierParams,
     tools::hashing::HashableType,
-    uint::{U1024Mod, U2048Mod, U4096Mod, U512Mod},
+    uint::{U1024Mod, U128Mod, U2048Mod, U256Mod, U4096Mod, U512Mod},
 };
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -85,14 +86,14 @@ impl PaillierParams for PaillierTest {
     are much smaller than 2*PRIME_BITS.
     */
 
-    const PRIME_BITS: u32 = 397;
-    type HalfUint = U512;
-    type HalfUintMod = U512Mod;
-    type Uint = U1024;
-    type UintMod = U1024Mod;
-    type WideUint = U2048;
-    type WideUintMod = U2048Mod;
-    type ExtraWideUint = U4096;
+    const PRIME_BITS: u32 = 128;
+    type HalfUint = U128;
+    type HalfUintMod = U128Mod;
+    type Uint = U256;
+    type UintMod = U256Mod;
+    type WideUint = U512;
+    type WideUintMod = U512Mod;
+    type ExtraWideUint = U1024;
 }
 
 /// Paillier parameters corresponding to 112 bits of security.
@@ -192,15 +193,17 @@ pub struct TestParams;
 // - Range checks will fail with the probability $q / 2^\eps$, so $\eps$ should be large enough.
 // - P^{fac} assumes $N ~ 2^{4 \ell + 2 \eps}$
 impl SchemeParams for TestParams {
-    type Curve = TinyCurve64;
+    type Curve = TinyCurve32;
+    // TODO: ReprUint is typenum::U192 because of RustCrypto stack internals, hence the U384 here,
+    // but once that is solved, this can be a U128 (or even smaller).
     type WideCurveUint = bigintv05::U384;
     // TODO: 8*24 = 192, this is to work around an issue with the ModulusSize-trait. This should be ideally be 8 bytes long.
     type HashOutput = [u8; 24];
     const SECURITY_BITS: usize = 16;
-    const SECURITY_PARAMETER: usize = 10;
-    const L_BOUND: u32 = 256;
-    const LP_BOUND: u32 = 256;
-    const EPS_BOUND: u32 = 320;
+    const SECURITY_PARAMETER: usize = 32;
+    const L_BOUND: u32 = 32;
+    const EPS_BOUND: u32 = 64;
+    const LP_BOUND: u32 = 160;
     type Paillier = PaillierTest;
     const CURVE_ORDER: NonZero<<Self::Paillier as PaillierParams>::Uint> =
         convert_uint(upcast_uint(Self::Curve::ORDER))
@@ -223,8 +226,8 @@ impl SchemeParams for ProductionParams112 {
     const SECURITY_BITS: usize = 112;
     const SECURITY_PARAMETER: usize = 256;
     const L_BOUND: u32 = 256;
-    const LP_BOUND: u32 = Self::L_BOUND * 5;
     const EPS_BOUND: u32 = Self::L_BOUND * 2;
+    const LP_BOUND: u32 = Self::L_BOUND * 5;
     type Paillier = PaillierProduction112;
     const CURVE_ORDER: NonZero<<Self::Paillier as PaillierParams>::Uint> =
         convert_uint(upcast_uint(Self::Curve::ORDER))
@@ -240,7 +243,7 @@ impl SchemeParams for ProductionParams112 {
 mod tests {
     use super::{
         bigintv05::{U256, U64},
-        upcast_uint, ProductionParams112, SchemeParams,
+        upcast_uint, ProductionParams112, SchemeParams, TestParams,
     };
 
     #[test]
@@ -269,7 +272,6 @@ mod tests {
     #[test]
     fn parameter_consistency() {
         assert!(ProductionParams112::are_self_consistent());
-        // TODO: These are not consistent right now.
-        // assert!(TestParams::are_self_consistent());
+        assert!(TestParams::are_self_consistent());
     }
 }

--- a/synedrion/src/curve/arithmetic.rs
+++ b/synedrion/src/curve/arithmetic.rs
@@ -502,25 +502,27 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::TestParams;
+    use crate::{SchemeParams, TestParams};
 
     use super::Scalar;
     use rand::SeedableRng;
     use rand_chacha::ChaChaRng;
-    #[test]
+
+    #[test_log::test]
     fn to_and_from_bytes() {
         let mut rng = ChaChaRng::from_seed([7u8; 32]);
         let s = Scalar::<TestParams>::random(&mut rng);
 
         // Round trip works
-        let bytes = s.to_be_bytes();
-        let s_from_bytes = Scalar::try_from_be_bytes(bytes.as_ref()).expect("bytes are valid");
-        assert_eq!(s, s_from_bytes);
+        let be_bytes = s.to_be_bytes();
+        let s_from_be_bytes = Scalar::try_from_be_bytes(be_bytes.as_ref()).expect("bytes are valid");
+        assert_eq!(s, s_from_be_bytes);
 
+        let chunk_size = TestParams::SECURITY_PARAMETER / 8;
         // …but building a `Scalar` from LE bytes does not.
-        let mut bytes = bytes;
+        let mut bytes = be_bytes;
         let le_bytes = bytes
-            .chunks_exact_mut(8)
+            .chunks_exact_mut(chunk_size)
             .flat_map(|word_bytes| {
                 word_bytes.reverse();
                 word_bytes.to_vec()

--- a/synedrion/src/curve/bip32.rs
+++ b/synedrion/src/curve/bip32.rs
@@ -27,8 +27,10 @@ mod sealed {
     use super::*;
     pub trait Sealed {}
     impl Sealed for VerifyingKey<tiny_curve::TinyCurve64> {}
+    impl Sealed for VerifyingKey<tiny_curve::TinyCurve32> {}
     impl Sealed for VerifyingKey<k256::Secp256k1> {}
     impl Sealed for SigningKey<tiny_curve::TinyCurve64> {}
+    impl Sealed for SigningKey<tiny_curve::TinyCurve32> {}
     impl Sealed for SigningKey<k256::Secp256k1> {}
 }
 

--- a/synedrion/src/paillier/encryption.rs
+++ b/synedrion/src/paillier/encryption.rs
@@ -194,7 +194,7 @@ impl<P: PaillierParams> Ciphertext<P> {
 
     /// Decrypts this ciphertext assuming that the plaintext is in range `[-N/2, N/2]`.
     pub fn decrypt(&self, sk: &SecretKeyPaillier<P>) -> SecretSigned<P::Uint> {
-        assert_eq!(sk.public_key(), &self.pk);
+        assert_eq!(sk.public_key(), &self.pk, "Public key mismatch");
 
         let pk = sk.public_key();
         let totient_wide = sk.totient_wide_unsigned();

--- a/synedrion/src/uint.rs
+++ b/synedrion/src/uint.rs
@@ -7,5 +7,6 @@ pub(crate) use public_signed::PublicSigned;
 pub(crate) use secret_signed::SecretSigned;
 pub(crate) use secret_unsigned::SecretUnsigned;
 pub(crate) use traits::{
-    Exponentiable, FromXofReader, HasWide, IsInvertible, ToMontgomery, U1024Mod, U2048Mod, U4096Mod, U512Mod,
+    Exponentiable, FromXofReader, HasWide, IsInvertible, ToMontgomery, U1024Mod, U128Mod, U2048Mod, U256Mod, U4096Mod,
+    U512Mod,
 };

--- a/synedrion/src/uint/traits.rs
+++ b/synedrion/src/uint/traits.rs
@@ -3,7 +3,7 @@ use crypto_bigint::{
     nlimbs,
     subtle::{ConditionallySelectable, CtOption},
     Bounded, ConcatMixed, Encoding, Gcd, Integer, Invert, Monty, PowBoundedExp, RandomMod, SplitMixed, WideningMul,
-    Zero, U1024, U2048, U4096, U512, U8192,
+    Zero, U1024, U128, U2048, U256, U4096, U512, U8192,
 };
 use digest::XofReader;
 use zeroize::Zeroize;
@@ -160,6 +160,14 @@ pub trait HasWide:
     }
 }
 
+impl HasWide for U128 {
+    type Wide = U256;
+}
+
+impl HasWide for U256 {
+    type Wide = U512;
+}
+
 impl HasWide for U512 {
     type Wide = U1024;
 }
@@ -176,6 +184,8 @@ impl HasWide for U4096 {
     type Wide = U8192;
 }
 
+pub type U128Mod = MontyForm<{ nlimbs!(128) }>;
+pub type U256Mod = MontyForm<{ nlimbs!(256) }>;
 pub type U512Mod = MontyForm<{ nlimbs!(512) }>;
 pub type U1024Mod = MontyForm<{ nlimbs!(1024) }>;
 pub type U2048Mod = MontyForm<{ nlimbs!(2048) }>;


### PR DESCRIPTION
Adjust test params to be as tight as possible:

- use TinyCurve32
- `L_BOUND` is 32
- `EPS_BOUND` is 64 (2*32)
- `LP_BOUND` is 160 (5*32)
- `PRIME_BITS` is 128 (so Uint is U256 etc)

The speedup when running tests is dramatic.

Master:

```
hyperfine -w 2 "cargo t --release"
 Benchmark 1: cargo t --release
   Time (mean ± σ):      7.790 s ±  0.122 s    [User: 43.535 s, System: 0.446 s]
   Range (min … max):    7.632 s …  8.011 s    10 runs
```

This PR:

```
hyperfine -w 2 "cargo t --release"
Benchmark 1: cargo t --release
  Time (mean ± σ):     942.8 ms ±  18.9 ms    [User: 2882.5 ms, System: 166.0 ms]
  Range (min … max):   919.8 ms … 971.8 ms    10 runs
```

**NOTE**: There is one potentially problematic change in this PR, to be reviewed carefully. The `checked_add` impl for `SecretSigned<T>` used to pick the biggest bound from the two operands and *then add 1* to it. This leads to a few test failures with the params as configured in this PR. The underlying reason is that now the curve order is so much closer to uint sizes that we run into corner cases where e.g. [Paillier decryption yields a SecretSigned with a bound of 255](https://github.com/entropyxyz/synedrion/blob/dp-use-TinyCurve32-in-tests/synedrion/src/paillier/encryption.rs#L224) (which comes from `MODULUS_BITS`), causing addition to always "overflow" (actually: fail the bounds check that `bound + 1 < T::BITS`).

~~We have discussed this bound increment last summer and I think we decided to keep the increment as the conservative choice, but I actually think it's wrong. Maybe now is the right time to make the final call on this?~~

I'm wrong, the last bit must be preserved. However, the simple bounds check breaks down in this corner case and we need to do something smarter for this to work. How about checking the last bit before and after the sum, and if the bit flipped we overflowed?
