### PR TITLE
RSA primes set the two MSBs

### DIFF
--- a/synedrion/src/cggmp21/conversion.rs
+++ b/synedrion/src/cggmp21/conversion.rs
@@ -1,4 +1,4 @@
-use crypto_bigint::{BitOps, Encoding, Zero};
+use crypto_bigint::{BitOps, Bounded, Encoding, Zero};
 
 use super::params::SchemeParams;
 use crate::{
@@ -110,12 +110,11 @@ fn secret_uint_from_scalar<P: SchemeParams>(
 pub(crate) fn secret_signed_from_scalar<P: SchemeParams>(
     value: &Secret<Scalar<P>>,
 ) -> SecretSigned<<P::Paillier as PaillierParams>::Uint> {
-    SecretSigned::new_modulo(
-        secret_uint_from_scalar::<P>(value),
-        &P::CURVE_ORDER,
-        P::CURVE_ORDER.as_ref().bits_vartime(),
-    )
-    .expect(concat![
+    debug_assert!(
+        P::CURVE_ORDER.as_ref().bits_vartime() < <<P::Paillier as PaillierParams>::Uint as Bounded>::BITS,
+        "the curve order is expected to be smaller than the `Uint` type"
+    );
+    SecretSigned::new_modulo(secret_uint_from_scalar::<P>(value), &P::CURVE_ORDER).expect(concat![
         "a curve scalar value is smaller than the curve order, ",
         "and the curve order fits in `PaillierParams::Uint`"
     ])

--- a/synedrion/src/cggmp21/conversion.rs
+++ b/synedrion/src/cggmp21/conversion.rs
@@ -1,4 +1,5 @@
-use crypto_bigint::{BitOps, Bounded, Encoding, Zero};
+use crypto_bigint::{BitOps, Encoding, Zero};
+use primeorder::elliptic_curve::{CurveArithmetic, PrimeField};
 
 use super::params::SchemeParams;
 use crate::{
@@ -110,11 +111,12 @@ fn secret_uint_from_scalar<P: SchemeParams>(
 pub(crate) fn secret_signed_from_scalar<P: SchemeParams>(
     value: &Secret<Scalar<P>>,
 ) -> SecretSigned<<P::Paillier as PaillierParams>::Uint> {
-    debug_assert!(
-        P::CURVE_ORDER.as_ref().bits_vartime() < <<P::Paillier as PaillierParams>::Uint as Bounded>::BITS,
-        "the curve order is expected to be smaller than the `Uint` type"
-    );
-    SecretSigned::new_modulo(secret_uint_from_scalar::<P>(value), &P::CURVE_ORDER).expect(concat![
+    SecretSigned::new_modulo(
+        secret_uint_from_scalar::<P>(value),
+        &P::CURVE_ORDER,
+        <<P::Curve as CurveArithmetic>::Scalar as PrimeField>::NUM_BITS,
+    )
+    .expect(concat![
         "a curve scalar value is smaller than the curve order, ",
         "and the curve order fits in `PaillierParams::Uint`"
     ])

--- a/synedrion/src/cggmp21/params.rs
+++ b/synedrion/src/cggmp21/params.rs
@@ -4,14 +4,14 @@ use core::{fmt::Debug, ops::Add};
 // and `k256` depends on the released one.
 // So as long as that is the case, `k256` `Uint` is separate
 // from the one used throughout the crate.
-use crypto_bigint::{BitOps, NonZero, Uint, U1024, U128, U2048, U256, U4096, U512, U8192};
+use crypto_bigint::{NonZero, Uint, U1024, U128, U2048, U256, U4096, U512, U8192};
 use digest::generic_array::ArrayLength;
 use ecdsa::hazmat::{DigestPrimitive, SignPrimitive, VerifyPrimitive};
 use primeorder::elliptic_curve::{
     bigint::{self as bigintv05, Concat, Uint as CurveUint},
     point::DecompressPoint,
     sec1::{FromEncodedPoint, ModulusSize, ToEncodedPoint},
-    Curve, CurveArithmetic, PrimeCurve,
+    Curve, CurveArithmetic, PrimeCurve, PrimeField,
 };
 use serde::{Deserialize, Serialize};
 
@@ -157,7 +157,7 @@ where
     /// required for them to be used for the CGGMP scheme.
     fn are_self_consistent() -> bool {
         // See Appendix C.1
-        Self::CURVE_ORDER.as_ref().bits_vartime() == Self::SECURITY_PARAMETER as u32
+        <<Self::Curve as CurveArithmetic>::Scalar as PrimeField>::NUM_BITS == Self::SECURITY_PARAMETER as u32
         && Self::L_BOUND >= Self::SECURITY_PARAMETER as u32
         && Self::EPS_BOUND >= Self::L_BOUND + Self::SECURITY_PARAMETER as u32
         && Self::LP_BOUND >= Self::L_BOUND * 3 + Self::EPS_BOUND

--- a/synedrion/src/paillier/encryption.rs
+++ b/synedrion/src/paillier/encryption.rs
@@ -221,7 +221,7 @@ impl<P: PaillierParams> Ciphertext<P> {
         // Note that this is in range `[0, N)`
         let positive_result = (x_mod * sk.inv_totient()).retrieve();
 
-        SecretSigned::new_modulo(positive_result, &pk.modulus_nonzero(), P::MODULUS_BITS)
+        SecretSigned::new_modulo(positive_result, &pk.modulus_nonzero())
             .expect("the value is within `[0, N)` by construction and the modulus fits into `P::Uint`")
     }
 
@@ -387,12 +387,7 @@ mod tests {
 
     /// Calculates `val` modulo `modulus`, returning the result in range `[-N/2, N/2]`
     fn reduce<P: PaillierParams>(val: &SecretSigned<P::Uint>, modulus: &NonZero<P::Uint>) -> SecretSigned<P::Uint> {
-        SecretSigned::new_modulo(
-            Secret::init_with(|| reduce_unsigned(val, modulus)),
-            modulus,
-            P::MODULUS_BITS,
-        )
-        .unwrap()
+        SecretSigned::new_modulo(Secret::init_with(|| reduce_unsigned(val, modulus)), modulus).unwrap()
     }
 
     /// Calculates `lhs * rhs` modulo `modulus`, returning the result in range `[-N/2, N/2]`
@@ -409,7 +404,7 @@ mod tests {
         let wide_product = lhs.mul_wide(&rhs);
         let wide_modulus = modulus.as_ref().to_wide();
         let result = P::Uint::try_from_wide(&(wide_product % NonZero::new(wide_modulus).unwrap())).unwrap();
-        SecretSigned::new_modulo(Secret::init_with(|| result), modulus, P::MODULUS_BITS).unwrap()
+        SecretSigned::new_modulo(Secret::init_with(|| result), modulus).unwrap()
     }
 
     /// Calculates `lhs + rhs` modulo `modulus`, returning the result in range `[-N/2, N/2]`
@@ -421,7 +416,7 @@ mod tests {
         let lhs = reduce_unsigned(lhs, modulus);
         let rhs = reduce_unsigned(rhs, modulus);
         let sum = lhs.add_mod(&rhs, modulus);
-        SecretSigned::new_modulo(Secret::init_with(|| sum), modulus, P::MODULUS_BITS).unwrap()
+        SecretSigned::new_modulo(Secret::init_with(|| sum), modulus).unwrap()
     }
 
     #[test]

--- a/synedrion/src/paillier/keys.rs
+++ b/synedrion/src/paillier/keys.rs
@@ -438,16 +438,16 @@ mod tests {
             Token::Field("p"),
             Token::Str(
                 concat![
-                    "e3b7608d5c3161cca23711e75436575251f55e9c3b34412388f592f71c638c73",
-                    "edf68a6af97aab03faff8c42357a8c50fb2110f1c12d8628debd5eefb0f676f3"
+                    "5b4fe6be31dbfa5fe153ec138abb8a8d8271386e6e359dd18f0ef4b8f7301391",
+                    "2f58867d5d8fb0f30b1d96f215100ff97097b3baac10c8cc3aac969e7df3acce"
                 ]
                 .to_string(),
             ),
             Token::Field("q"),
             Token::Str(
                 concat![
-                    "17ea88a0e3187f0353c7c092f708369f5c6267e30c2a4c23a2eae9b524ffe0ed",
-                    "227fc2a20e965b6f697f913fcc281e5bde33fc435391bd3650d5950d5407db92"
+                    "732bbb2b9a150d2797ab52dde9dd00f467b6608d5c3161cca23711e754365752",
+                    "51f55e9c3b34412388f592f71c638c73edf68a6af97aab03faff8c42357a8cd0"
                 ]
                 .to_string(),
             ),

--- a/synedrion/src/paillier/params.rs
+++ b/synedrion/src/paillier/params.rs
@@ -1,7 +1,7 @@
 use crypto_bigint::{
     modular::Retrieve,
     subtle::{ConditionallyNegatable, ConditionallySelectable, ConstantTimeGreater, CtOption},
-    Bounded, Encoding, Gcd, Integer, InvMod, Invert, Monty, PowBoundedExp, RandomMod,
+    Bounded, Encoding, Gcd, Integer, InvMod, Invert, Monty, PowBoundedExp, RandomBits, RandomMod,
 };
 use crypto_primes::RandomPrimeWithRng;
 use serde::{Deserialize, Serialize};
@@ -29,6 +29,7 @@ pub trait PaillierParams: core::fmt::Debug + PartialEq + Eq + Clone + Send + Syn
     type HalfUint: Integer<Monty = Self::HalfUintMod>
         + Bounded
         + RandomMod
+        + RandomBits
         + RandomPrimeWithRng
         + Serialize
         + for<'de> Deserialize<'de>

--- a/synedrion/src/uint/secret_signed.rs
+++ b/synedrion/src/uint/secret_signed.rs
@@ -120,17 +120,27 @@ where
 
     /// Creates a [`SignedSecret`] from an unsigned value in range `[0, modulus)`,
     /// treating the values greater than `modulus / 2` as negative ones (modulo `modulus`).
-    /// `modulus_bound` is the bit bound for the modulus; the bound of the result will be set to `modulus_bound - 1`
-    /// (since it is the bound for the absolute value).
+    ///
+    /// NOTE: `modulus_bits` must be a compile-time constant to ensure the consistency
+    /// of the generated bound between runs.
     ///
     /// Returns `None` if the bound is too large, or if `abs(value)` is greater or equal to `2^bound`.
-    pub fn new_modulo(positive_value: Secret<T>, modulus: &NonZero<T>) -> Option<Self> {
+    pub fn new_modulo(positive_value: Secret<T>, modulus: &NonZero<T>, modulus_bits: u32) -> Option<Self> {
+        // We are taking a `bound` explicitly and not deriving it from the `modulus`
+        // because we want it to be the same across different runs.
+        // While currently all the moduli we use here are compile-time constants,
+        // that is not ensured locally and the assumption can be broken without noticing it.
+        //
+        // It could be made a const generic parameter to this method,
+        // but Rust does not allow specifying the value of this parameter from an associated constant
+        // (until `const_generic_exprs` lands), so we have to pass it at runtime.
+
         let half_modulus = modulus.as_ref().wrapping_shr_vartime(1);
         let is_negative = positive_value.expose_secret().ct_gt(&half_modulus);
         // Can't define a `Sub<Secret>` for `Uint`, so have to re-wrap manually.
         let negative_value = Secret::init_with(|| (*modulus.as_ref() - positive_value.expose_secret()).wrapping_neg());
         let value = Secret::<T>::conditional_select(&positive_value, &negative_value, is_negative);
-        Self::new_from_unsigned(value, modulus.bits_vartime() - 1)
+        Self::new_from_unsigned(value, modulus_bits - 1)
     }
 
     /// Asserts that the value is within the interval the paper denotes as $±2^exp$.


### PR DESCRIPTION
Setting the two MSBs when searching for RSA primes means they will have the bit length of a `P::Uint` which in turns means we do not need to explicitly provide modulus bounds. 

Builds on #195. Fixes #183.
