### PR TITLE
Ensure correct size of `y` argument for `П^{dec}`

### DIFF
--- a/PAPER.md
+++ b/PAPER.md
@@ -46,6 +46,22 @@ The above item leads to another problem. If those values are indeed echo-broadca
 Fig. 8, Round 2, 2b) - `\psi_{j,i}` creation requires `F_{i,j}` which are not yet available since they're the ones created on other nodes. The previous paper version has `F_{j,i}` there. Same for `\hat{\psi_{j,i}}`.
 
 
+# Range of `delta_i`
+
+There is some inconsistency with ranges in the Presigning protocol (Fig. 8).
+
+When we construct `delta_i` in Round 3, step 2, its range is `±2^{\ell^\prime + \eps + 1 + ceil(log2(n))}` where `n` is the number of parties.
+`\ell^\prime + \eps` is the range of a single `beta_{j,i}` coming from another node (as proven by `П^{aff-g}` in step 1); all the other terms have much smaller ranges, so adding them results in increasing the range by at most 1 bit.
+Since there are `n` `beta_{j,i}` in the sum, we add `ceil(log2(n))`, getting the final expression.
+
+If we reach the error round (Fig. 9) and need to construct `П^{dec}`, `delta_i` serves as the `y` argument.
+But the description of the proof (Fig. 28) requires `y ∈ ±2^{\ell^\prime}` (and correspondingly, `\beta` is sampled from `±2^{\ell^\prime + \eps}` to mask `y`).
+
+So to accommodate for the actual range of `delta_i`, we have to bump the range of `beta` and the range check of `w` by `\eps + 1 + ceil(log2(n))`, and add the number of parties to the public parameters of `П^{dec}`.
+
+Same applies to `chi_i`.
+
+
 # Echo-broadcasting
 
 In order to be able to generate verifiable evidence for each failure, some values have to be echo-broadcasted instead of normal broadcast/direct messaging given in the paper. Here is the list of such variables

--- a/synedrion/src/cggmp21/entities.rs
+++ b/synedrion/src/cggmp21/entities.rs
@@ -112,6 +112,10 @@ pub struct KeyShareChange<P: SchemeParams, I: Ord> {
 }
 
 impl<P: SchemeParams, I: Ord> PublicAuxInfos<P, I> {
+    pub(crate) fn num_parties(&self) -> usize {
+        self.0.len()
+    }
+
     pub(crate) fn as_map(&self) -> &BTreeMap<I, PublicAuxInfo<P>> {
         &self.0
     }

--- a/synedrion/src/paillier/keys.rs
+++ b/synedrion/src/paillier/keys.rs
@@ -313,6 +313,8 @@ impl<P: PaillierParams> PublicKeyPaillierWire<P> {
 pub(crate) struct PublicKeyPaillier<P: PaillierParams> {
     modulus: PublicModulus<P>,
     monty_params_mod_n_squared: <P::WideUintMod as Monty>::Params,
+    /// N converted to Motgomery form modulo N^2
+    modulus_mod_modulus_squared: P::WideUintMod,
     /// The minimal public key (for hashing purposes)
     public_key_wire: PublicKeyPaillierWire<P>,
 }
@@ -323,6 +325,8 @@ impl<P: PaillierParams> PublicKeyPaillier<P> {
             Odd::new(modulus.modulus().mul_wide(modulus.modulus())).expect("Square of odd number is odd"),
         );
 
+        let modulus_mod_modulus_squared = modulus.modulus().to_wide().to_montgomery(&monty_params_mod_n_squared);
+
         let public_key_wire = PublicKeyPaillierWire {
             modulus: modulus.to_wire(),
         };
@@ -330,6 +334,7 @@ impl<P: PaillierParams> PublicKeyPaillier<P> {
         PublicKeyPaillier {
             modulus,
             monty_params_mod_n_squared,
+            modulus_mod_modulus_squared,
             public_key_wire,
         }
     }
@@ -366,6 +371,11 @@ impl<P: PaillierParams> PublicKeyPaillier<P> {
     /// Returns precomputed parameters for integers modulo N^2
     pub fn monty_params_mod_n_squared(&self) -> &<P::WideUintMod as Monty>::Params {
         &self.monty_params_mod_n_squared
+    }
+
+    /// Returns the precomputed N in the Montgomery representation modulo N^2
+    pub fn modulus_mod_modulus_squared(&self) -> &P::WideUintMod {
+        &self.modulus_mod_modulus_squared
     }
 
     /// Returns a uniformly chosen number in range $[0, N)$ such that it is invertible modulo $N$, in Montgomery form.

--- a/synedrion/src/paillier/params.rs
+++ b/synedrion/src/paillier/params.rs
@@ -75,7 +75,7 @@ pub trait PaillierParams: core::fmt::Debug + PartialEq + Eq + Clone + Send + Syn
     type WideUint: Integer<Monty = Self::WideUintMod>
         + Bounded
         + ConditionallySelectable
-        + Encoding
+        + Encoding<Repr: Zeroize>
         + Hashable
         + HasWide<Wide = Self::ExtraWideUint>
         + RandomMod

--- a/synedrion/src/uint/secret_unsigned.rs
+++ b/synedrion/src/uint/secret_unsigned.rs
@@ -78,20 +78,6 @@ where
 
 impl<T> SecretUnsigned<T>
 where
-    T: Zeroize + Integer + Bounded + HasWide,
-    T::Wide: Zeroize + Integer + Bounded,
-{
-    pub fn mul_wide(&self, rhs: &T) -> SecretUnsigned<T::Wide> {
-        SecretUnsigned::new(
-            Secret::init_with(|| self.value.expose_secret().mul_wide(rhs)),
-            self.bound + rhs.bits_vartime(),
-        )
-        .expect("the new bound is valid since the constituent ones were")
-    }
-}
-
-impl<T> SecretUnsigned<T>
-where
     T: Zeroize + Clone + HasWide,
     T::Wide: Zeroize,
 {


### PR DESCRIPTION
- Change the modulus size in `TestParams` to 128. 
- Ensure the correct size of `y` argument for `П^{dec}` (`delta_i` and `chi_i`). See the change in `PAPER.md` for the theoretical background. Most of the changes are just dealing with the `П^{dec}` now requiring some operations on wide Uints.

I think this is the correct approach from the mathematical perspective (although having to add some `_wide` methods is not great, see also #198). Fixes #187. I think it is safe to do since we added the `DEVIATION` comments in the proof itself, and the node in `PAPER.md`, so the future audit will review it.