### PR TITLE
Remove HashOutput from SchemeParams and delete FofHasher

### DIFF
--- a/synedrion/src/cggmp21/aux_gen.rs
+++ b/synedrion/src/cggmp21/aux_gen.rs
@@ -18,6 +18,7 @@ use manul::protocol::{
 };
 use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
+use serde_encoded_bytes::{Hex, SliceLike};
 
 use super::{
     entities::{AuxInfo, PublicAuxInfo, PublicAuxInfos, SecretAuxInfo},
@@ -431,6 +432,7 @@ pub(super) struct Round1<P: SchemeParams, Id: PartyId> {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(super) struct Round1EchoBroadcast {
+    #[serde(with = "SliceLike::<Hex>")]
     pub(super) cap_v: Box<[u8]>,
 }
 

--- a/synedrion/src/cggmp21/aux_gen.rs
+++ b/synedrion/src/cggmp21/aux_gen.rs
@@ -170,11 +170,12 @@ fn make_sid<P: SchemeParams, Id: PartyId>(
     shared_randomness: &[u8],
     associated_data: &AuxGenAssociatedData<Id>,
 ) -> Box<[u8]> {
+    let len = <P::Curve as Curve>::FieldBytesSize::USIZE * 2;
     XofHasher::new_with_dst(b"AuxGen SID")
         .chain_type::<P::Curve>()
         .chain(&shared_randomness)
         .chain(&associated_data.ids)
-        .finalize_boxed(<P::Curve as Curve>::FieldBytesSize::USIZE)
+        .finalize_boxed(len)
 }
 
 impl<P: SchemeParams, Id: PartyId> ProtocolError<Id> for AuxGenError<P, Id> {
@@ -317,6 +318,7 @@ pub(super) struct PublicData<P: SchemeParams> {
 
 impl<P: SchemeParams> PublicData<P> {
     pub(super) fn hash<Id: PartyId>(&self, sid: &[u8], id: &Id) -> Box<[u8]> {
+        let len = <P::Curve as Curve>::FieldBytesSize::USIZE * 2;
         XofHasher::new_with_dst(b"KeyInit")
             .chain(&sid)
             .chain(id)
@@ -325,7 +327,7 @@ impl<P: SchemeParams> PublicData<P> {
             .chain(&self.psi)
             .chain(&self.rid)
             .chain(&self.u)
-            .finalize_boxed(<P::Curve as Curve>::FieldBytesSize::USIZE)
+            .finalize_boxed(len)
     }
 }
 

--- a/synedrion/src/cggmp21/aux_gen_tests.rs
+++ b/synedrion/src/cggmp21/aux_gen_tests.rs
@@ -162,7 +162,7 @@ fn r2_hash_mismatch() {
                 // Send a wrong hash in the Round 1 message
                 let message = Round1EchoBroadcast {
                     cap_v: XofHasher::new_with_dst(b"bad hash")
-                        .finalize_boxed(<<P as SchemeParams>::Curve as Curve>::FieldBytesSize::USIZE),
+                        .finalize_boxed(<<P as SchemeParams>::Curve as Curve>::FieldBytesSize::USIZE * 2),
                 };
                 let echo_broadcast = EchoBroadcast::new(serializer, message)?;
                 return Ok(echo_broadcast);

--- a/synedrion/src/cggmp21/aux_gen_tests.rs
+++ b/synedrion/src/cggmp21/aux_gen_tests.rs
@@ -1,6 +1,5 @@
 use alloc::collections::BTreeSet;
 
-use digest::typenum::Unsigned;
 use manul::{
     combinators::misbehave::Misbehaving,
     dev::{BinaryFormat, TestSessionParams, TestSigner, TestVerifier},
@@ -10,7 +9,6 @@ use manul::{
     },
     signature::Keypair,
 };
-use primeorder::elliptic_curve::Curve;
 use rand_chacha::ChaCha8Rng;
 use rand_core::{CryptoRngCore, OsRng, SeedableRng};
 
@@ -161,8 +159,7 @@ fn r2_hash_mismatch() {
             if round.id() == 1 {
                 // Send a wrong hash in the Round 1 message
                 let message = Round1EchoBroadcast {
-                    cap_v: XofHasher::new_with_dst(b"bad hash")
-                        .finalize_boxed(<<P as SchemeParams>::Curve as Curve>::FieldBytesSize::USIZE * 2),
+                    cap_v: XofHasher::new_with_dst(b"bad hash").finalize_boxed(P::SECURITY_BITS),
                 };
                 let echo_broadcast = EchoBroadcast::new(serializer, message)?;
                 return Ok(echo_broadcast);

--- a/synedrion/src/cggmp21/interactive_signing.rs
+++ b/synedrion/src/cggmp21/interactive_signing.rs
@@ -10,7 +10,7 @@ use core::{
     fmt::{self, Debug, Display},
     marker::PhantomData,
 };
-use digest::typenum::Unsigned;
+
 use manul::protocol::{
     Artifact, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, EntryPoint, FinalizeOutcome, LocalError,
     MessageValidationError, NormalBroadcast, PartyId, Payload, Protocol, ProtocolError, ProtocolMessage,
@@ -240,13 +240,12 @@ fn make_epid<P: SchemeParams, Id: PartyId>(
     shared_randomness: &[u8],
     associated_data: &InteractiveSigningAssociatedData<P, Id>,
 ) -> Box<[u8]> {
-    let len = <P::Curve as Curve>::FieldBytesSize::USIZE * 2;
     XofHasher::new_with_dst(b"InteractiveSigning EPID")
         .chain_type::<P::Curve>()
         .chain(&shared_randomness)
         .chain(&associated_data.shares)
         .chain(&associated_data.aux)
-        .finalize_boxed(len)
+        .finalize_boxed(P::SECURITY_BITS)
 }
 
 impl<P: SchemeParams, Id: PartyId> ProtocolError<Id> for InteractiveSigningError<P, Id> {

--- a/synedrion/src/cggmp21/interactive_signing.rs
+++ b/synedrion/src/cggmp21/interactive_signing.rs
@@ -240,12 +240,13 @@ fn make_epid<P: SchemeParams, Id: PartyId>(
     shared_randomness: &[u8],
     associated_data: &InteractiveSigningAssociatedData<P, Id>,
 ) -> Box<[u8]> {
+    let len = <P::Curve as Curve>::FieldBytesSize::USIZE * 2;
     XofHasher::new_with_dst(b"InteractiveSigning EPID")
         .chain_type::<P::Curve>()
         .chain(&shared_randomness)
         .chain(&associated_data.shares)
         .chain(&associated_data.aux)
-        .finalize_boxed(<P::Curve as Curve>::FieldBytesSize::USIZE)
+        .finalize_boxed(len)
 }
 
 impl<P: SchemeParams, Id: PartyId> ProtocolError<Id> for InteractiveSigningError<P, Id> {

--- a/synedrion/src/cggmp21/key_init.rs
+++ b/synedrion/src/cggmp21/key_init.rs
@@ -17,6 +17,7 @@ use manul::protocol::{
 };
 use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
+use serde_encoded_bytes::{Hex, SliceLike};
 
 use super::{
     entities::KeyShare,
@@ -317,6 +318,7 @@ struct Round1<P: SchemeParams, Id> {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct Round1EchoBroadcast {
+    #[serde(with = "SliceLike::<Hex>")]
     cap_v: Box<[u8]>,
 }
 

--- a/synedrion/src/cggmp21/key_init.rs
+++ b/synedrion/src/cggmp21/key_init.rs
@@ -8,8 +8,6 @@ use core::{
     fmt::{self, Debug, Display},
     marker::PhantomData,
 };
-use digest::typenum::Unsigned;
-use primeorder::elliptic_curve::Curve;
 
 use manul::protocol::{
     Artifact, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, EntryPoint, FinalizeOutcome, LocalError,
@@ -124,12 +122,11 @@ fn make_sid<P: SchemeParams, Id: PartyId>(
     shared_randomness: &[u8],
     associated_data: &KeyInitAssociatedData<Id>,
 ) -> Box<[u8]> {
-    let len = <P::Curve as Curve>::FieldBytesSize::USIZE * 2;
     XofHasher::new_with_dst(b"KeyInit SID")
         .chain_type::<P::Curve>()
         .chain(&shared_randomness)
         .chain(&associated_data.ids)
-        .finalize_boxed(len)
+        .finalize_boxed(P::SECURITY_BITS)
 }
 
 impl<P: SchemeParams, Id: PartyId> ProtocolError<Id> for KeyInitError<P> {
@@ -223,7 +220,6 @@ where
     P: SchemeParams,
 {
     pub(super) fn hash<Id: Serialize>(&self, sid: &[u8], id: &Id) -> Box<[u8]> {
-        let len = <P::Curve as Curve>::FieldBytesSize::USIZE * 2;
         XofHasher::new_with_dst(b"KeyInit")
             .chain(&sid)
             .chain(id)
@@ -231,7 +227,7 @@ where
             .chain(&self.cap_a)
             .chain(&self.rho)
             .chain(&self.u)
-            .finalize_boxed(len)
+            .finalize_boxed(P::SECURITY_BITS)
     }
 }
 

--- a/synedrion/src/cggmp21/key_init.rs
+++ b/synedrion/src/cggmp21/key_init.rs
@@ -124,11 +124,12 @@ fn make_sid<P: SchemeParams, Id: PartyId>(
     shared_randomness: &[u8],
     associated_data: &KeyInitAssociatedData<Id>,
 ) -> Box<[u8]> {
+    let len = <P::Curve as Curve>::FieldBytesSize::USIZE * 2;
     XofHasher::new_with_dst(b"KeyInit SID")
         .chain_type::<P::Curve>()
         .chain(&shared_randomness)
         .chain(&associated_data.ids)
-        .finalize_boxed(<P::Curve as Curve>::FieldBytesSize::USIZE)
+        .finalize_boxed(len)
 }
 
 impl<P: SchemeParams, Id: PartyId> ProtocolError<Id> for KeyInitError<P> {
@@ -219,10 +220,10 @@ pub(super) struct PublicData<P: SchemeParams> {
 
 impl<P> PublicData<P>
 where
-    // TODO(dp): don't need this
     P: SchemeParams,
 {
     pub(super) fn hash<Id: Serialize>(&self, sid: &[u8], id: &Id) -> Box<[u8]> {
+        let len = <P::Curve as Curve>::FieldBytesSize::USIZE * 2;
         XofHasher::new_with_dst(b"KeyInit")
             .chain(&sid)
             .chain(id)
@@ -230,7 +231,7 @@ where
             .chain(&self.cap_a)
             .chain(&self.rho)
             .chain(&self.u)
-            .finalize_boxed(<P::Curve as Curve>::FieldBytesSize::USIZE)
+            .finalize_boxed(len)
     }
 }
 

--- a/synedrion/src/cggmp21/key_refresh.rs
+++ b/synedrion/src/cggmp21/key_refresh.rs
@@ -211,11 +211,12 @@ fn make_sid<P: SchemeParams, Id: PartyId>(
     shared_randomness: &[u8],
     associated_data: &KeyRefreshAssociatedData<Id>,
 ) -> Box<[u8]> {
+    let len = <P::Curve as Curve>::FieldBytesSize::USIZE * 2;
     XofHasher::new_with_dst(b"KeyRefresh SID")
         .chain_type::<P::Curve>()
         .chain(&shared_randomness)
         .chain(&associated_data.ids)
-        .finalize_boxed(<P::Curve as Curve>::FieldBytesSize::USIZE)
+        .finalize_boxed(len)
 }
 
 impl<P: SchemeParams, Id: PartyId> ProtocolError<Id> for KeyRefreshError<P, Id> {
@@ -468,6 +469,7 @@ pub(super) struct PublicData<P: SchemeParams, Id> {
 
 impl<P: SchemeParams, Id: PartyId> PublicData<P, Id> {
     pub(super) fn hash(&self, sid: &[u8], id: &Id) -> Box<[u8]> {
+        let len = <P::Curve as Curve>::FieldBytesSize::USIZE * 2;
         XofHasher::new_with_dst(b"KeyInit")
             .chain(&sid)
             .chain(id)
@@ -479,7 +481,7 @@ impl<P: SchemeParams, Id: PartyId> PublicData<P, Id> {
             .chain(&self.psi)
             .chain(&self.rid)
             .chain(&self.u)
-            .finalize_boxed(<P::Curve as Curve>::FieldBytesSize::USIZE)
+            .finalize_boxed(len)
     }
 }
 

--- a/synedrion/src/cggmp21/key_refresh.rs
+++ b/synedrion/src/cggmp21/key_refresh.rs
@@ -8,8 +8,6 @@ use core::{
     fmt::{self, Debug, Display},
     marker::PhantomData,
 };
-use digest::typenum::Unsigned;
-use primeorder::elliptic_curve::Curve;
 
 use crypto_bigint::BitOps;
 use manul::protocol::{
@@ -211,12 +209,11 @@ fn make_sid<P: SchemeParams, Id: PartyId>(
     shared_randomness: &[u8],
     associated_data: &KeyRefreshAssociatedData<Id>,
 ) -> Box<[u8]> {
-    let len = <P::Curve as Curve>::FieldBytesSize::USIZE * 2;
     XofHasher::new_with_dst(b"KeyRefresh SID")
         .chain_type::<P::Curve>()
         .chain(&shared_randomness)
         .chain(&associated_data.ids)
-        .finalize_boxed(len)
+        .finalize_boxed(P::SECURITY_BITS)
 }
 
 impl<P: SchemeParams, Id: PartyId> ProtocolError<Id> for KeyRefreshError<P, Id> {
@@ -469,7 +466,6 @@ pub(super) struct PublicData<P: SchemeParams, Id> {
 
 impl<P: SchemeParams, Id: PartyId> PublicData<P, Id> {
     pub(super) fn hash(&self, sid: &[u8], id: &Id) -> Box<[u8]> {
-        let len = <P::Curve as Curve>::FieldBytesSize::USIZE * 2;
         XofHasher::new_with_dst(b"KeyInit")
             .chain(&sid)
             .chain(id)
@@ -481,7 +477,7 @@ impl<P: SchemeParams, Id: PartyId> PublicData<P, Id> {
             .chain(&self.psi)
             .chain(&self.rid)
             .chain(&self.u)
-            .finalize_boxed(len)
+            .finalize_boxed(P::SECURITY_BITS)
     }
 }
 

--- a/synedrion/src/cggmp21/key_refresh.rs
+++ b/synedrion/src/cggmp21/key_refresh.rs
@@ -18,6 +18,7 @@ use manul::protocol::{
 };
 use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
+use serde_encoded_bytes::{Hex, SliceLike};
 
 use super::{
     entities::{AuxInfo, KeyShareChange, PublicAuxInfo, PublicAuxInfos, SecretAuxInfo},
@@ -619,6 +620,7 @@ pub(super) struct Round1<P: SchemeParams, Id: PartyId> {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(super) struct Round1EchoBroadcast {
+    #[serde(with = "SliceLike::<Hex>")]
     pub(super) cap_v: Box<[u8]>,
 }
 

--- a/synedrion/src/cggmp21/key_refresh.rs
+++ b/synedrion/src/cggmp21/key_refresh.rs
@@ -2,11 +2,14 @@
 //! This protocol generates an update to the secret key shares and new auxiliary parameters
 //! for ZK proofs (e.g. Paillier keys).
 
+use alloc::boxed::Box;
 use alloc::collections::{BTreeMap, BTreeSet};
 use core::{
     fmt::{self, Debug, Display},
     marker::PhantomData,
 };
+use digest::typenum::Unsigned;
+use primeorder::elliptic_curve::Curve;
 
 use crypto_bigint::BitOps;
 use manul::protocol::{
@@ -31,7 +34,7 @@ use crate::{
     },
     tools::{
         bitvec::BitVec,
-        hashing::{Chain, FofHasher, XofHasher},
+        hashing::{Chain, XofHasher},
         protocol_shortcuts::{verify_that, DeserializeAll, DowncastMap, GetRound, MapValues, SafeGet, Without},
         Secret,
     },
@@ -69,7 +72,7 @@ where
         message: &EchoBroadcast,
     ) -> Result<(), MessageValidationError> {
         match round_id {
-            r if r == &1 => message.verify_is_not::<Round1EchoBroadcast<P>>(deserializer),
+            r if r == &1 => message.verify_is_not::<Round1EchoBroadcast>(deserializer),
             r if r == &2 => message.verify_is_not::<Round2EchoBroadcast<P, Id>>(deserializer),
             r if r == &3 => message.verify_is_not::<Round3EchoBroadcast<P, Id>>(deserializer),
             _ => Err(MessageValidationError::InvalidEvidence("Invalid round number".into())),
@@ -207,12 +210,12 @@ pub struct KeyRefreshAssociatedData<Id> {
 fn make_sid<P: SchemeParams, Id: PartyId>(
     shared_randomness: &[u8],
     associated_data: &KeyRefreshAssociatedData<Id>,
-) -> P::HashOutput {
-    FofHasher::<P>::new_with_dst(b"KeyRefresh SID")
+) -> Box<[u8]> {
+    XofHasher::new_with_dst(b"KeyRefresh SID")
         .chain_type::<P::Curve>()
         .chain(&shared_randomness)
         .chain(&associated_data.ids)
-        .finalize()
+        .finalize_boxed(<P::Curve as Curve>::FieldBytesSize::USIZE)
 }
 
 impl<P: SchemeParams, Id: PartyId> ProtocolError<Id> for KeyRefreshError<P, Id> {
@@ -279,7 +282,7 @@ impl<P: SchemeParams, Id: PartyId> ProtocolError<Id> for KeyRefreshError<P, Id> 
                 let r1_eb = previous_messages
                     .get_round(1)?
                     .echo_broadcast
-                    .deserialize::<Round1EchoBroadcast<P>>(deserializer)?;
+                    .deserialize::<Round1EchoBroadcast>(deserializer)?;
                 let r2_nb = message
                     .normal_broadcast
                     .deserialize::<Round2NormalBroadcast<P, Id>>(deserializer)?;
@@ -464,9 +467,9 @@ pub(super) struct PublicData<P: SchemeParams, Id> {
 }
 
 impl<P: SchemeParams, Id: PartyId> PublicData<P, Id> {
-    pub(super) fn hash(&self, sid: &P::HashOutput, id: &Id) -> P::HashOutput {
-        FofHasher::<P>::new_with_dst(b"KeyInit")
-            .chain(sid)
+    pub(super) fn hash(&self, sid: &[u8], id: &Id) -> Box<[u8]> {
+        XofHasher::new_with_dst(b"KeyInit")
+            .chain(&sid)
             .chain(id)
             .chain(&self.cap_xs)
             .chain(&self.cap_ys)
@@ -476,7 +479,7 @@ impl<P: SchemeParams, Id: PartyId> PublicData<P, Id> {
             .chain(&self.psi)
             .chain(&self.rid)
             .chain(&self.u)
-            .finalize()
+            .finalize_boxed(<P::Curve as Curve>::FieldBytesSize::USIZE)
     }
 }
 
@@ -607,7 +610,7 @@ pub(super) struct Context<P: SchemeParams, Id> {
     pub(super) my_id: Id,
     other_ids: BTreeSet<Id>,
     all_ids: BTreeSet<Id>,
-    pub(super) sid: P::HashOutput,
+    pub(super) sid: Box<[u8]>,
 }
 
 #[derive(Debug)]
@@ -617,12 +620,12 @@ pub(super) struct Round1<P: SchemeParams, Id: PartyId> {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(super) struct Round1EchoBroadcast<P: SchemeParams> {
-    pub(super) cap_v: P::HashOutput,
+pub(super) struct Round1EchoBroadcast {
+    pub(super) cap_v: Box<[u8]>,
 }
 
-struct Round1Payload<P: SchemeParams> {
-    cap_v: P::HashOutput,
+struct Round1Payload {
+    cap_v: Box<[u8]>,
 }
 
 impl<P: SchemeParams, Id: PartyId> Round<Id> for Round1<P, Id> {
@@ -649,7 +652,7 @@ impl<P: SchemeParams, Id: PartyId> Round<Id> for Round1<P, Id> {
         _rng: &mut impl CryptoRngCore,
         serializer: &Serializer,
     ) -> Result<EchoBroadcast, LocalError> {
-        let message = Round1EchoBroadcast::<P> {
+        let message = Round1EchoBroadcast {
             cap_v: self.public_data.hash(&self.context.sid, &self.context.my_id),
         };
         EchoBroadcast::new(serializer, message)
@@ -665,8 +668,8 @@ impl<P: SchemeParams, Id: PartyId> Round<Id> for Round1<P, Id> {
         message.direct_message.assert_is_none()?;
         let echo_broadcast = message
             .echo_broadcast
-            .deserialize::<Round1EchoBroadcast<P>>(deserializer)?;
-        let payload = Round1Payload::<P> {
+            .deserialize::<Round1EchoBroadcast>(deserializer)?;
+        let payload = Round1Payload {
             cap_v: echo_broadcast.cap_v,
         };
         Ok(Payload::new(payload))
@@ -678,7 +681,7 @@ impl<P: SchemeParams, Id: PartyId> Round<Id> for Round1<P, Id> {
         payloads: BTreeMap<Id, Payload>,
         _artifacts: BTreeMap<Id, Artifact>,
     ) -> Result<FinalizeOutcome<Id, Self::Protocol>, LocalError> {
-        let payloads = payloads.downcast_all::<Round1Payload<P>>()?;
+        let payloads = payloads.downcast_all::<Round1Payload>()?;
         let cap_vs = payloads.map_values(|payload| payload.cap_v);
         let next_round = Round2 {
             context: self.context,
@@ -693,7 +696,7 @@ impl<P: SchemeParams, Id: PartyId> Round<Id> for Round1<P, Id> {
 struct Round2<P: SchemeParams, Id: PartyId> {
     context: Context<P, Id>,
     public_data: PublicData<P, Id>,
-    cap_vs: BTreeMap<Id, P::HashOutput>,
+    cap_vs: BTreeMap<Id, Box<[u8]>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/synedrion/src/cggmp21/key_refresh_tests.rs
+++ b/synedrion/src/cggmp21/key_refresh_tests.rs
@@ -164,7 +164,7 @@ fn r2_hash_mismatch() {
                 // Send a wrong hash in the Round 1 message
                 let message = Round1EchoBroadcast {
                     cap_v: XofHasher::new_with_dst(b"bad hash")
-                        .finalize_boxed(<<P as SchemeParams>::Curve as Curve>::FieldBytesSize::USIZE),
+                        .finalize_boxed(<<P as SchemeParams>::Curve as Curve>::FieldBytesSize::USIZE * 2),
                 };
                 let echo_broadcast = EchoBroadcast::new(serializer, message)?;
                 return Ok(echo_broadcast);

--- a/synedrion/src/cggmp21/key_refresh_tests.rs
+++ b/synedrion/src/cggmp21/key_refresh_tests.rs
@@ -1,6 +1,4 @@
 use alloc::collections::BTreeSet;
-use digest::typenum::Unsigned;
-use primeorder::elliptic_curve::Curve;
 
 use manul::{
     combinators::misbehave::Misbehaving,
@@ -163,8 +161,7 @@ fn r2_hash_mismatch() {
             if round.id() == 1 {
                 // Send a wrong hash in the Round 1 message
                 let message = Round1EchoBroadcast {
-                    cap_v: XofHasher::new_with_dst(b"bad hash")
-                        .finalize_boxed(<<P as SchemeParams>::Curve as Curve>::FieldBytesSize::USIZE * 2),
+                    cap_v: XofHasher::new_with_dst(b"bad hash").finalize_boxed(P::SECURITY_BITS),
                 };
                 let echo_broadcast = EchoBroadcast::new(serializer, message)?;
                 return Ok(echo_broadcast);

--- a/synedrion/src/cggmp21/params.rs
+++ b/synedrion/src/cggmp21/params.rs
@@ -182,8 +182,6 @@ pub struct TestParams;
 impl SchemeParams for TestParams {
     type Curve = TinyCurve64;
     type WideCurveUint = bigintv05::U384;
-    // // TODO: 8*24 = 192, this is to work around an issue with the ModulusSize-trait. This should be ideally be 8 bytes long.
-    // type HashOutput = [u8; 24];
     const SECURITY_BITS: usize = 16;
     const SECURITY_PARAMETER: usize = 10;
     const L_BOUND: u32 = 256;
@@ -207,7 +205,6 @@ pub struct ProductionParams112;
 impl SchemeParams for ProductionParams112 {
     type Curve = k256::Secp256k1;
     type WideCurveUint = bigintv05::U512;
-    // type HashOutput = [u8; 32];
     const SECURITY_BITS: usize = 112;
     const SECURITY_PARAMETER: usize = 256;
     const L_BOUND: u32 = 256;

--- a/synedrion/src/cggmp21/params.rs
+++ b/synedrion/src/cggmp21/params.rs
@@ -5,7 +5,7 @@ use core::{fmt::Debug, ops::Add};
 // So as long as that is the case, `k256` `Uint` is separate
 // from the one used throughout the crate.
 use crypto_bigint::{BitOps, NonZero, Uint, U1024, U2048, U4096, U512, U8192};
-use digest::generic_array::{ArrayLength, GenericArray};
+use digest::generic_array::ArrayLength;
 use ecdsa::hazmat::{DigestPrimitive, SignPrimitive, VerifyPrimitive};
 use primeorder::elliptic_curve::{
     bigint::{self as bigintv05, Concat, Uint as CurveUint},
@@ -128,18 +128,6 @@ where
     type Curve: CurveArithmetic + PrimeCurve + HashableType + DigestPrimitive;
     /// Double the curve Scalar-width integer type.
     type WideCurveUint: bigintv05::Integer + bigintv05::Split<Output = <Self::Curve as Curve>::Uint>;
-    // TODO: We should get rid of this entirely, along with the FofHasher. Instead generate a Box<[u8]> of length 2 * P::SECURITY_BITS and use that.
-    /// Bla
-    type HashOutput: Clone
-        + Default
-        + Debug
-        + Send
-        + Sync
-        + PartialEq
-        + From<GenericArray<u8, <Self::Curve as Curve>::FieldBytesSize>>
-        + AsRef<[u8]>
-        + Serialize
-        + for<'x> Deserialize<'x>;
 
     /// The number of bits of security provided by the scheme.
     const SECURITY_BITS: usize; // $m$ in the paper
@@ -194,8 +182,8 @@ pub struct TestParams;
 impl SchemeParams for TestParams {
     type Curve = TinyCurve64;
     type WideCurveUint = bigintv05::U384;
-    // TODO: 8*24 = 192, this is to work around an issue with the ModulusSize-trait. This should be ideally be 8 bytes long.
-    type HashOutput = [u8; 24];
+    // // TODO: 8*24 = 192, this is to work around an issue with the ModulusSize-trait. This should be ideally be 8 bytes long.
+    // type HashOutput = [u8; 24];
     const SECURITY_BITS: usize = 16;
     const SECURITY_PARAMETER: usize = 10;
     const L_BOUND: u32 = 256;
@@ -219,7 +207,7 @@ pub struct ProductionParams112;
 impl SchemeParams for ProductionParams112 {
     type Curve = k256::Secp256k1;
     type WideCurveUint = bigintv05::U512;
-    type HashOutput = [u8; 32];
+    // type HashOutput = [u8; 32];
     const SECURITY_BITS: usize = 112;
     const SECURITY_PARAMETER: usize = 256;
     const L_BOUND: u32 = 256;

--- a/synedrion/src/tools/hashing.rs
+++ b/synedrion/src/tools/hashing.rs
@@ -58,8 +58,11 @@ impl XofHasher {
         self.0.finalize_xof()
     }
 
-    pub fn finalize_boxed(self, len: usize) -> Box<[u8]> {
-        self.0.finalize_xof().read_boxed(len)
+    /// Finalizes into enough bytes to bring the collision probability under `2^(-security_bits)`.
+    pub fn finalize_boxed(self, security_bits: usize) -> Box<[u8]> {
+        // A common heuristic for hashes is that the log2 of the collision probability is half the output size.
+        // We may not have enough output bytes, but this constitutes the best effort.
+        self.0.finalize_xof().read_boxed((security_bits * 2).div_ceil(8))
     }
 }
 


### PR DESCRIPTION
Switch to using the `XofHasher` and delete the `FofHasher` and, thus, the `HashOutput` associated type on `SchemeParams`. Instead of a fixed-length array we use `Box<[u8]>`.

Given these hashes are used for the Fiat-Shamir transform we need to ensure our hashes are not subject to bias. For this reason we read 2 * curve field size number of bytes from the hash.
