### PR TITLE
Generic hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped MSRV to 1.83 ([#176])
 - The API is now generic over the elliptic curve ([#186])
 - Added `k256` (Secp256k1 parameters), `bip32` (BIP32 support), and `dev` (`tiny-curve` parameters) features. ([#199])
+- Added a `Digest` type to `SchemeParams`. ([#204])
 
 
 [#156]: https://github.com/entropyxyz/synedrion/pull/156
@@ -20,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#176]: https://github.com/entropyxyz/synedrion/pull/176
 [#186]: https://github.com/entropyxyz/synedrion/pull/186
 [#199]: https://github.com/entropyxyz/synedrion/pull/199
+[#204]: https://github.com/entropyxyz/synedrion/pull/204
 
 
 ## [0.2.0] - 2024-11-17

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ categories = ["cryptography", "no-std"]
 manul = { git = "https://github.com/entropyxyz/manul.git", rev = "9810d0188d64d4fca3c95efd75e3b565c5db4233" }
 signature = { version = "2", default-features = false }
 rand_core = { version = "0.6.4", default-features = false }
-sha3 = { version = "0.10", default-features = false }
 digest = { version = "0.10", default-features = false, features = ["alloc"] }
 hashing-serializer = { version = "0.1", default-features = false }
 secrecy = { version = "0.10", default-features = false }
@@ -37,6 +36,7 @@ displaydoc = { version = "0.2", default-features = false }
 tiny-curve = { version = "0.2.2", optional = true, features = ["ecdsa", "serde"] }
 k256 = { version = "0.13", optional = true, default-features = false, features = ["ecdsa"] }
 bip32 = { version = "0.5", optional = true, default-features = false, features = ["alloc"] }
+sha3 = { version = "0.10", optional = true, default-features = false }
 
 [dev-dependencies]
 manul = { git = "https://github.com/entropyxyz/manul.git", rev = "9810d0188d64d4fca3c95efd75e3b565c5db4233", features = [
@@ -51,12 +51,13 @@ tiny-curve = { version = "0.2.2", features = ["ecdsa", "serde"] }
 impls = "1"
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 test-log = { version = "0.2.16", default-features = false, features = ["trace", "color"] }
+sha3 = { version = "0.10", default-features = false }
 
 [features]
 private-benches = ["k256"]
-k256 = ["dep:k256", "bip32?/secp256k1"]
+k256 = ["dep:k256", "bip32?/secp256k1", "sha3"]
 bip32 = ["dep:bip32", "tiny-curve?/bip32"]
-dev = ["tiny-curve"]
+dev = ["tiny-curve", "sha3"]
 
 [[bench]]
 bench = true

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -10,7 +10,7 @@ mod bip32;
 
 pub use ecdsa::RecoverableSignature;
 
-pub(crate) use arithmetic::{secret_split, Point, Scalar};
+pub(crate) use arithmetic::{chain_curve, secret_split, Point, Scalar};
 
 #[cfg(feature = "bip32")]
 pub use bip32::{DeriveChildKey, PublicTweakable, SecretTweakable};

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -1,4 +1,5 @@
 mod full;
+mod internal;
 mod threshold;
 
 pub use full::{AuxInfo, KeyShare, KeyShareChange};
@@ -7,3 +8,4 @@ pub use threshold::ThresholdKeyShare;
 pub(crate) use full::{
     AuxInfoPrecomputed, PublicAuxInfo, PublicAuxInfoPrecomputed, PublicAuxInfos, PublicKeyShares, SecretAuxInfo,
 };
+pub(crate) use internal::Sid;

--- a/src/entities/internal.rs
+++ b/src/entities/internal.rs
@@ -18,7 +18,7 @@ impl Sid {
                 .chain_type::<P::Curve>()
                 .chain(&shared_randomness)
                 .chain(&ids)
-                .finalize_boxed(P::SECURITY_BITS),
+                .finalize(),
         )
     }
 }

--- a/src/entities/internal.rs
+++ b/src/entities/internal.rs
@@ -4,7 +4,7 @@ use manul::protocol::PartyId;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    params::SchemeParams,
+    params::{chain_scheme_params, SchemeParams},
     tools::hashing::{Chain, HashOutput, Hasher},
 };
 
@@ -16,12 +16,10 @@ pub(crate) struct Sid(HashOutput);
 
 impl Sid {
     pub fn new<P: SchemeParams, Id: PartyId>(shared_randomness: &[u8], ids: &BTreeSet<Id>) -> Self {
-        Self(
-            Hasher::<P::Digest>::new_with_dst(b"SID")
-                .chain_type::<P::Curve>()
-                .chain(&shared_randomness)
-                .chain(&ids)
-                .finalize(P::SECURITY_BITS),
-        )
+        let digest = Hasher::<P::Digest>::new_with_dst(b"SID");
+        let digest = chain_scheme_params::<P, _>(digest);
+        let digest = digest.chain(&shared_randomness).chain(&ids);
+
+        Self(digest.finalize(P::SECURITY_BITS))
     }
 }

--- a/src/entities/internal.rs
+++ b/src/entities/internal.rs
@@ -8,6 +8,9 @@ use crate::{
     tools::hashing::{Chain, HashOutput, Hasher},
 };
 
+/// The session identifier (see Remark 4.1 in the paper).
+///
+/// The session identifier is tied to the identity of the parties, the mathematical parameters, and the public key.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct Sid(HashOutput);
 

--- a/src/entities/internal.rs
+++ b/src/entities/internal.rs
@@ -1,0 +1,24 @@
+use alloc::collections::BTreeSet;
+
+use manul::protocol::PartyId;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    params::SchemeParams,
+    tools::hashing::{Chain, HashOutput, Hasher},
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct Sid(HashOutput);
+
+impl Sid {
+    pub fn new<P: SchemeParams, Id: PartyId>(shared_randomness: &[u8], ids: &BTreeSet<Id>) -> Self {
+        Self(
+            Hasher::<P>::new_with_dst(b"SID")
+                .chain_type::<P::Curve>()
+                .chain(&shared_randomness)
+                .chain(&ids)
+                .finalize_boxed(P::SECURITY_BITS),
+        )
+    }
+}

--- a/src/entities/internal.rs
+++ b/src/entities/internal.rs
@@ -17,11 +17,11 @@ pub(crate) struct Sid(HashOutput);
 impl Sid {
     pub fn new<P: SchemeParams, Id: PartyId>(shared_randomness: &[u8], ids: &BTreeSet<Id>) -> Self {
         Self(
-            Hasher::<P>::new_with_dst(b"SID")
+            Hasher::<P::Digest>::new_with_dst(b"SID")
                 .chain_type::<P::Curve>()
                 .chain(&shared_randomness)
                 .chain(&ids)
-                .finalize(),
+                .finalize(P::SECURITY_BITS),
         )
     }
 }

--- a/src/paillier.rs
+++ b/src/paillier.rs
@@ -6,5 +6,5 @@ mod rsa;
 
 pub(crate) use encryption::{Ciphertext, CiphertextWire, MaskedRandomizer, Randomizer};
 pub(crate) use keys::{PublicKeyPaillier, PublicKeyPaillierWire, SecretKeyPaillier, SecretKeyPaillierWire};
-pub(crate) use params::PaillierParams;
+pub(crate) use params::{chain_paillier_params, PaillierParams};
 pub(crate) use ring_pedersen::{RPCommitmentWire, RPParams, RPParamsWire, RPSecret};

--- a/src/paillier/params.rs
+++ b/src/paillier/params.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;
 
 use crate::{
+    tools::hashing::Chain,
     tools::hashing::Hashable,
     uint::{HasWide, ToMontgomery},
 };
@@ -102,4 +103,12 @@ pub trait PaillierParams: core::fmt::Debug + PartialEq + Eq + Clone + Send + Syn
         + Serialize
         + for<'de> Deserialize<'de>
         + Zeroize;
+}
+
+pub(crate) fn chain_paillier_params<P, C>(digest: C) -> C
+where
+    P: PaillierParams,
+    C: Chain,
+{
+    digest.chain_bytes(&P::PRIME_BITS.to_be_bytes())
 }

--- a/src/params.rs
+++ b/src/params.rs
@@ -13,3 +13,4 @@ pub(crate) use conversion::{
     public_signed_from_scalar, scalar_from_signed, scalar_from_wide_signed, secret_scalar_from_signed,
     secret_scalar_from_wide_signed, secret_signed_from_scalar,
 };
+pub(crate) use traits::chain_scheme_params;

--- a/src/params/dev.rs
+++ b/src/params/dev.rs
@@ -6,6 +6,7 @@ use elliptic_curve::{
     Curve,
 };
 use serde::{Deserialize, Serialize};
+use sha3::Shake256;
 use tiny_curve::TinyCurve32;
 
 #[cfg(feature = "bip32")]
@@ -51,6 +52,7 @@ impl SchemeParams for TestParams {
     // TODO: ReprUint is typenum::U192 because of RustCrypto stack internals, hence the U384 here,
     // but once that is solved, this can be a U128 (or even smaller).
     type WideCurveUint = bigintv05::U384;
+    type Digest = Shake256;
     const SECURITY_BITS: usize = 16;
     const SECURITY_PARAMETER: usize = 32;
     const L_BOUND: u32 = 32;

--- a/src/params/k256.rs
+++ b/src/params/k256.rs
@@ -12,6 +12,7 @@ use elliptic_curve::{
     Curve,
 };
 use serde::{Deserialize, Serialize};
+use sha3::Shake256;
 
 #[cfg(feature = "bip32")]
 use ecdsa::{SigningKey, VerifyingKey};
@@ -49,6 +50,7 @@ pub struct ProductionParams112;
 impl SchemeParams for ProductionParams112 {
     type Curve = k256::Secp256k1;
     type WideCurveUint = bigintv05::U512;
+    type Digest = Shake256;
     const SECURITY_BITS: usize = 112;
     const SECURITY_PARAMETER: usize = 256;
     const L_BOUND: u32 = 256;

--- a/src/params/traits.rs
+++ b/src/params/traits.rs
@@ -5,10 +5,11 @@ use core::{fmt::Debug, ops::Add};
 // So as long as that is the case, `k256` `Uint` is separate
 // from the one used throughout the crate.
 use crypto_bigint::NonZero;
-use digest::generic_array::ArrayLength;
+use digest::{ExtendableOutput, Update};
 use ecdsa::hazmat::{DigestPrimitive, SignPrimitive, VerifyPrimitive};
 use elliptic_curve::{
     bigint::{self as bigintv05, Concat, Split},
+    generic_array::ArrayLength,
     point::DecompressPoint,
     sec1::{FromEncodedPoint, ModulusSize, ToEncodedPoint},
     Curve, CurveArithmetic, PrimeCurve, PrimeField,
@@ -55,6 +56,11 @@ where
     type Curve: CurveArithmetic + PrimeCurve + HashableType + DigestPrimitive;
     /// Double the curve Scalar-width integer type.
     type WideCurveUint: bigintv05::Integer + Split<Output = <Self::Curve as Curve>::Uint>;
+
+    /// The hash that will be used for protocol's internal purposes.
+    ///
+    /// Note: the collision probability must be consistent with [`Self::SECURITY_BITS`].
+    type Digest: Default + Update + ExtendableOutput;
 
     /// The number of bits of security provided by the scheme.
     const SECURITY_BITS: usize; // $m$ in the paper

--- a/src/protocols/aux_gen.rs
+++ b/src/protocols/aux_gen.rs
@@ -29,7 +29,7 @@ use crate::{
     params::SchemeParams,
     tools::{
         bitvec::BitVec,
-        hashing::{Chain, XofHasher},
+        hashing::{Chain, Hasher},
         protocol_shortcuts::{verify_that, DeserializeAll, DowncastMap, GetRound, MapValues, SafeGet, Without},
     },
     zk::{FacProof, ModProof, PrmProof},
@@ -167,7 +167,7 @@ fn make_sid<P: SchemeParams, Id: PartyId>(
     shared_randomness: &[u8],
     associated_data: &AuxGenAssociatedData<Id>,
 ) -> Box<[u8]> {
-    XofHasher::new_with_dst(b"AuxGen SID")
+    Hasher::<P>::new_with_dst(b"AuxGen SID")
         .chain_type::<P::Curve>()
         .chain(&shared_randomness)
         .chain(&associated_data.ids)
@@ -314,7 +314,7 @@ pub(super) struct PublicData<P: SchemeParams> {
 
 impl<P: SchemeParams> PublicData<P> {
     pub(super) fn hash<Id: PartyId>(&self, sid: &[u8], id: &Id) -> Box<[u8]> {
-        XofHasher::new_with_dst(b"KeyInit")
+        Hasher::<P>::new_with_dst(b"KeyInit")
             .chain(&sid)
             .chain(id)
             .chain(&self.paillier_pk.clone().into_wire())

--- a/src/protocols/aux_gen.rs
+++ b/src/protocols/aux_gen.rs
@@ -2,7 +2,6 @@
 //!
 //! This is a subset of the protocol that generates the auxiliary data, with share update bits removed.
 
-use alloc::boxed::Box;
 use alloc::collections::{BTreeMap, BTreeSet};
 use core::{
     fmt::{self, Debug, Display},
@@ -18,10 +17,9 @@ use manul::protocol::{
 };
 use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
-use serde_encoded_bytes::{Hex, SliceLike};
 
 use crate::{
-    entities::{AuxInfo, PublicAuxInfo, PublicAuxInfos, SecretAuxInfo},
+    entities::{AuxInfo, PublicAuxInfo, PublicAuxInfos, SecretAuxInfo, Sid},
     paillier::{
         PaillierParams, PublicKeyPaillier, PublicKeyPaillierWire, RPParams, RPParamsWire, RPSecret, SecretKeyPaillier,
         SecretKeyPaillierWire,
@@ -29,7 +27,7 @@ use crate::{
     params::SchemeParams,
     tools::{
         bitvec::BitVec,
-        hashing::{Chain, Hasher},
+        hashing::{Chain, HashOutput, Hasher},
         protocol_shortcuts::{verify_that, DeserializeAll, DowncastMap, GetRound, MapValues, SafeGet, Without},
     },
     zk::{FacProof, ModProof, PrmProof},
@@ -163,17 +161,6 @@ pub struct AuxGenAssociatedData<Id> {
     pub ids: BTreeSet<Id>,
 }
 
-fn make_sid<P: SchemeParams, Id: PartyId>(
-    shared_randomness: &[u8],
-    associated_data: &AuxGenAssociatedData<Id>,
-) -> Box<[u8]> {
-    Hasher::<P>::new_with_dst(b"AuxGen SID")
-        .chain_type::<P::Curve>()
-        .chain(&shared_randomness)
-        .chain(&associated_data.ids)
-        .finalize_boxed(P::SECURITY_BITS)
-}
-
 impl<P: SchemeParams, Id: PartyId> ProtocolError<Id> for AuxGenError<P, Id> {
     type AssociatedData = AuxGenAssociatedData<Id>;
 
@@ -216,7 +203,7 @@ impl<P: SchemeParams, Id: PartyId> ProtocolError<Id> for AuxGenError<P, Id> {
         previous_messages: BTreeMap<RoundId, ProtocolMessage>,
         combined_echos: BTreeMap<RoundId, BTreeMap<Id, EchoBroadcast>>,
     ) -> Result<(), ProtocolValidationError> {
-        let sid = make_sid::<P, Id>(shared_randomness, associated_data);
+        let sid = Sid::new::<P, Id>(shared_randomness, &associated_data.ids);
 
         match &self.error {
             Error::R2HashMismatch => {
@@ -313,9 +300,9 @@ pub(super) struct PublicData<P: SchemeParams> {
 }
 
 impl<P: SchemeParams> PublicData<P> {
-    pub(super) fn hash<Id: PartyId>(&self, sid: &[u8], id: &Id) -> Box<[u8]> {
+    pub(super) fn hash<Id: PartyId>(&self, sid: &Sid, id: &Id) -> HashOutput {
         Hasher::<P>::new_with_dst(b"KeyInit")
-            .chain(&sid)
+            .chain(sid)
             .chain(id)
             .chain(&self.paillier_pk.clone().into_wire())
             .chain(&self.rp_params.to_wire())
@@ -367,12 +354,7 @@ where
 
         let other_ids = self.all_ids.clone().without(id);
 
-        let sid = make_sid::<P, Id>(
-            shared_randomness,
-            &AuxGenAssociatedData {
-                ids: self.all_ids.clone(),
-            },
-        );
+        let sid = Sid::new::<P, Id>(shared_randomness, &self.all_ids);
 
         // Paillier secret key $p_i$, $q_i$
         let paillier_sk = SecretKeyPaillierWire::<P::Paillier>::random(rng);
@@ -419,7 +401,7 @@ pub(super) struct Context<P: SchemeParams, Id> {
     rp_params: RPParams<P::Paillier>,
     pub(super) my_id: Id,
     other_ids: BTreeSet<Id>,
-    pub(super) sid: Box<[u8]>,
+    pub(super) sid: Sid,
 }
 
 #[derive(Debug)]
@@ -430,12 +412,11 @@ pub(super) struct Round1<P: SchemeParams, Id: PartyId> {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(super) struct Round1EchoBroadcast {
-    #[serde(with = "SliceLike::<Hex>")]
-    pub(super) cap_v: Box<[u8]>,
+    pub(super) cap_v: HashOutput,
 }
 
 struct Round1Payload {
-    cap_v: Box<[u8]>,
+    cap_v: HashOutput,
 }
 
 impl<P: SchemeParams, Id: PartyId> Round<Id> for Round1<P, Id> {
@@ -506,7 +487,7 @@ impl<P: SchemeParams, Id: PartyId> Round<Id> for Round1<P, Id> {
 struct Round2<P: SchemeParams, Id: PartyId> {
     context: Context<P, Id>,
     public_data: PublicData<P>,
-    cap_vs: BTreeMap<Id, Box<[u8]>>,
+    cap_vs: BTreeMap<Id, HashOutput>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/protocols/aux_gen.rs
+++ b/src/protocols/aux_gen.rs
@@ -309,7 +309,7 @@ impl<P: SchemeParams> PublicData<P> {
             .chain(&self.psi)
             .chain(&self.rid)
             .chain(&self.u)
-            .finalize_boxed(P::SECURITY_BITS)
+            .finalize()
     }
 }
 

--- a/src/protocols/aux_gen.rs
+++ b/src/protocols/aux_gen.rs
@@ -301,7 +301,7 @@ pub(super) struct PublicData<P: SchemeParams> {
 
 impl<P: SchemeParams> PublicData<P> {
     pub(super) fn hash<Id: PartyId>(&self, sid: &Sid, id: &Id) -> HashOutput {
-        Hasher::<P>::new_with_dst(b"KeyInit")
+        Hasher::<P::Digest>::new_with_dst(b"KeyInit")
             .chain(sid)
             .chain(id)
             .chain(&self.paillier_pk.clone().into_wire())
@@ -309,7 +309,7 @@ impl<P: SchemeParams> PublicData<P> {
             .chain(&self.psi)
             .chain(&self.rid)
             .chain(&self.u)
-            .finalize()
+            .finalize(P::SECURITY_BITS)
     }
 }
 

--- a/src/protocols/interactive_signing.rs
+++ b/src/protocols/interactive_signing.rs
@@ -249,7 +249,7 @@ impl Epid {
                 .chain(&shared_randomness)
                 .chain(&associated_data.shares)
                 .chain(&associated_data.aux)
-                .finalize_boxed(P::SECURITY_BITS),
+                .finalize(),
         )
     }
 }

--- a/src/protocols/interactive_signing.rs
+++ b/src/protocols/interactive_signing.rs
@@ -247,12 +247,12 @@ impl Epid {
         associated_data: &InteractiveSigningAssociatedData<P, Id>,
     ) -> Self {
         Self(
-            Hasher::<P>::new_with_dst(b"EPID")
+            Hasher::<P::Digest>::new_with_dst(b"EPID")
                 .chain_type::<P::Curve>()
                 .chain(&shared_randomness)
                 .chain(&associated_data.shares)
                 .chain(&associated_data.aux)
-                .finalize(),
+                .finalize(P::SECURITY_BITS),
         )
     }
 }

--- a/src/protocols/interactive_signing.rs
+++ b/src/protocols/interactive_signing.rs
@@ -235,6 +235,9 @@ impl<P: SchemeParams, Id: PartyId> InteractiveSigningAssociatedData<P, Id> {
     }
 }
 
+/// The epoch identifier (see Remark 4.1 in the paper).
+///
+/// The epoch identifier is tied to the key-refresh epoch and the auxiliary key material of the parties for that epoch.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct Epid(HashOutput);
 

--- a/src/protocols/interactive_signing.rs
+++ b/src/protocols/interactive_signing.rs
@@ -30,7 +30,7 @@ use crate::{
     paillier::{Ciphertext, CiphertextWire, PaillierParams, Randomizer},
     params::{secret_scalar_from_signed, secret_signed_from_scalar, SchemeParams},
     tools::{
-        hashing::{Chain, XofHasher},
+        hashing::{Chain, Hasher},
         protocol_shortcuts::{
             sum_non_empty, sum_non_empty_ref, verify_that, DeserializeAll, DowncastMap, GetRound, MapValues, SafeGet,
             Without,
@@ -240,7 +240,7 @@ fn make_epid<P: SchemeParams, Id: PartyId>(
     shared_randomness: &[u8],
     associated_data: &InteractiveSigningAssociatedData<P, Id>,
 ) -> Box<[u8]> {
-    XofHasher::new_with_dst(b"InteractiveSigning EPID")
+    Hasher::<P>::new_with_dst(b"InteractiveSigning EPID")
         .chain_type::<P::Curve>()
         .chain(&shared_randomness)
         .chain(&associated_data.shares)

--- a/src/protocols/key_init.rs
+++ b/src/protocols/key_init.rs
@@ -25,7 +25,7 @@ use crate::{
     params::SchemeParams,
     tools::{
         bitvec::BitVec,
-        hashing::{Chain, XofHasher},
+        hashing::{Chain, Hasher},
         protocol_shortcuts::{verify_that, DeserializeAll, DowncastMap, GetRound, MapValues, SafeGet, Without},
         Secret,
     },
@@ -121,7 +121,7 @@ fn make_sid<P: SchemeParams, Id: PartyId>(
     shared_randomness: &[u8],
     associated_data: &KeyInitAssociatedData<Id>,
 ) -> Box<[u8]> {
-    XofHasher::new_with_dst(b"KeyInit SID")
+    Hasher::<P>::new_with_dst(b"KeyInit SID")
         .chain_type::<P::Curve>()
         .chain(&shared_randomness)
         .chain(&associated_data.ids)
@@ -219,7 +219,7 @@ where
     P: SchemeParams,
 {
     pub(super) fn hash<Id: Serialize>(&self, sid: &[u8], id: &Id) -> Box<[u8]> {
-        XofHasher::new_with_dst(b"KeyInit")
+        Hasher::<P>::new_with_dst(b"KeyInit")
             .chain(&sid)
             .chain(id)
             .chain(&self.cap_x)

--- a/src/protocols/key_init.rs
+++ b/src/protocols/key_init.rs
@@ -213,7 +213,7 @@ where
             .chain(&self.cap_a)
             .chain(&self.rho)
             .chain(&self.u)
-            .finalize_boxed(P::SECURITY_BITS)
+            .finalize()
     }
 }
 

--- a/src/protocols/key_init.rs
+++ b/src/protocols/key_init.rs
@@ -206,14 +206,14 @@ where
     P: SchemeParams,
 {
     pub(super) fn hash<Id: Serialize>(&self, sid: &Sid, id: &Id) -> HashOutput {
-        Hasher::<P>::new_with_dst(b"KeyInit")
+        Hasher::<P::Digest>::new_with_dst(b"KeyInit")
             .chain(sid)
             .chain(id)
             .chain(&self.cap_x)
             .chain(&self.cap_a)
             .chain(&self.rho)
             .chain(&self.u)
-            .finalize()
+            .finalize(P::SECURITY_BITS)
     }
 }
 

--- a/src/protocols/key_init.rs
+++ b/src/protocols/key_init.rs
@@ -2,7 +2,6 @@
 //! Note that this protocol only generates the key itself which is not enough to perform signing;
 //! auxiliary parameters need to be generated as well (during the KeyRefresh protocol).
 
-use alloc::boxed::Box;
 use alloc::collections::{BTreeMap, BTreeSet};
 use core::{
     fmt::{self, Debug, Display},
@@ -17,15 +16,14 @@ use manul::protocol::{
 };
 use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
-use serde_encoded_bytes::{Hex, SliceLike};
 
 use crate::{
     curve::{Point, Scalar},
-    entities::KeyShare,
+    entities::{KeyShare, Sid},
     params::SchemeParams,
     tools::{
         bitvec::BitVec,
-        hashing::{Chain, Hasher},
+        hashing::{Chain, HashOutput, Hasher},
         protocol_shortcuts::{verify_that, DeserializeAll, DowncastMap, GetRound, MapValues, SafeGet, Without},
         Secret,
     },
@@ -117,17 +115,6 @@ pub struct KeyInitAssociatedData<Id> {
     pub ids: BTreeSet<Id>,
 }
 
-fn make_sid<P: SchemeParams, Id: PartyId>(
-    shared_randomness: &[u8],
-    associated_data: &KeyInitAssociatedData<Id>,
-) -> Box<[u8]> {
-    Hasher::<P>::new_with_dst(b"KeyInit SID")
-        .chain_type::<P::Curve>()
-        .chain(&shared_randomness)
-        .chain(&associated_data.ids)
-        .finalize_boxed(P::SECURITY_BITS)
-}
-
 impl<P: SchemeParams, Id: PartyId> ProtocolError<Id> for KeyInitError<P> {
     type AssociatedData = KeyInitAssociatedData<Id>;
 
@@ -156,7 +143,7 @@ impl<P: SchemeParams, Id: PartyId> ProtocolError<Id> for KeyInitError<P> {
         previous_messages: BTreeMap<RoundId, ProtocolMessage>,
         combined_echos: BTreeMap<RoundId, BTreeMap<Id, EchoBroadcast>>,
     ) -> Result<(), ProtocolValidationError> {
-        let sid = make_sid::<P, Id>(shared_randomness, associated_data);
+        let sid = Sid::new::<P, Id>(shared_randomness, &associated_data.ids);
 
         match self.error {
             Error::R2HashMismatch => {
@@ -218,9 +205,9 @@ impl<P> PublicData<P>
 where
     P: SchemeParams,
 {
-    pub(super) fn hash<Id: Serialize>(&self, sid: &[u8], id: &Id) -> Box<[u8]> {
+    pub(super) fn hash<Id: Serialize>(&self, sid: &Sid, id: &Id) -> HashOutput {
         Hasher::<P>::new_with_dst(b"KeyInit")
-            .chain(&sid)
+            .chain(sid)
             .chain(id)
             .chain(&self.cap_x)
             .chain(&self.cap_a)
@@ -267,12 +254,7 @@ impl<P: SchemeParams, Id: PartyId> EntryPoint<Id> for KeyInit<P, Id> {
 
         let other_ids = self.all_ids.clone().without(id);
 
-        let sid = make_sid::<P, Id>(
-            shared_randomness,
-            &KeyInitAssociatedData {
-                ids: self.all_ids.clone(),
-            },
-        );
+        let sid = Sid::new::<P, Id>(shared_randomness, &self.all_ids);
 
         // The secret share
         let x = Secret::init_with(|| Scalar::random(rng));
@@ -306,7 +288,7 @@ pub(super) struct Context<P: SchemeParams, Id> {
     pub(super) x: Secret<Scalar<P>>,
     pub(super) tau: SchSecret<P>,
     pub(super) public_data: PublicData<P>,
-    pub(super) sid: Box<[u8]>,
+    pub(super) sid: Sid,
 }
 
 #[derive(Debug)]
@@ -316,12 +298,11 @@ struct Round1<P: SchemeParams, Id> {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct Round1EchoBroadcast {
-    #[serde(with = "SliceLike::<Hex>")]
-    cap_v: Box<[u8]>,
+    cap_v: HashOutput,
 }
 
 struct Round1Payload {
-    cap_v: Box<[u8]>,
+    cap_v: HashOutput,
 }
 
 impl<P, Id> Round<Id> for Round1<P, Id>
@@ -391,7 +372,7 @@ where
 #[derive(Debug)]
 struct Round2<P: SchemeParams, Id> {
     context: Context<P, Id>,
-    cap_vs: BTreeMap<Id, Box<[u8]>>,
+    cap_vs: BTreeMap<Id, HashOutput>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]

--- a/src/protocols/key_refresh.rs
+++ b/src/protocols/key_refresh.rs
@@ -466,7 +466,7 @@ impl<P: SchemeParams, Id: PartyId> PublicData<P, Id> {
             .chain(&self.psi)
             .chain(&self.rid)
             .chain(&self.u)
-            .finalize_boxed(P::SECURITY_BITS)
+            .finalize()
     }
 }
 

--- a/src/protocols/key_refresh.rs
+++ b/src/protocols/key_refresh.rs
@@ -362,7 +362,7 @@ impl<P: SchemeParams, Id: PartyId> ProtocolError<Id> for KeyRefreshError<P, Id> 
                     .echo_broadcast
                     .deserialize::<Round2EchoBroadcast<P, Id>>(deserializer)?;
                 let cap_y_ji = r2_eb.cap_ys.try_get("public Elgamal values", reported_by)?;
-                let mut reader = Hasher::<P>::new_with_dst(b"KeyRefresh Round3")
+                let mut reader = Hasher::<P::Digest>::new_with_dst(b"KeyRefresh Round3")
                     .chain(&sid)
                     .chain(&rid)
                     .chain(guilty_party)
@@ -455,7 +455,7 @@ pub(super) struct PublicData<P: SchemeParams, Id> {
 
 impl<P: SchemeParams, Id: PartyId> PublicData<P, Id> {
     pub(super) fn hash(&self, sid: &Sid, id: &Id) -> HashOutput {
-        Hasher::<P>::new_with_dst(b"KeyInit")
+        Hasher::<P::Digest>::new_with_dst(b"KeyInit")
             .chain(sid)
             .chain(id)
             .chain(&self.cap_xs)
@@ -466,7 +466,7 @@ impl<P: SchemeParams, Id: PartyId> PublicData<P, Id> {
             .chain(&self.psi)
             .chain(&self.rid)
             .chain(&self.u)
-            .finalize()
+            .finalize(P::SECURITY_BITS)
     }
 }
 
@@ -997,7 +997,7 @@ impl<P: SchemeParams, Id: PartyId> Round<Id> for Round3<P, Id> {
 
         let cap_y = r2_payload.cap_ys.safe_get("Elgamal public keys", my_id)?;
         let y = self.context.ys.safe_get("Elgamal secrets", destination)?;
-        let mut reader = Hasher::<P>::new_with_dst(b"KeyRefresh Round3")
+        let mut reader = Hasher::<P::Digest>::new_with_dst(b"KeyRefresh Round3")
             .chain(&self.context.sid)
             .chain(&self.rid_combined)
             .chain(my_id)
@@ -1033,7 +1033,7 @@ impl<P: SchemeParams, Id: PartyId> Round<Id> for Round3<P, Id> {
         let r2_payload = self.r2_payloads.safe_get("Round 2 payloads", from)?;
         let cap_y = r2_payload.cap_ys.safe_get("Elgamal public keys", my_id)?;
         let y = self.context.ys.safe_get("Elgamal secrets", from)?;
-        let mut reader = Hasher::<P>::new_with_dst(b"KeyRefresh Round3")
+        let mut reader = Hasher::<P::Digest>::new_with_dst(b"KeyRefresh Round3")
             .chain(&self.context.sid)
             .chain(&self.rid_combined)
             .chain(from)

--- a/src/protocols/key_refresh.rs
+++ b/src/protocols/key_refresh.rs
@@ -33,7 +33,7 @@ use crate::{
     params::SchemeParams,
     tools::{
         bitvec::BitVec,
-        hashing::{Chain, XofHasher},
+        hashing::{Chain, Hasher},
         protocol_shortcuts::{verify_that, DeserializeAll, DowncastMap, GetRound, MapValues, SafeGet, Without},
         Secret,
     },
@@ -211,7 +211,7 @@ fn make_sid<P: SchemeParams, Id: PartyId>(
     shared_randomness: &[u8],
     associated_data: &KeyRefreshAssociatedData<Id>,
 ) -> Box<[u8]> {
-    XofHasher::new_with_dst(b"KeyRefresh SID")
+    Hasher::<P>::new_with_dst(b"KeyRefresh SID")
         .chain_type::<P::Curve>()
         .chain(&shared_randomness)
         .chain(&associated_data.ids)
@@ -375,7 +375,7 @@ impl<P: SchemeParams, Id: PartyId> ProtocolError<Id> for KeyRefreshError<P, Id> 
                     .echo_broadcast
                     .deserialize::<Round2EchoBroadcast<P, Id>>(deserializer)?;
                 let cap_y_ji = r2_eb.cap_ys.try_get("public Elgamal values", reported_by)?;
-                let mut reader = XofHasher::new_with_dst(b"KeyRefresh Round3")
+                let mut reader = Hasher::<P>::new_with_dst(b"KeyRefresh Round3")
                     .chain(&sid)
                     .chain(&rid)
                     .chain(guilty_party)
@@ -468,7 +468,7 @@ pub(super) struct PublicData<P: SchemeParams, Id> {
 
 impl<P: SchemeParams, Id: PartyId> PublicData<P, Id> {
     pub(super) fn hash(&self, sid: &[u8], id: &Id) -> Box<[u8]> {
-        XofHasher::new_with_dst(b"KeyInit")
+        Hasher::<P>::new_with_dst(b"KeyInit")
             .chain(&sid)
             .chain(id)
             .chain(&self.cap_xs)
@@ -1016,7 +1016,7 @@ impl<P: SchemeParams, Id: PartyId> Round<Id> for Round3<P, Id> {
 
         let cap_y = r2_payload.cap_ys.safe_get("Elgamal public keys", my_id)?;
         let y = self.context.ys.safe_get("Elgamal secrets", destination)?;
-        let mut reader = XofHasher::new_with_dst(b"KeyRefresh Round3")
+        let mut reader = Hasher::<P>::new_with_dst(b"KeyRefresh Round3")
             .chain(&self.context.sid)
             .chain(&self.rid_combined)
             .chain(my_id)
@@ -1052,7 +1052,7 @@ impl<P: SchemeParams, Id: PartyId> Round<Id> for Round3<P, Id> {
         let r2_payload = self.r2_payloads.safe_get("Round 2 payloads", from)?;
         let cap_y = r2_payload.cap_ys.safe_get("Elgamal public keys", my_id)?;
         let y = self.context.ys.safe_get("Elgamal secrets", from)?;
-        let mut reader = XofHasher::new_with_dst(b"KeyRefresh Round3")
+        let mut reader = Hasher::<P>::new_with_dst(b"KeyRefresh Round3")
             .chain(&self.context.sid)
             .chain(&self.rid_combined)
             .chain(from)

--- a/src/protocols/key_refresh.rs
+++ b/src/protocols/key_refresh.rs
@@ -2,7 +2,6 @@
 //! This protocol generates an update to the secret key shares and new auxiliary parameters
 //! for ZK proofs (e.g. Paillier keys).
 
-use alloc::boxed::Box;
 use alloc::collections::{BTreeMap, BTreeSet};
 use core::{
     fmt::{self, Debug, Display},
@@ -21,11 +20,10 @@ use manul::{
 };
 use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
-use serde_encoded_bytes::{Hex, SliceLike};
 
 use crate::{
     curve::{secret_split, Point, Scalar},
-    entities::{AuxInfo, KeyShareChange, PublicAuxInfo, PublicAuxInfos, SecretAuxInfo},
+    entities::{AuxInfo, KeyShareChange, PublicAuxInfo, PublicAuxInfos, SecretAuxInfo, Sid},
     paillier::{
         PaillierParams, PublicKeyPaillier, PublicKeyPaillierWire, RPParams, RPParamsWire, RPSecret, SecretKeyPaillier,
         SecretKeyPaillierWire,
@@ -33,7 +31,7 @@ use crate::{
     params::SchemeParams,
     tools::{
         bitvec::BitVec,
-        hashing::{Chain, Hasher},
+        hashing::{Chain, HashOutput, Hasher},
         protocol_shortcuts::{verify_that, DeserializeAll, DowncastMap, GetRound, MapValues, SafeGet, Without},
         Secret,
     },
@@ -207,17 +205,6 @@ pub struct KeyRefreshAssociatedData<Id> {
     pub ids: BTreeSet<Id>,
 }
 
-fn make_sid<P: SchemeParams, Id: PartyId>(
-    shared_randomness: &[u8],
-    associated_data: &KeyRefreshAssociatedData<Id>,
-) -> Box<[u8]> {
-    Hasher::<P>::new_with_dst(b"KeyRefresh SID")
-        .chain_type::<P::Curve>()
-        .chain(&shared_randomness)
-        .chain(&associated_data.ids)
-        .finalize_boxed(P::SECURITY_BITS)
-}
-
 impl<P: SchemeParams, Id: PartyId> ProtocolError<Id> for KeyRefreshError<P, Id> {
     type AssociatedData = KeyRefreshAssociatedData<Id>;
 
@@ -275,7 +262,7 @@ impl<P: SchemeParams, Id: PartyId> ProtocolError<Id> for KeyRefreshError<P, Id> 
         previous_messages: BTreeMap<RoundId, ProtocolMessage>,
         combined_echos: BTreeMap<RoundId, BTreeMap<Id, EchoBroadcast>>,
     ) -> Result<(), ProtocolValidationError> {
-        let sid = make_sid::<P, Id>(shared_randomness, associated_data);
+        let sid = Sid::new::<P, Id>(shared_randomness, &associated_data.ids);
 
         match &self.error {
             Error::R2HashMismatch => {
@@ -467,9 +454,9 @@ pub(super) struct PublicData<P: SchemeParams, Id> {
 }
 
 impl<P: SchemeParams, Id: PartyId> PublicData<P, Id> {
-    pub(super) fn hash(&self, sid: &[u8], id: &Id) -> Box<[u8]> {
+    pub(super) fn hash(&self, sid: &Sid, id: &Id) -> HashOutput {
         Hasher::<P>::new_with_dst(b"KeyInit")
-            .chain(&sid)
+            .chain(sid)
             .chain(id)
             .chain(&self.cap_xs)
             .chain(&self.cap_ys)
@@ -520,12 +507,7 @@ impl<P: SchemeParams, Id: PartyId> EntryPoint<Id> for KeyRefresh<P, Id> {
 
         let other_ids = self.all_ids.clone().without(id);
 
-        let sid = make_sid::<P, Id>(
-            shared_randomness,
-            &KeyRefreshAssociatedData {
-                ids: self.all_ids.clone(),
-            },
-        );
+        let sid = Sid::new::<P, Id>(shared_randomness, &self.all_ids);
 
         // Paillier secret key $p_i$, $q_i$
         let paillier_sk = SecretKeyPaillierWire::<P::Paillier>::random(rng);
@@ -610,7 +592,7 @@ pub(super) struct Context<P: SchemeParams, Id> {
     pub(super) my_id: Id,
     other_ids: BTreeSet<Id>,
     all_ids: BTreeSet<Id>,
-    pub(super) sid: Box<[u8]>,
+    pub(super) sid: Sid,
 }
 
 #[derive(Debug)]
@@ -621,12 +603,11 @@ pub(super) struct Round1<P: SchemeParams, Id: PartyId> {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(super) struct Round1EchoBroadcast {
-    #[serde(with = "SliceLike::<Hex>")]
-    pub(super) cap_v: Box<[u8]>,
+    pub(super) cap_v: HashOutput,
 }
 
 struct Round1Payload {
-    cap_v: Box<[u8]>,
+    cap_v: HashOutput,
 }
 
 impl<P: SchemeParams, Id: PartyId> Round<Id> for Round1<P, Id> {
@@ -697,7 +678,7 @@ impl<P: SchemeParams, Id: PartyId> Round<Id> for Round1<P, Id> {
 struct Round2<P: SchemeParams, Id: PartyId> {
     context: Context<P, Id>,
     public_data: PublicData<P, Id>,
-    cap_vs: BTreeMap<Id, Box<[u8]>>,
+    cap_vs: BTreeMap<Id, HashOutput>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/protocols/misbehavior_tests/aux_gen.rs
+++ b/src/protocols/misbehavior_tests/aux_gen.rs
@@ -21,7 +21,7 @@ use crate::{
     paillier::{PaillierParams, PublicKeyPaillierWire, RPParams, RPParamsWire, RPSecret, SecretKeyPaillierWire},
     params::SchemeParams,
     tools::{
-        hashing::XofHasher,
+        hashing::Hasher,
         protocol_shortcuts_dev::{check_evidence_with_behavior, check_invalid_message_evidence, CheckPart},
     },
     zk::{FacProof, ModProof, PrmProof},
@@ -158,7 +158,7 @@ fn r2_hash_mismatch() {
             if round.id() == 1 {
                 // Send a wrong hash in the Round 1 message
                 let message = Round1EchoBroadcast {
-                    cap_v: XofHasher::new_with_dst(b"bad hash").finalize_boxed(P::SECURITY_BITS),
+                    cap_v: Hasher::<P>::new_with_dst(b"bad hash").finalize_boxed(P::SECURITY_BITS),
                 };
                 let echo_broadcast = EchoBroadcast::new(serializer, message)?;
                 return Ok(echo_broadcast);

--- a/src/protocols/misbehavior_tests/aux_gen.rs
+++ b/src/protocols/misbehavior_tests/aux_gen.rs
@@ -158,7 +158,7 @@ fn r2_hash_mismatch() {
             if round.id() == 1 {
                 // Send a wrong hash in the Round 1 message
                 let message = Round1EchoBroadcast {
-                    cap_v: Hasher::<P>::new_with_dst(b"bad hash").finalize_boxed(P::SECURITY_BITS),
+                    cap_v: Hasher::<P>::new_with_dst(b"bad hash").finalize(),
                 };
                 let echo_broadcast = EchoBroadcast::new(serializer, message)?;
                 return Ok(echo_broadcast);

--- a/src/protocols/misbehavior_tests/aux_gen.rs
+++ b/src/protocols/misbehavior_tests/aux_gen.rs
@@ -158,7 +158,7 @@ fn r2_hash_mismatch() {
             if round.id() == 1 {
                 // Send a wrong hash in the Round 1 message
                 let message = Round1EchoBroadcast {
-                    cap_v: Hasher::<P>::new_with_dst(b"bad hash").finalize(),
+                    cap_v: Hasher::<<P as SchemeParams>::Digest>::new_with_dst(b"bad hash").finalize(P::SECURITY_BITS),
                 };
                 let echo_broadcast = EchoBroadcast::new(serializer, message)?;
                 return Ok(echo_broadcast);

--- a/src/protocols/misbehavior_tests/key_refresh.rs
+++ b/src/protocols/misbehavior_tests/key_refresh.rs
@@ -22,7 +22,7 @@ use crate::{
     paillier::{PaillierParams, PublicKeyPaillierWire, RPParams, RPParamsWire, RPSecret, SecretKeyPaillierWire},
     params::SchemeParams,
     tools::{
-        hashing::XofHasher,
+        hashing::Hasher,
         protocol_shortcuts_dev::{check_evidence_with_behavior, check_invalid_message_evidence, CheckPart},
         Secret,
     },
@@ -160,7 +160,7 @@ fn r2_hash_mismatch() {
             if round.id() == 1 {
                 // Send a wrong hash in the Round 1 message
                 let message = Round1EchoBroadcast {
-                    cap_v: XofHasher::new_with_dst(b"bad hash").finalize_boxed(P::SECURITY_BITS),
+                    cap_v: Hasher::<P>::new_with_dst(b"bad hash").finalize_boxed(P::SECURITY_BITS),
                 };
                 let echo_broadcast = EchoBroadcast::new(serializer, message)?;
                 return Ok(echo_broadcast);

--- a/src/protocols/misbehavior_tests/key_refresh.rs
+++ b/src/protocols/misbehavior_tests/key_refresh.rs
@@ -160,7 +160,7 @@ fn r2_hash_mismatch() {
             if round.id() == 1 {
                 // Send a wrong hash in the Round 1 message
                 let message = Round1EchoBroadcast {
-                    cap_v: Hasher::<P>::new_with_dst(b"bad hash").finalize(),
+                    cap_v: Hasher::<<P as SchemeParams>::Digest>::new_with_dst(b"bad hash").finalize(P::SECURITY_BITS),
                 };
                 let echo_broadcast = EchoBroadcast::new(serializer, message)?;
                 return Ok(echo_broadcast);

--- a/src/protocols/misbehavior_tests/key_refresh.rs
+++ b/src/protocols/misbehavior_tests/key_refresh.rs
@@ -160,7 +160,7 @@ fn r2_hash_mismatch() {
             if round.id() == 1 {
                 // Send a wrong hash in the Round 1 message
                 let message = Round1EchoBroadcast {
-                    cap_v: Hasher::<P>::new_with_dst(b"bad hash").finalize_boxed(P::SECURITY_BITS),
+                    cap_v: Hasher::<P>::new_with_dst(b"bad hash").finalize(),
                 };
                 let echo_broadcast = EchoBroadcast::new(serializer, message)?;
                 return Ok(echo_broadcast);

--- a/src/tools/hashing.rs
+++ b/src/tools/hashing.rs
@@ -61,11 +61,11 @@ impl<P: SchemeParams> Hasher<P> {
         self.0.finalize_xof()
     }
 
-    /// Finalizes into enough bytes to bring the collision probability under `2^(-security_bits)`.
-    pub fn finalize_boxed(self, security_bits: usize) -> HashOutput {
+    /// Finalizes into enough bytes to bring the collision probability to what's required by the scheme's security.
+    pub fn finalize(self) -> HashOutput {
         // A common heuristic for hashes is that the log2 of the collision probability is half the output size.
         // We may not have enough output bytes, but this constitutes the best effort.
-        HashOutput(self.0.finalize_xof().read_boxed((security_bits * 2).div_ceil(8)))
+        HashOutput(self.0.finalize_xof().read_boxed((P::SECURITY_BITS * 2).div_ceil(8)))
     }
 }
 

--- a/src/tools/hashing.rs
+++ b/src/tools/hashing.rs
@@ -25,10 +25,6 @@ pub trait Chain: Sized {
     fn chain<T: Hashable>(self, hashable: &T) -> Self {
         hashable.chain(self)
     }
-
-    fn chain_type<T: HashableType>(self) -> Self {
-        T::chain_type(self)
-    }
 }
 
 /// Wraps an extendable output hash for easier replacement, and standardizes the use of DST.
@@ -75,11 +71,6 @@ where
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HashOutput(#[serde(with = "SliceLike::<Hex>")] Box<[u8]>);
-
-/// A trait allowing hashing of types without having access to their instances.
-pub trait HashableType {
-    fn chain_type<C: Chain>(digest: C) -> C;
-}
 
 /// A trait allowing complex objects to give access to their contents for hashing purposes
 /// without the need of a conversion to a new form (e.g. serialization).

--- a/src/zk/aff_g.rs
+++ b/src/zk/aff_g.rs
@@ -109,7 +109,7 @@ impl<P: SchemeParams> AffGProof<P> {
         // Original: $s^y$. Modified: $s^{-y}$
         let cap_t = setup.commit(&(-secret.y), &mu).to_wire();
 
-        let mut reader = Hasher::<P>::new_with_dst(HASH_TAG)
+        let mut reader = Hasher::<P::Digest>::new_with_dst(HASH_TAG)
             // commitments
             .chain(&cap_a)
             .chain(&cap_b_x)
@@ -176,7 +176,7 @@ impl<P: SchemeParams> AffGProof<P> {
         assert!(public.cap_d.public_key() == public.pk0);
         assert!(public.cap_y.public_key() == public.pk1);
 
-        let mut reader = Hasher::<P>::new_with_dst(HASH_TAG)
+        let mut reader = Hasher::<P::Digest>::new_with_dst(HASH_TAG)
             // commitments
             .chain(&self.cap_a)
             .chain(&self.cap_b_x)

--- a/src/zk/aff_g.rs
+++ b/src/zk/aff_g.rs
@@ -10,7 +10,7 @@ use crate::{
         Randomizer,
     },
     params::{public_signed_from_scalar, scalar_from_signed, secret_scalar_from_signed, SchemeParams},
-    tools::hashing::{Chain, Hashable, XofHasher},
+    tools::hashing::{Chain, Hashable, Hasher},
     uint::{PublicSigned, SecretSigned},
 };
 
@@ -109,7 +109,7 @@ impl<P: SchemeParams> AffGProof<P> {
         // Original: $s^y$. Modified: $s^{-y}$
         let cap_t = setup.commit(&(-secret.y), &mu).to_wire();
 
-        let mut reader = XofHasher::new_with_dst(HASH_TAG)
+        let mut reader = Hasher::<P>::new_with_dst(HASH_TAG)
             // commitments
             .chain(&cap_a)
             .chain(&cap_b_x)
@@ -176,7 +176,7 @@ impl<P: SchemeParams> AffGProof<P> {
         assert!(public.cap_d.public_key() == public.pk0);
         assert!(public.cap_y.public_key() == public.pk1);
 
-        let mut reader = XofHasher::new_with_dst(HASH_TAG)
+        let mut reader = Hasher::<P>::new_with_dst(HASH_TAG)
             // commitments
             .chain(&self.cap_a)
             .chain(&self.cap_b_x)

--- a/src/zk/aff_g_star.rs
+++ b/src/zk/aff_g_star.rs
@@ -115,7 +115,7 @@ impl<P: SchemeParams> AffGStarProof<P> {
             })
             .unzip();
 
-        let mut reader = Hasher::<P>::new_with_dst(HASH_TAG)
+        let mut reader = Hasher::<P::Digest>::new_with_dst(HASH_TAG)
             // commitments
             .chain(&commitments)
             // public parameters
@@ -182,7 +182,7 @@ impl<P: SchemeParams> AffGStarProof<P> {
         assert!(public.cap_d.public_key() == public.pk0);
         assert!(public.cap_y.public_key() == public.pk1);
 
-        let mut reader = Hasher::<P>::new_with_dst(HASH_TAG)
+        let mut reader = Hasher::<P::Digest>::new_with_dst(HASH_TAG)
             // commitments
             .chain(&self.commitments)
             // public parameters

--- a/src/zk/aff_g_star.rs
+++ b/src/zk/aff_g_star.rs
@@ -11,7 +11,7 @@ use crate::{
     params::{scalar_from_signed, secret_scalar_from_signed, SchemeParams},
     tools::{
         bitvec::BitVec,
-        hashing::{Chain, Hashable, XofHasher},
+        hashing::{Chain, Hashable, Hasher},
     },
     uint::{PublicSigned, SecretSigned},
 };
@@ -115,7 +115,7 @@ impl<P: SchemeParams> AffGStarProof<P> {
             })
             .unzip();
 
-        let mut reader = XofHasher::new_with_dst(HASH_TAG)
+        let mut reader = Hasher::<P>::new_with_dst(HASH_TAG)
             // commitments
             .chain(&commitments)
             // public parameters
@@ -182,7 +182,7 @@ impl<P: SchemeParams> AffGStarProof<P> {
         assert!(public.cap_d.public_key() == public.pk0);
         assert!(public.cap_y.public_key() == public.pk1);
 
-        let mut reader = XofHasher::new_with_dst(HASH_TAG)
+        let mut reader = Hasher::<P>::new_with_dst(HASH_TAG)
             // commitments
             .chain(&self.commitments)
             // public parameters

--- a/src/zk/dec.rs
+++ b/src/zk/dec.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     tools::{
         bitvec::BitVec,
-        hashing::{Chain, Hashable, XofHasher},
+        hashing::{Chain, Hashable, Hasher},
     },
     uint::{PublicSigned, SecretSigned},
 };
@@ -139,7 +139,7 @@ impl<P: SchemeParams> DecProof<P> {
             })
             .unzip();
 
-        let mut reader = XofHasher::new_with_dst(HASH_TAG)
+        let mut reader = Hasher::<P>::new_with_dst(HASH_TAG)
             // commitments
             .chain(&commitments)
             // public parameters
@@ -188,7 +188,7 @@ impl<P: SchemeParams> DecProof<P> {
     }
 
     pub fn verify(&self, public: DecPublicInputs<'_, P>, setup: &RPParams<P::Paillier>, aux: &impl Hashable) -> bool {
-        let mut reader = XofHasher::new_with_dst(HASH_TAG)
+        let mut reader = Hasher::<P>::new_with_dst(HASH_TAG)
             // commitments
             .chain(&self.commitments)
             // public parameters

--- a/src/zk/dec.rs
+++ b/src/zk/dec.rs
@@ -139,7 +139,7 @@ impl<P: SchemeParams> DecProof<P> {
             })
             .unzip();
 
-        let mut reader = Hasher::<P>::new_with_dst(HASH_TAG)
+        let mut reader = Hasher::<P::Digest>::new_with_dst(HASH_TAG)
             // commitments
             .chain(&commitments)
             // public parameters
@@ -188,7 +188,7 @@ impl<P: SchemeParams> DecProof<P> {
     }
 
     pub fn verify(&self, public: DecPublicInputs<'_, P>, setup: &RPParams<P::Paillier>, aux: &impl Hashable) -> bool {
-        let mut reader = Hasher::<P>::new_with_dst(HASH_TAG)
+        let mut reader = Hasher::<P::Digest>::new_with_dst(HASH_TAG)
             // commitments
             .chain(&self.commitments)
             // public parameters

--- a/src/zk/elog.rs
+++ b/src/zk/elog.rs
@@ -62,7 +62,7 @@ impl<P: SchemeParams> ElogProof<P> {
         let cap_n = m.mul_by_generator() + public.cap_x * &alpha;
         let cap_b = public.h * &m;
 
-        let mut reader = Hasher::<P>::new_with_dst(HASH_TAG)
+        let mut reader = Hasher::<P::Digest>::new_with_dst(HASH_TAG)
             // commitments
             .chain(&cap_a)
             .chain(&cap_n)
@@ -93,7 +93,7 @@ impl<P: SchemeParams> ElogProof<P> {
     }
 
     pub fn verify(&self, public: ElogPublicInputs<'_, P>, aux: &impl Hashable) -> bool {
-        let mut reader = Hasher::<P>::new_with_dst(HASH_TAG)
+        let mut reader = Hasher::<P::Digest>::new_with_dst(HASH_TAG)
             // commitments
             .chain(&self.cap_a)
             .chain(&self.cap_n)

--- a/src/zk/elog.rs
+++ b/src/zk/elog.rs
@@ -7,7 +7,7 @@ use crate::{
     curve::{Point, Scalar},
     params::SchemeParams,
     tools::{
-        hashing::{Chain, Hashable, XofHasher},
+        hashing::{Chain, Hashable, Hasher},
         Secret,
     },
 };
@@ -62,7 +62,7 @@ impl<P: SchemeParams> ElogProof<P> {
         let cap_n = m.mul_by_generator() + public.cap_x * &alpha;
         let cap_b = public.h * &m;
 
-        let mut reader = XofHasher::new_with_dst(HASH_TAG)
+        let mut reader = Hasher::<P>::new_with_dst(HASH_TAG)
             // commitments
             .chain(&cap_a)
             .chain(&cap_n)
@@ -93,7 +93,7 @@ impl<P: SchemeParams> ElogProof<P> {
     }
 
     pub fn verify(&self, public: ElogPublicInputs<'_, P>, aux: &impl Hashable) -> bool {
-        let mut reader = XofHasher::new_with_dst(HASH_TAG)
+        let mut reader = Hasher::<P>::new_with_dst(HASH_TAG)
             // commitments
             .chain(&self.cap_a)
             .chain(&self.cap_n)

--- a/src/zk/enc_elg.rs
+++ b/src/zk/enc_elg.rs
@@ -86,7 +86,7 @@ impl<P: SchemeParams> EncElgProof<P> {
         let cap_z = beta.mul_by_generator();
         let cap_t = setup.commit(&alpha, &gamma).to_wire();
 
-        let mut reader = Hasher::<P>::new_with_dst(HASH_TAG)
+        let mut reader = Hasher::<P::Digest>::new_with_dst(HASH_TAG)
             // commitments
             .chain(&cap_s)
             .chain(&cap_d)
@@ -134,7 +134,7 @@ impl<P: SchemeParams> EncElgProof<P> {
     ) -> bool {
         assert_eq!(public.cap_c.public_key(), public.pk0);
 
-        let mut reader = Hasher::<P>::new_with_dst(HASH_TAG)
+        let mut reader = Hasher::<P::Digest>::new_with_dst(HASH_TAG)
             // commitments
             .chain(&self.cap_s)
             .chain(&self.cap_d)

--- a/src/zk/enc_elg.rs
+++ b/src/zk/enc_elg.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     params::{public_signed_from_scalar, scalar_from_signed, secret_scalar_from_signed, SchemeParams},
     tools::{
-        hashing::{Chain, Hashable, XofHasher},
+        hashing::{Chain, Hashable, Hasher},
         Secret,
     },
     uint::{PublicSigned, SecretSigned},
@@ -86,7 +86,7 @@ impl<P: SchemeParams> EncElgProof<P> {
         let cap_z = beta.mul_by_generator();
         let cap_t = setup.commit(&alpha, &gamma).to_wire();
 
-        let mut reader = XofHasher::new_with_dst(HASH_TAG)
+        let mut reader = Hasher::<P>::new_with_dst(HASH_TAG)
             // commitments
             .chain(&cap_s)
             .chain(&cap_d)
@@ -134,7 +134,7 @@ impl<P: SchemeParams> EncElgProof<P> {
     ) -> bool {
         assert_eq!(public.cap_c.public_key(), public.pk0);
 
-        let mut reader = XofHasher::new_with_dst(HASH_TAG)
+        let mut reader = Hasher::<P>::new_with_dst(HASH_TAG)
             // commitments
             .chain(&self.cap_s)
             .chain(&self.cap_d)

--- a/src/zk/fac.rs
+++ b/src/zk/fac.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     paillier::{PaillierParams, PublicKeyPaillier, RPCommitmentWire, RPParams, SecretKeyPaillier},
     params::SchemeParams,
-    tools::hashing::{Chain, Hashable, XofHasher},
+    tools::hashing::{Chain, Hashable, Hasher},
     uint::{HasWide, PublicSigned, SecretSigned},
 };
 
@@ -87,7 +87,7 @@ impl<P: SchemeParams> FacProof<P> {
         let cap_t = (&cap_q.pow(&alpha) * &setup.commit_zero_value(&r)).to_wire();
         let cap_q = cap_q.to_wire();
 
-        let mut reader = XofHasher::new_with_dst(HASH_TAG)
+        let mut reader = Hasher::<P>::new_with_dst(HASH_TAG)
             // commitments
             .chain(&cap_p)
             .chain(&cap_q)
@@ -131,7 +131,7 @@ impl<P: SchemeParams> FacProof<P> {
         setup: &RPParams<P::Paillier>,
         aux: &impl Hashable,
     ) -> bool {
-        let mut reader = XofHasher::new_with_dst(HASH_TAG)
+        let mut reader = Hasher::<P>::new_with_dst(HASH_TAG)
             // commitments
             .chain(&self.cap_p)
             .chain(&self.cap_q)

--- a/src/zk/fac.rs
+++ b/src/zk/fac.rs
@@ -87,7 +87,7 @@ impl<P: SchemeParams> FacProof<P> {
         let cap_t = (&cap_q.pow(&alpha) * &setup.commit_zero_value(&r)).to_wire();
         let cap_q = cap_q.to_wire();
 
-        let mut reader = Hasher::<P>::new_with_dst(HASH_TAG)
+        let mut reader = Hasher::<P::Digest>::new_with_dst(HASH_TAG)
             // commitments
             .chain(&cap_p)
             .chain(&cap_q)
@@ -131,7 +131,7 @@ impl<P: SchemeParams> FacProof<P> {
         setup: &RPParams<P::Paillier>,
         aux: &impl Hashable,
     ) -> bool {
-        let mut reader = Hasher::<P>::new_with_dst(HASH_TAG)
+        let mut reader = Hasher::<P::Digest>::new_with_dst(HASH_TAG)
             // commitments
             .chain(&self.cap_p)
             .chain(&self.cap_q)

--- a/src/zk/mod_.rs
+++ b/src/zk/mod_.rs
@@ -36,7 +36,7 @@ struct ModChallenge<P: SchemeParams>(Vec<<P::Paillier as PaillierParams>::Uint>)
 
 impl<P: SchemeParams> ModChallenge<P> {
     fn new(pk: &PublicKeyPaillier<P::Paillier>, commitment: &ModCommitment<P>, aux: &impl Hashable) -> Self {
-        let mut reader = Hasher::<P>::new_with_dst(HASH_TAG)
+        let mut reader = Hasher::<P::Digest>::new_with_dst(HASH_TAG)
             .chain(pk.as_wire())
             .chain(commitment)
             .chain(aux)
@@ -145,7 +145,7 @@ impl<P: SchemeParams> ModProof<P> {
             return false;
         }
 
-        let mut reader = Hasher::<P>::new_with_dst(b"P_mod RNG")
+        let mut reader = Hasher::<P::Digest>::new_with_dst(b"P_mod RNG")
             // commitments
             .chain(&self.commitment)
             // public parameters

--- a/src/zk/mod_.rs
+++ b/src/zk/mod_.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     paillier::{PaillierParams, PublicKeyPaillier, SecretKeyPaillier},
     params::SchemeParams,
-    tools::hashing::{Chain, Hashable, XofHasher},
+    tools::hashing::{Chain, Hashable, Hasher},
     uint::{Exponentiable, IsInvertible, ToMontgomery},
 };
 
@@ -36,7 +36,7 @@ struct ModChallenge<P: SchemeParams>(Vec<<P::Paillier as PaillierParams>::Uint>)
 
 impl<P: SchemeParams> ModChallenge<P> {
     fn new(pk: &PublicKeyPaillier<P::Paillier>, commitment: &ModCommitment<P>, aux: &impl Hashable) -> Self {
-        let mut reader = XofHasher::new_with_dst(HASH_TAG)
+        let mut reader = Hasher::<P>::new_with_dst(HASH_TAG)
             .chain(pk.as_wire())
             .chain(commitment)
             .chain(aux)
@@ -145,7 +145,7 @@ impl<P: SchemeParams> ModProof<P> {
             return false;
         }
 
-        let mut reader = XofHasher::new_with_dst(b"P_mod RNG")
+        let mut reader = Hasher::<P>::new_with_dst(b"P_mod RNG")
             // commitments
             .chain(&self.commitment)
             // public parameters

--- a/src/zk/prm.rs
+++ b/src/zk/prm.rs
@@ -14,7 +14,7 @@ use crate::{
     params::SchemeParams,
     tools::{
         bitvec::BitVec,
-        hashing::{Chain, Hashable, XofHasher},
+        hashing::{Chain, Hashable, Hasher},
     },
     uint::{Exponentiable, SecretUnsigned, ToMontgomery},
 };
@@ -49,7 +49,7 @@ struct PrmChallenge(BitVec);
 
 impl PrmChallenge {
     fn new<P: SchemeParams>(commitment: &PrmCommitment<P>, setup: &RPParams<P::Paillier>, aux: &impl Hashable) -> Self {
-        let mut reader = XofHasher::new_with_dst(HASH_TAG)
+        let mut reader = Hasher::<P>::new_with_dst(HASH_TAG)
             .chain(commitment)
             .chain(&setup.to_wire())
             .chain(aux)

--- a/src/zk/prm.rs
+++ b/src/zk/prm.rs
@@ -49,7 +49,7 @@ struct PrmChallenge(BitVec);
 
 impl PrmChallenge {
     fn new<P: SchemeParams>(commitment: &PrmCommitment<P>, setup: &RPParams<P::Paillier>, aux: &impl Hashable) -> Self {
-        let mut reader = Hasher::<P>::new_with_dst(HASH_TAG)
+        let mut reader = Hasher::<P::Digest>::new_with_dst(HASH_TAG)
             .chain(commitment)
             .chain(&setup.to_wire())
             .chain(aux)

--- a/src/zk/sch.rs
+++ b/src/zk/sch.rs
@@ -10,7 +10,7 @@ use crate::{
     curve::{Point, Scalar},
     params::SchemeParams,
     tools::{
-        hashing::{Chain, Hashable, XofHasher},
+        hashing::{Chain, Hashable, Hasher},
         Secret,
     },
 };
@@ -47,7 +47,7 @@ struct SchChallenge<P: SchemeParams>(Scalar<P>);
 
 impl<P: SchemeParams> SchChallenge<P> {
     fn new(public: &Point<P>, commitment: &SchCommitment<P>, aux: &impl Hashable) -> Self {
-        let mut reader = XofHasher::new_with_dst(HASH_TAG)
+        let mut reader = Hasher::<P>::new_with_dst(HASH_TAG)
             .chain(aux)
             .chain(public)
             .chain(commitment)

--- a/src/zk/sch.rs
+++ b/src/zk/sch.rs
@@ -47,7 +47,7 @@ struct SchChallenge<P: SchemeParams>(Scalar<P>);
 
 impl<P: SchemeParams> SchChallenge<P> {
     fn new(public: &Point<P>, commitment: &SchCommitment<P>, aux: &impl Hashable) -> Self {
-        let mut reader = Hasher::<P>::new_with_dst(HASH_TAG)
+        let mut reader = Hasher::<P::Digest>::new_with_dst(HASH_TAG)
             .chain(aux)
             .chain(public)
             .chain(commitment)


### PR DESCRIPTION
- Make the hasher an associated type of `SchemeParams::Digest`, since we want the hash security to match overall security.
- Renamed `XofHasher` to `Hasher`.
- Wrapped hash output, SID, and EPID into their own types
- Hashing all scheme parameters, not just the curve order