### PR TITLE
Disband `HasWide` and make it easier to define custom `SchemeParams`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.3.1] - in development
+## [0.4.0] - in development
+
+### Changed
+
+- `ExtraWideUint` type moved from `PaillerParams` to `SchemeParams`. ([#205])
+
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Removed `HasWide` requirement from `PaillierParams` types, in favor of `Extendable` and `MulWide` with blanket impl for all `Uint`s. ([#205])
+- Removed `Encoding`, `Serialize`, and `Deserialize` requirement from `PaillierParams` types, in favor of `BoxedEncoding` with blanket impl for all `Uint`s. ([#205])
 
 
 [#205]: https://github.com/entropyxyz/synedrion/pull/205

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `ExtraWideUint` type moved from `PaillerParams` to `SchemeParams`. ([#205])
 - Removed `*Mod` types from `PaillierParams`. ([#205])
+- Removed `CURVE_ORDER` and `CURVE_ORDER_WIDE` from `SchemeParams`. ([#205])
 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `ExtraWideUint` type moved from `PaillerParams` to `SchemeParams`. ([#205])
+- Removed `*Mod` types from `PaillierParams`. ([#205])
 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a `Digest` type to `SchemeParams`. ([#204])
 
 
+### Added
+
+- 128-bit production parameters for Secp256k1 (`k256::ProductionParams128`). ([#205])
+
+
 [#156]: https://github.com/entropyxyz/synedrion/pull/156
 [#170]: https://github.com/entropyxyz/synedrion/pull/170
 [#176]: https://github.com/entropyxyz/synedrion/pull/176

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.3.1] - in development
+
+### Fixed
+
+- Removed `HasWide` requirement from `PaillierParams` types, in favor of `Extendable` and `MulWide` with blanket impl for all `Uint`s. ([#205])
+
+
+[#205]: https://github.com/entropyxyz/synedrion/pull/205
+
+
 ## [0.3.0] - 2025-04-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed `HasWide` requirement from `PaillierParams` types, in favor of `Extendable` and `MulWide` with blanket impl for all `Uint`s. ([#205])
 - Removed `Encoding`, `Serialize`, and `Deserialize` requirement from `PaillierParams` types, in favor of `BoxedEncoding` with blanket impl for all `Uint`s. ([#205])
+- All constants but `SECURITY_BITS` in `SchemeParams` are now derived automatically. ([#205])
 
 
 [#205]: https://github.com/entropyxyz/synedrion/pull/205

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ExtraWideUint` type moved from `PaillerParams` to `SchemeParams`. ([#205])
 - Removed `*Mod` types from `PaillierParams`. ([#205])
 - Removed `CURVE_ORDER` and `CURVE_ORDER_WIDE` from `SchemeParams`. ([#205])
+- Removed `WideCurveUint` from `SchemeParams`. ([#205])
 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - 128-bit production parameters for Secp256k1 (`k256::ProductionParams128`). ([#205])
+- Exposed `PaillierParams` to allow users to define their own parameter sets. ([#205])
 
 
 [#156]: https://github.com/entropyxyz/synedrion/pull/156

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1159,6 +1159,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1201,6 +1207,7 @@ dependencies = [
  "serde_assert",
  "sha3",
  "signature",
+ "static_assertions",
  "test-log",
  "tiny-curve",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "synedrion"
-version = "0.3.0"
+version = "0.3.1-dev"
 dependencies = [
  "bip32",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "synedrion"
-version = "0.3.1-dev"
+version = "0.4.0-dev"
 dependencies = [
  "bip32",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,8 @@ test-log = { version = "0.2.16", default-features = false, features = ["trace", 
 sha3 = { version = "0.10", default-features = false }
 
 [features]
-private-benches = ["k256", "dep:criterion"]
-k256 = ["dep:k256", "bip32?/secp256k1", "sha3"]
+private-benches = ["k256", "criterion"]
+k256 = ["dep:k256", "bip32?/secp256k1", "sha3", "crypto-bigint/extra-sizes"]
 bip32 = ["dep:bip32", "tiny-curve?/bip32"]
 dev = ["tiny-curve", "sha3"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "synedrion"
 authors = ['Entropy Cryptography <engineering@entropy.xyz>']
-version = "0.3.0"
+version = "0.3.1-dev"
 edition = "2021"
 rust-version = "1.83"
 license = "AGPL-3.0-or-later"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "synedrion"
 authors = ['Entropy Cryptography <engineering@entropy.xyz>']
-version = "0.3.1-dev"
+version = "0.4.0-dev"
 edition = "2021"
 rust-version = "1.83"
 license = "AGPL-3.0-or-later"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ crypto-primes = { version = "0.6.2", default-features = false }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde-encoded-bytes = { version = "0.2", default-features = false, features = ["hex", "base64"] }
 displaydoc = { version = "0.2", default-features = false }
+static_assertions = "1"
 
 tiny-curve = { version = "0.2.2", optional = true, features = ["ecdsa", "serde"] }
 k256 = { version = "0.13", optional = true, default-features = false, features = ["ecdsa"] }

--- a/src/curve/arithmetic.rs
+++ b/src/curve/arithmetic.rs
@@ -1,4 +1,4 @@
-use alloc::{format, string::String, vec, vec::Vec};
+use alloc::{boxed::Box, format, string::String, vec, vec::Vec};
 use core::ops::{Add, Mul, Neg, Rem, Sub};
 
 use digest::XofReader;
@@ -25,6 +25,7 @@ use ::{ecdsa::SigningKey, elliptic_curve::SecretKey};
 use crate::{
     params::SchemeParams,
     tools::{hashing::Chain, BoxedRng, Secret},
+    uint::BoxedEncoding,
 };
 
 pub(crate) fn chain_curve<Crv, Chn>(digest: Chn) -> Chn
@@ -198,6 +199,19 @@ where
         Self(<P::Curve as CurveArithmetic>::Scalar::conditional_select(
             &a.0, &b.0, choice,
         ))
+    }
+}
+
+impl<P> BoxedEncoding for Scalar<P>
+where
+    P: SchemeParams,
+{
+    fn to_be_bytes(&self) -> Box<[u8]> {
+        (*self).to_be_bytes().as_ref().into()
+    }
+
+    fn try_from_be_bytes(bytes: &[u8]) -> Result<Self, String> {
+        Self::try_from_be_bytes(bytes)
     }
 }
 

--- a/src/curve/arithmetic.rs
+++ b/src/curve/arithmetic.rs
@@ -1,5 +1,5 @@
 use alloc::{boxed::Box, format, string::String, vec, vec::Vec};
-use core::ops::{Add, Mul, Neg, Rem, Sub};
+use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Rem, Sub, SubAssign};
 
 use digest::XofReader;
 use ecdsa::VerifyingKey;
@@ -334,6 +334,15 @@ where
     }
 }
 
+impl<'a, P> AddAssign<&'a Scalar<P>> for Scalar<P>
+where
+    P: SchemeParams,
+{
+    fn add_assign(&mut self, rhs: &'a Scalar<P>) {
+        self.0 += rhs.0
+    }
+}
+
 impl<P> Add<Scalar<P>> for Scalar<P>
 where
     P: SchemeParams,
@@ -356,17 +365,6 @@ where
     }
 }
 
-impl<P> Add<&Scalar<P>> for Scalar<P>
-where
-    P: SchemeParams,
-{
-    type Output = Self;
-
-    fn add(self, rhs: &Self) -> Self {
-        Self(self.0.add(&rhs.0))
-    }
-}
-
 impl<P> Add<Point<P>> for Point<P>
 where
     P: SchemeParams,
@@ -375,6 +373,15 @@ where
 
     fn add(self, rhs: Self) -> Self {
         Self(self.0.add(&(rhs.0)))
+    }
+}
+
+impl<'a, P> SubAssign<&'a Scalar<P>> for Scalar<P>
+where
+    P: SchemeParams,
+{
+    fn sub_assign(&mut self, rhs: &'a Scalar<P>) {
+        self.0 -= rhs.0
     }
 }
 
@@ -389,14 +396,12 @@ where
     }
 }
 
-impl<P> Sub<&Scalar<P>> for Scalar<P>
+impl<'a, P> MulAssign<&'a Scalar<P>> for Scalar<P>
 where
     P: SchemeParams,
 {
-    type Output = Self;
-
-    fn sub(self, rhs: &Scalar<P>) -> Self {
-        Self(self.0.sub(&(rhs.0)))
+    fn mul_assign(&mut self, rhs: &'a Scalar<P>) {
+        self.0 *= rhs.0
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,12 +51,14 @@ pub use signature;
 
 pub use curve::RecoverableSignature;
 pub use entities::{AuxInfo, KeyShare, KeyShareChange, ThresholdKeyShare};
+pub use paillier::PaillierParams;
 pub use params::SchemeParams;
 pub use protocols::{
     AuxGen, AuxGenAssociatedData, AuxGenProtocol, InteractiveSigning, InteractiveSigningAssociatedData,
     InteractiveSigningProtocol, KeyInit, KeyInitAssociatedData, KeyInitProtocol, KeyRefresh, KeyRefreshAssociatedData,
     KeyRefreshProtocol, KeyResharing, KeyResharingProtocol, NewHolder, OldHolder, PrehashedMessage,
 };
+pub use uint::{BoxedEncoding, Extendable, MulWide};
 
 #[cfg(feature = "bip32")]
 pub use curve::{DeriveChildKey, PublicTweakable, SecretTweakable};

--- a/src/paillier.rs
+++ b/src/paillier.rs
@@ -4,7 +4,9 @@ mod params;
 mod ring_pedersen;
 mod rsa;
 
+pub use params::PaillierParams;
+
 pub(crate) use encryption::{Ciphertext, CiphertextWire, MaskedRandomizer, Randomizer};
 pub(crate) use keys::{PublicKeyPaillier, PublicKeyPaillierWire, SecretKeyPaillier, SecretKeyPaillierWire};
-pub(crate) use params::{chain_paillier_params, PaillierParams};
+pub(crate) use params::chain_paillier_params;
 pub(crate) use ring_pedersen::{RPCommitmentWire, RPParams, RPParamsWire, RPSecret};

--- a/src/paillier/encryption.rs
+++ b/src/paillier/encryption.rs
@@ -17,7 +17,7 @@ use super::{
 };
 use crate::{
     tools::Secret,
-    uint::{Exponentiable, HasWide, PublicSigned, SecretSigned, SecretUnsigned, ToMontgomery},
+    uint::{Exponentiable, Extendable, PublicSigned, SecretSigned, SecretUnsigned, ToMontgomery},
 };
 
 /// A public randomizer-like quantity used in ZK proofs.
@@ -378,13 +378,13 @@ mod tests {
     use crate::{
         dev::PaillierTest,
         tools::Secret,
-        uint::{HasWide, SecretSigned},
+        uint::{Extendable, MulWide, SecretSigned},
     };
 
     /// Calculates `val` modulo `modulus`, returning the result in range `[0, modulus)`.
     fn reduce_unsigned<T>(val: &SecretSigned<T>, modulus: &NonZero<T>) -> T
     where
-        T: Zeroize + Integer + HasWide + Bounded + ConditionallySelectable,
+        T: Zeroize + Integer + Bounded + ConditionallySelectable,
     {
         let abs_result = *val.abs().expose_secret() % modulus;
         if (val.is_negative() & !abs_result.is_zero()).into() {

--- a/src/paillier/encryption.rs
+++ b/src/paillier/encryption.rs
@@ -17,12 +17,12 @@ use super::{
 };
 use crate::{
     tools::Secret,
-    uint::{Exponentiable, Extendable, PublicSigned, SecretSigned, SecretUnsigned, ToMontgomery},
+    uint::{Exponentiable, Extendable, PublicSigned, PublicUint, SecretSigned, SecretUnsigned, ToMontgomery},
 };
 
 /// A public randomizer-like quantity used in ZK proofs.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct MaskedRandomizer<P: PaillierParams>(P::Uint);
+pub(crate) struct MaskedRandomizer<P: PaillierParams>(PublicUint<P::Uint>);
 
 /// A ciphertext randomizer (an invertible element of $\mathbb{Z}_N$).
 #[derive(Debug, Clone)]
@@ -60,7 +60,8 @@ impl<P: PaillierParams> Randomizer<P> {
         MaskedRandomizer(
             (self.randomizer_mod.pow(exponent) * &coeff.randomizer_mod)
                 .expose_secret()
-                .retrieve(),
+                .retrieve()
+                .into(),
         )
     }
 }
@@ -68,7 +69,7 @@ impl<P: PaillierParams> Randomizer<P> {
 /// Paillier ciphertext.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct CiphertextWire<P: PaillierParams> {
-    ciphertext: P::WideUint,
+    ciphertext: PublicUint<P::WideUint>,
     phantom: PhantomData<P>,
 }
 
@@ -311,7 +312,7 @@ impl<P: PaillierParams> Ciphertext<P> {
 
     pub fn to_wire(&self) -> CiphertextWire<P> {
         CiphertextWire {
-            ciphertext: self.ciphertext.retrieve(),
+            ciphertext: self.ciphertext.retrieve().into(),
             phantom: PhantomData,
         }
     }

--- a/src/paillier/encryption.rs
+++ b/src/paillier/encryption.rs
@@ -6,7 +6,7 @@ use core::{
 use crypto_bigint::{
     modular::Retrieve,
     subtle::{Choice, ConditionallyNegatable},
-    Invert, Monty,
+    Integer, Invert, Monty,
 };
 use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
@@ -28,11 +28,11 @@ pub(crate) struct MaskedRandomizer<P: PaillierParams>(PublicUint<P::Uint>);
 #[derive(Debug, Clone)]
 pub(crate) struct Randomizer<P: PaillierParams> {
     randomizer: Secret<P::Uint>,
-    randomizer_mod: Secret<P::UintMod>,
+    randomizer_mod: Secret<<P::Uint as Integer>::Monty>,
 }
 
 impl<P: PaillierParams> Randomizer<P> {
-    fn new_mod(randomizer_mod: Secret<P::UintMod>) -> Self {
+    fn new_mod(randomizer_mod: Secret<<P::Uint as Integer>::Monty>) -> Self {
         let randomizer = randomizer_mod.retrieve();
         Self {
             randomizer,
@@ -86,7 +86,7 @@ impl<P: PaillierParams> CiphertextWire<P> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Ciphertext<P: PaillierParams> {
     pk: PublicKeyPaillier<P>,
-    ciphertext: P::WideUintMod,
+    ciphertext: <P::WideUint as Integer>::Monty,
 }
 
 impl<P: PaillierParams> Ciphertext<P> {
@@ -116,7 +116,7 @@ impl<P: PaillierParams> Ciphertext<P> {
 
         prod_mod.conditional_negate(plaintext_is_negative);
 
-        let factor1 = prod_mod + &P::WideUintMod::one(pk.monty_params_mod_n_squared().clone());
+        let factor1 = prod_mod + &<P::WideUint as Integer>::Monty::one(pk.monty_params_mod_n_squared().clone());
 
         let randomizer = randomizer.randomizer.to_wide();
         let pk_modulus = pk.modulus_signed();
@@ -146,7 +146,7 @@ impl<P: PaillierParams> Ciphertext<P> {
             prod_mod = -prod_mod;
         }
 
-        let factor1 = prod_mod + P::WideUintMod::one(pk.monty_params_mod_n_squared().clone());
+        let factor1 = prod_mod + <P::WideUint as Integer>::Monty::one(pk.monty_params_mod_n_squared().clone());
 
         let randomizer = randomizer.0.to_wide();
         let pk_modulus = pk.modulus_signed();
@@ -219,7 +219,7 @@ impl<P: PaillierParams> Ciphertext<P> {
 
         // Calculate `C^phi mod N^2`. The result is already secret.
         let t = Secret::init_with(|| self.ciphertext.pow(&totient_wide));
-        let one = P::WideUintMod::one(pk.monty_params_mod_n_squared().clone());
+        let one = <P::WideUint as Integer>::Monty::one(pk.monty_params_mod_n_squared().clone());
         let x = (t - &one).retrieve() / pk.modulus_wide_nonzero();
         let x = Secret::init_with(|| {
             P::Uint::try_from_wide(x.expose_secret()).expect("the value is within `Uint` limtis by construction")
@@ -276,7 +276,7 @@ impl<P: PaillierParams> Ciphertext<P> {
     // (e.g. in the P_enc sigma-protocol), we need to process the sign correctly.
     fn homomorphic_mul<V>(self, rhs: &V) -> Self
     where
-        P::WideUintMod: Exponentiable<V>,
+        <P::WideUint as Integer>::Monty: Exponentiable<V>,
     {
         Self {
             pk: self.pk,
@@ -286,7 +286,7 @@ impl<P: PaillierParams> Ciphertext<P> {
 
     fn homomorphic_mul_ref<V>(&self, rhs: &V) -> Self
     where
-        P::WideUintMod: Exponentiable<V>,
+        <P::WideUint as Integer>::Monty: Exponentiable<V>,
     {
         Self {
             pk: self.pk.clone(),
@@ -348,7 +348,7 @@ impl<P: PaillierParams> Add<&Ciphertext<P>> for &Ciphertext<P> {
 
 impl<P: PaillierParams, V> Mul<&V> for Ciphertext<P>
 where
-    P::WideUintMod: Exponentiable<V>,
+    <P::WideUint as Integer>::Monty: Exponentiable<V>,
 {
     type Output = Ciphertext<P>;
     fn mul(self, rhs: &V) -> Ciphertext<P> {
@@ -358,7 +358,7 @@ where
 
 impl<P: PaillierParams, V> Mul<&V> for &Ciphertext<P>
 where
-    P::WideUintMod: Exponentiable<V>,
+    <P::WideUint as Integer>::Monty: Exponentiable<V>,
 {
     type Output = Ciphertext<P>;
     fn mul(self, rhs: &V) -> Ciphertext<P> {

--- a/src/paillier/keys.rs
+++ b/src/paillier/keys.rs
@@ -286,7 +286,7 @@ where
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(bound(serialize = "PublicModulusWire<P>: Serialize"))]
 #[serde(bound(deserialize = "for<'x> PublicModulusWire<P>: Deserialize<'x>"))]
 pub(crate) struct PublicKeyPaillierWire<P: PaillierParams> {
@@ -447,9 +447,9 @@ mod tests {
                 len: 2,
             },
             Token::Field("p"),
-            Token::Str("03e91c6b6f3a29a048826fa4cf85f8fa".to_string()),
+            Token::Str("0xfaf885cfa46f8248a0293a6f6b1ce903".to_string()),
             Token::Field("q"),
-            Token::Str("afb93af2508fc289c196078937d9d8e6".to_string()),
+            Token::Str("0xe6d8d937890796c189c28f50f23ab9af".to_string()),
             Token::StructEnd,
             Token::StructEnd,
         ];

--- a/src/paillier/keys.rs
+++ b/src/paillier/keys.rs
@@ -16,7 +16,7 @@ use super::{
 };
 use crate::{
     tools::Secret,
-    uint::{HasWide, PublicSigned, SecretSigned, SecretUnsigned, ToMontgomery},
+    uint::{Extendable, MulWide, PublicSigned, SecretSigned, SecretUnsigned, ToMontgomery},
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/paillier/keys.rs
+++ b/src/paillier/keys.rs
@@ -54,18 +54,18 @@ pub(crate) struct SecretKeyPaillier<P: PaillierParams> {
     /// The secret primes with some precomputed constants,
     primes: SecretPrimes<P>,
     /// The inverse of the totient modulo the modulus ($\phi(N)^{-1} \mod N$).
-    inv_totient: Secret<P::UintMod>,
+    inv_totient: Secret<<P::Uint as Integer>::Monty>,
     /// The inverse of the modulus modulo the totient ($N^{-1} \mod \phi(N)$).
     inv_modulus: SecretUnsigned<P::Uint>,
     /// $p^{-1} \mod q$, a constant used when joining an RNS-represented number using Garner's algorithm.
-    inv_p_mod_q: Secret<P::HalfUintMod>,
+    inv_p_mod_q: Secret<<P::HalfUint as Integer>::Monty>,
     // $u$ such that $u = -1 \mod p$ and $u = 1 \mod q$. Used for sampling of non-square residues.
-    nonsquare_sampling_constant: Secret<P::UintMod>,
+    nonsquare_sampling_constant: Secret<<P::Uint as Integer>::Monty>,
     // TODO (#162): these should be secret, but they are not zeroizable.
     /// Montgomery parameters for operations modulo $p$.
-    monty_params_mod_p: <P::HalfUintMod as Monty>::Params,
+    monty_params_mod_p: <<P::HalfUint as Integer>::Monty as Monty>::Params,
     /// Montgomery parameters for operations modulo $q$.
-    monty_params_mod_q: <P::HalfUintMod as Monty>::Params,
+    monty_params_mod_q: <<P::HalfUint as Integer>::Monty as Monty>::Params,
     /// The precomputed public key
     public_key: PublicKeyPaillier<P>,
 }
@@ -78,8 +78,10 @@ where
         let primes = secret_key.primes.into_precomputed();
         let modulus = primes.modulus_wire().into_precomputed();
 
-        let monty_params_mod_p = P::HalfUintMod::new_params_vartime(primes.p_half_odd().expose_secret().clone());
-        let monty_params_mod_q = P::HalfUintMod::new_params_vartime(primes.q_half_odd().expose_secret().clone());
+        let monty_params_mod_p =
+            <P::HalfUint as Integer>::Monty::new_params_vartime(primes.p_half_odd().expose_secret().clone());
+        let monty_params_mod_q =
+            <P::HalfUint as Integer>::Monty::new_params_vartime(primes.q_half_odd().expose_secret().clone());
 
         let inv_totient = Secret::init_with(|| {
             primes
@@ -120,7 +122,7 @@ where
 
         let one = Secret::init_with(|| {
             // TODO (#162): `monty_params_mod_q` is cloned here and can remain on the stack.
-            <P::HalfUintMod as Monty>::one(monty_params_mod_q.clone())
+            <<P::HalfUint as Integer>::Monty as Monty>::one(monty_params_mod_q.clone())
         });
         let t = (&inv_p_mod_q + &inv_p_mod_q - one).retrieve();
 
@@ -139,8 +141,9 @@ where
                 .checked_sub(&<P::Uint as Integer>::one())
                 .expect("does not overflow by construction")
         });
-        let nonsquare_sampling_constant =
-            Secret::init_with(|| P::UintMod::new(*u.expose_secret(), modulus.monty_params_mod_n().clone()));
+        let nonsquare_sampling_constant = Secret::init_with(|| {
+            <P::Uint as Integer>::Monty::new(*u.expose_secret(), modulus.monty_params_mod_n().clone())
+        });
 
         let public_key = PublicKeyPaillier::new(modulus);
 
@@ -176,7 +179,7 @@ where
     }
 
     /// Returns $\phi(N)^{-1} \mod N$
-    pub fn inv_totient(&self) -> &Secret<P::UintMod> {
+    pub fn inv_totient(&self) -> &Secret<<P::Uint as Integer>::Monty> {
         &self.inv_totient
     }
 
@@ -189,7 +192,7 @@ where
         &self.public_key
     }
 
-    pub fn rns_split(&self, elem: &P::Uint) -> (P::HalfUintMod, P::HalfUintMod) {
+    pub fn rns_split(&self, elem: &P::Uint) -> (<P::HalfUint as Integer>::Monty, <P::HalfUint as Integer>::Monty) {
         // May be some speed up potential here since we know p and q are small,
         // but it needs to be supported by `crypto-bigint`.
         let p_rem = *elem % self.primes.p_nonzero().expose_secret();
@@ -204,7 +207,11 @@ where
         (p_rem_mod, q_rem_mod)
     }
 
-    fn sqrt_part(&self, x: &P::HalfUintMod, modulus: &Secret<P::HalfUint>) -> Option<P::HalfUintMod> {
+    fn sqrt_part(
+        &self,
+        x: &<P::HalfUint as Integer>::Monty,
+        modulus: &Secret<P::HalfUint>,
+    ) -> Option<<P::HalfUint as Integer>::Monty> {
         // Both `p` and `q` are safe primes, so they're 3 mod 4.
         // This means that if square root exists, it must be of the form `+/- x^((modulus+1)/4)`.
         // Also it means that `(modulus+1)/4 == modulus/4+1`
@@ -223,7 +230,11 @@ where
         }
     }
 
-    pub fn rns_sqrt(&self, rns: &(P::HalfUintMod, P::HalfUintMod)) -> Option<(P::HalfUintMod, P::HalfUintMod)> {
+    #[allow(clippy::type_complexity)]
+    pub fn rns_sqrt(
+        &self,
+        rns: &(<P::HalfUint as Integer>::Monty, <P::HalfUint as Integer>::Monty),
+    ) -> Option<(<P::HalfUint as Integer>::Monty, <P::HalfUint as Integer>::Monty)> {
         // TODO (#73): when we can extract the modulus from `HalfUintMod`, this can be moved there.
         // For now we have to keep this a method of SecretKey to have access to `p` and `q`.
         let (p_part, q_part) = rns;
@@ -235,7 +246,7 @@ where
         }
     }
 
-    pub fn rns_join(&self, rns: &(P::HalfUintMod, P::HalfUintMod)) -> P::Uint {
+    pub fn rns_join(&self, rns: &(<P::HalfUint as Integer>::Monty, <P::HalfUint as Integer>::Monty)) -> P::Uint {
         // We have `a = x mod p`, `b = x mod q`; we want to find `x mod (pq)`.
         // One step of Garner's algorithm:
         // x = a + p * ((b - a) * p^{-1} mod q)
@@ -282,7 +293,7 @@ where
         // Note that since `y` and `u` are invertible
         // (`y` is selected that way, and `u` is not a multiple of either `p` or `q`),
         // the result will be invertible as well.
-        P::UintMod::conditional_select(&w, &-w, b).retrieve()
+        <P::Uint as Integer>::Monty::conditional_select(&w, &-w, b).retrieve()
     }
 }
 
@@ -312,16 +323,16 @@ impl<P: PaillierParams> PublicKeyPaillierWire<P> {
 #[derive(Debug, Clone)]
 pub(crate) struct PublicKeyPaillier<P: PaillierParams> {
     modulus: PublicModulus<P>,
-    monty_params_mod_n_squared: <P::WideUintMod as Monty>::Params,
+    monty_params_mod_n_squared: <<P::WideUint as Integer>::Monty as Monty>::Params,
     /// N converted to Motgomery form modulo N^2
-    modulus_mod_modulus_squared: P::WideUintMod,
+    modulus_mod_modulus_squared: <P::WideUint as Integer>::Monty,
     /// The minimal public key (for hashing purposes)
     public_key_wire: PublicKeyPaillierWire<P>,
 }
 
 impl<P: PaillierParams> PublicKeyPaillier<P> {
     fn new(modulus: PublicModulus<P>) -> Self {
-        let monty_params_mod_n_squared = P::WideUintMod::new_params_vartime(
+        let monty_params_mod_n_squared = <P::WideUint as Integer>::Monty::new_params_vartime(
             Odd::new(modulus.modulus().mul_wide(modulus.modulus())).expect("Square of odd number is odd"),
         );
 
@@ -364,17 +375,17 @@ impl<P: PaillierParams> PublicKeyPaillier<P> {
     }
 
     /// Returns precomputed parameters for integers modulo N
-    pub fn monty_params_mod_n(&self) -> &<P::UintMod as Monty>::Params {
+    pub fn monty_params_mod_n(&self) -> &<<P::Uint as Integer>::Monty as Monty>::Params {
         self.modulus.monty_params_mod_n()
     }
 
     /// Returns precomputed parameters for integers modulo N^2
-    pub fn monty_params_mod_n_squared(&self) -> &<P::WideUintMod as Monty>::Params {
+    pub fn monty_params_mod_n_squared(&self) -> &<<P::WideUint as Integer>::Monty as Monty>::Params {
         &self.monty_params_mod_n_squared
     }
 
     /// Returns the precomputed N in the Montgomery representation modulo N^2
-    pub fn modulus_mod_modulus_squared(&self) -> &P::WideUintMod {
+    pub fn modulus_mod_modulus_squared(&self) -> &<P::WideUint as Integer>::Monty {
         &self.modulus_mod_modulus_squared
     }
 

--- a/src/paillier/params.rs
+++ b/src/paillier/params.rs
@@ -53,7 +53,6 @@ pub trait PaillierParams: core::fmt::Debug + PartialEq + Eq + Clone + Send + Syn
     type UintMod: ConditionallySelectable
         + PowBoundedExp<Self::Uint>
         + PowBoundedExp<Self::WideUint>
-        + PowBoundedExp<Self::ExtraWideUint>
         + Monty<Integer = Self::Uint>
         + Retrieve<Output = Self::Uint>
         + Invert<Output = CtOption<Self::UintMod>>
@@ -64,8 +63,6 @@ pub trait PaillierParams: core::fmt::Debug + PartialEq + Eq + Clone + Send + Syn
     type WideUint: Integer<Monty = Self::WideUintMod>
         + Bounded
         + ConditionallySelectable
-        + MulWide<Self::WideUint, Self::ExtraWideUint>
-        + Extendable<Self::ExtraWideUint>
         + RandomMod
         + BoxedEncoding
         + Zeroize;
@@ -79,13 +76,6 @@ pub trait PaillierParams: core::fmt::Debug + PartialEq + Eq + Clone + Send + Syn
         + Invert<Output = CtOption<Self::WideUintMod>>
         + Retrieve<Output = Self::WideUint>
         + Zeroize;
-
-    /// An integer that fits the squared RSA modulus times a small factor.
-    /// Used in some ZK proofs.
-    // Technically, it doesn't have to be that large, but the time spent multiplying these
-    // is negligible, and when it is used as an exponent, it is bounded anyway.
-    // So it is easier to keep it as a double of `WideUint`.
-    type ExtraWideUint: Bounded + ConditionallySelectable + Integer + RandomMod + BoxedEncoding + Zeroize;
 }
 
 pub(crate) fn chain_paillier_params<P, C>(digest: C) -> C

--- a/src/paillier/params.rs
+++ b/src/paillier/params.rs
@@ -77,14 +77,13 @@ pub trait PaillierParams: core::fmt::Debug + PartialEq + Eq + Clone + Send + Syn
         + Retrieve<Output = Self::WideUint>
         + Zeroize;
 
-    fn are_self_consistent() -> bool {
-        Self::MODULUS_BITS == 2 * Self::PRIME_BITS
-            && Self::HalfUint::BITS >= Self::PRIME_BITS
-            && Self::Uint::BITS >= Self::MODULUS_BITS
-            && Self::Uint::BITS >= Self::HalfUint::BITS
-            && Self::WideUint::BITS >= Self::MODULUS_BITS * 2
-            && Self::WideUint::BITS >= Self::Uint::BITS
-    }
+    /// Evaluates to `true` if the associated constants and the sizes of associated types are self-consistent.
+    const SELF_CONSISTENT: bool = Self::MODULUS_BITS == 2 * Self::PRIME_BITS
+        && Self::HalfUint::BITS >= Self::PRIME_BITS
+        && Self::Uint::BITS >= Self::MODULUS_BITS
+        && Self::Uint::BITS >= Self::HalfUint::BITS
+        && Self::WideUint::BITS >= Self::MODULUS_BITS * 2
+        && Self::WideUint::BITS >= Self::Uint::BITS;
 }
 
 pub(crate) fn chain_paillier_params<P, C>(digest: C) -> C

--- a/src/paillier/params.rs
+++ b/src/paillier/params.rs
@@ -76,6 +76,15 @@ pub trait PaillierParams: core::fmt::Debug + PartialEq + Eq + Clone + Send + Syn
         + Invert<Output = CtOption<Self::WideUintMod>>
         + Retrieve<Output = Self::WideUint>
         + Zeroize;
+
+    fn are_self_consistent() -> bool {
+        Self::MODULUS_BITS == 2 * Self::PRIME_BITS
+            && Self::HalfUint::BITS >= Self::PRIME_BITS
+            && Self::Uint::BITS >= Self::MODULUS_BITS
+            && Self::Uint::BITS >= Self::HalfUint::BITS
+            && Self::WideUint::BITS >= Self::MODULUS_BITS * 2
+            && Self::WideUint::BITS >= Self::Uint::BITS
+    }
 }
 
 pub(crate) fn chain_paillier_params<P, C>(digest: C) -> C

--- a/src/paillier/params.rs
+++ b/src/paillier/params.rs
@@ -8,7 +8,6 @@ use zeroize::Zeroize;
 
 use crate::{
     tools::hashing::Chain,
-    tools::hashing::Hashable,
     uint::{BoxedEncoding, Extendable, MulWide},
 };
 
@@ -42,7 +41,6 @@ pub trait PaillierParams: core::fmt::Debug + PartialEq + Eq + Clone + Send + Syn
         + Gcd<Output = Self::Uint>
         + ConditionallySelectable
         + ConstantTimeGreater
-        + Hashable
         + MulWide<Self::Uint, Self::WideUint>
         + Extendable<Self::WideUint>
         + InvMod<Output = Self::Uint>
@@ -66,7 +64,6 @@ pub trait PaillierParams: core::fmt::Debug + PartialEq + Eq + Clone + Send + Syn
     type WideUint: Integer<Monty = Self::WideUintMod>
         + Bounded
         + ConditionallySelectable
-        + Hashable
         + MulWide<Self::WideUint, Self::ExtraWideUint>
         + Extendable<Self::ExtraWideUint>
         + RandomMod
@@ -88,7 +85,7 @@ pub trait PaillierParams: core::fmt::Debug + PartialEq + Eq + Clone + Send + Syn
     // Technically, it doesn't have to be that large, but the time spent multiplying these
     // is negligible, and when it is used as an exponent, it is bounded anyway.
     // So it is easier to keep it as a double of `WideUint`.
-    type ExtraWideUint: Bounded + ConditionallySelectable + Hashable + Integer + RandomMod + BoxedEncoding + Zeroize;
+    type ExtraWideUint: Bounded + ConditionallySelectable + Integer + RandomMod + BoxedEncoding + Zeroize;
 }
 
 pub(crate) fn chain_paillier_params<P, C>(digest: C) -> C

--- a/src/paillier/params.rs
+++ b/src/paillier/params.rs
@@ -10,7 +10,7 @@ use zeroize::Zeroize;
 use crate::{
     tools::hashing::Chain,
     tools::hashing::Hashable,
-    uint::{HasWide, ToMontgomery},
+    uint::{Extendable, MulWide},
 };
 
 pub trait PaillierParams: core::fmt::Debug + PartialEq + Eq + Clone + Send + Sync {
@@ -28,8 +28,8 @@ pub trait PaillierParams: core::fmt::Debug + PartialEq + Eq + Clone + Send + Syn
         + RandomPrimeWithRng
         + Serialize
         + for<'de> Deserialize<'de>
-        + HasWide<Wide = Self::Uint>
-        + ToMontgomery
+        + MulWide<Self::HalfUint, Self::Uint>
+        + Extendable<Self::Uint>
         + Zeroize;
 
     /// A modulo-residue counterpart of `HalfUint`.
@@ -46,13 +46,13 @@ pub trait PaillierParams: core::fmt::Debug + PartialEq + Eq + Clone + Send + Syn
         + ConstantTimeGreater
         + Encoding<Repr: Zeroize>
         + Hashable
-        + HasWide<Wide = Self::WideUint>
+        + MulWide<Self::Uint, Self::WideUint>
+        + Extendable<Self::WideUint>
         + InvMod<Output = Self::Uint>
         + RandomMod
         + RandomPrimeWithRng
         + Serialize
         + for<'de> Deserialize<'de>
-        + ToMontgomery
         + Zeroize;
 
     /// A modulo-residue counterpart of `Uint`.
@@ -72,11 +72,11 @@ pub trait PaillierParams: core::fmt::Debug + PartialEq + Eq + Clone + Send + Syn
         + ConditionallySelectable
         + Encoding<Repr: Zeroize>
         + Hashable
-        + HasWide<Wide = Self::ExtraWideUint>
+        + MulWide<Self::WideUint, Self::ExtraWideUint>
+        + Extendable<Self::ExtraWideUint>
         + RandomMod
         + Serialize
         + for<'de> Deserialize<'de>
-        + ToMontgomery
         + Zeroize;
 
     /// A modulo-residue counterpart of `WideUint`.

--- a/src/paillier/params.rs
+++ b/src/paillier/params.rs
@@ -11,6 +11,7 @@ use crate::{
     uint::{BoxedEncoding, Extendable, MulWide},
 };
 
+/// Parameters of Paillier encryption.
 pub trait PaillierParams: core::fmt::Debug + PartialEq + Eq + Clone + Send + Sync {
     /// The size of one of the pair of RSA primes.
     const PRIME_BITS: u32;
@@ -53,6 +54,7 @@ pub trait PaillierParams: core::fmt::Debug + PartialEq + Eq + Clone + Send + Syn
         + Zeroize;
 
     /// An integer that fits the squared RSA modulus.
+    ///
     /// Used for Paillier ciphertexts.
     type WideUint: Integer<
             Monty: PowBoundedExp<Self::Uint>

--- a/src/paillier/ring_pedersen.rs
+++ b/src/paillier/ring_pedersen.rs
@@ -11,7 +11,7 @@ use super::{
 };
 use crate::{
     tools::Secret,
-    uint::{Exponentiable, SecretUnsigned, ToMontgomery},
+    uint::{Exponentiable, PublicUint, SecretUnsigned, ToMontgomery},
 };
 
 /// Ring-Pedersen secret.
@@ -151,8 +151,8 @@ impl<P: PaillierParams> RPParams<P> {
     pub fn to_wire(&self) -> RPParamsWire<P> {
         RPParamsWire {
             modulus: self.modulus.to_wire(),
-            base_randomizer: self.base_randomizer.retrieve(),
-            base_value: self.base_value.retrieve(),
+            base_randomizer: self.base_randomizer.retrieve().into(),
+            base_value: self.base_value.retrieve().into(),
         }
     }
 }
@@ -165,10 +165,10 @@ pub(crate) struct RPParamsWire<P: PaillierParams> {
     /// The public modulus $\hat{N}$
     modulus: PublicModulusWire<P>,
     /// The ring-Pedersen base for randomizer exponentiation.
-    base_randomizer: P::Uint, // $t$
+    base_randomizer: PublicUint<P::Uint>, // $t$
     /// The ring-Pedersen base for secret exponentiation
     /// (a number belonging to the group produced by the randomizer base).
-    base_value: P::Uint, // $s = t^\lambda$, where $\lambda$ is the secret
+    base_value: PublicUint<P::Uint>, // $s = t^\lambda$, where $\lambda$ is the secret
 }
 
 impl<P: PaillierParams> RPParamsWire<P> {
@@ -193,7 +193,7 @@ pub(crate) struct RPCommitment<P: PaillierParams>(P::UintMod);
 
 impl<P: PaillierParams> RPCommitment<P> {
     pub fn to_wire(&self) -> RPCommitmentWire<P> {
-        RPCommitmentWire(self.0.retrieve())
+        RPCommitmentWire(self.0.retrieve().into())
     }
 
     /// Raise to the power of `exponent`.
@@ -213,7 +213,7 @@ impl<'a, P: PaillierParams> Mul<&'a RPCommitment<P>> for &'a RPCommitment<P> {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct RPCommitmentWire<P: PaillierParams>(P::Uint);
+pub(crate) struct RPCommitmentWire<P: PaillierParams>(PublicUint<P::Uint>);
 
 impl<P: PaillierParams> RPCommitmentWire<P> {
     pub fn to_precomputed(&self, params: &RPParams<P>) -> RPCommitment<P> {

--- a/src/paillier/rsa.rs
+++ b/src/paillier/rsa.rs
@@ -11,7 +11,8 @@ use super::params::PaillierParams;
 use crate::{
     tools::Secret,
     uint::{
-        Extendable, FromXofReader, IsInvertible, MulWide, PublicSigned, SecretSigned, SecretUnsigned, ToMontgomery,
+        Extendable, FromXofReader, IsInvertible, MulWide, PublicSigned, PublicUint, SecretSigned, SecretUnsigned,
+        ToMontgomery,
     },
 };
 
@@ -225,12 +226,12 @@ impl<P: PaillierParams> SecretPrimes<P> {
 /// The minimized structure containing the public RSA modulus.
 ///
 /// Suitable for serialization or transmission.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-pub(crate) struct PublicModulusWire<P: PaillierParams>(P::Uint);
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct PublicModulusWire<P: PaillierParams>(PublicUint<P::Uint>);
 
 impl<P: PaillierParams> PublicModulusWire<P> {
     fn new(primes: &SecretPrimesWire<P>) -> Self {
-        Self(primes.p.expose_secret().mul_wide(primes.q.expose_secret()))
+        Self(primes.p.expose_secret().mul_wide(primes.q.expose_secret()).into())
     }
 
     pub fn modulus(&self) -> &P::Uint {
@@ -261,7 +262,7 @@ impl<P: PaillierParams> Eq for PublicModulus<P> {}
 
 impl<P: PaillierParams> PublicModulus<P> {
     pub fn new(modulus: PublicModulusWire<P>) -> Self {
-        let odd_modulus = Odd::new(modulus.0).expect("the RSA modulus is odd");
+        let odd_modulus = Odd::new(modulus.0.clone().inner()).expect("the RSA modulus is odd");
         let monty_params_mod_n = P::UintMod::new_params_vartime(odd_modulus);
         Self {
             modulus,
@@ -278,7 +279,7 @@ impl<P: PaillierParams> PublicModulus<P> {
     }
 
     pub fn modulus_nonzero(&self) -> NonZero<P::Uint> {
-        NonZero::new(self.modulus.0).expect("the modulus is non-zero")
+        NonZero::new(self.modulus.0.clone().inner()).expect("the modulus is non-zero")
     }
 
     pub fn modulus_signed(&self) -> PublicSigned<P::WideUint> {

--- a/src/paillier/rsa.rs
+++ b/src/paillier/rsa.rs
@@ -10,7 +10,9 @@ use serde::{Deserialize, Serialize};
 use super::params::PaillierParams;
 use crate::{
     tools::Secret,
-    uint::{FromXofReader, HasWide, IsInvertible, PublicSigned, SecretSigned, SecretUnsigned, ToMontgomery},
+    uint::{
+        Extendable, FromXofReader, IsInvertible, MulWide, PublicSigned, SecretSigned, SecretUnsigned, ToMontgomery,
+    },
 };
 
 #[cfg(test)]

--- a/src/paillier/rsa.rs
+++ b/src/paillier/rsa.rs
@@ -248,7 +248,7 @@ pub(crate) struct PublicModulus<P: PaillierParams> {
     /// The base RSA modulus $N$.
     modulus: PublicModulusWire<P>,
     /// Montgomery representation parameters for modulo $N$.
-    monty_params_mod_n: <P::UintMod as Monty>::Params,
+    monty_params_mod_n: <<P::Uint as Integer>::Monty as Monty>::Params,
 }
 
 impl<P: PaillierParams> PartialEq for PublicModulus<P> {
@@ -263,7 +263,7 @@ impl<P: PaillierParams> Eq for PublicModulus<P> {}
 impl<P: PaillierParams> PublicModulus<P> {
     pub fn new(modulus: PublicModulusWire<P>) -> Self {
         let odd_modulus = Odd::new(modulus.0.clone().inner()).expect("the RSA modulus is odd");
-        let monty_params_mod_n = P::UintMod::new_params_vartime(odd_modulus);
+        let monty_params_mod_n = <P::Uint as Integer>::Monty::new_params_vartime(odd_modulus);
         Self {
             modulus,
             monty_params_mod_n,
@@ -288,7 +288,7 @@ impl<P: PaillierParams> PublicModulus<P> {
             .expect("the modulus can be bounded by 2^MODULUS_BITS")
     }
 
-    pub fn monty_params_mod_n(&self) -> &<P::UintMod as Monty>::Params {
+    pub fn monty_params_mod_n(&self) -> &<<P::Uint as Integer>::Monty as Monty>::Params {
         &self.monty_params_mod_n
     }
 
@@ -316,7 +316,7 @@ impl<P: PaillierParams> PublicModulus<P> {
     }
 
     /// Returns a uniformly chosen invertible quadratic residue modulo $N$, in Montgomery form.
-    pub fn random_quadratic_residue(&self, rng: &mut dyn CryptoRngCore) -> P::UintMod {
+    pub fn random_quadratic_residue(&self, rng: &mut dyn CryptoRngCore) -> <P::Uint as Integer>::Monty {
         self.random_invertible_residue(rng)
             .to_montgomery(&self.monty_params_mod_n)
             .square()

--- a/src/params/conversion.rs
+++ b/src/params/conversion.rs
@@ -6,7 +6,7 @@ use crate::{
     curve::Scalar,
     paillier::PaillierParams,
     tools::Secret,
-    uint::{HasWide, PublicSigned, SecretSigned},
+    uint::{Extendable, PublicSigned, SecretSigned},
 };
 
 fn uint_from_scalar<P: SchemeParams>(value: &Scalar<P>) -> <P::Paillier as PaillierParams>::Uint {

--- a/src/params/conversion.rs
+++ b/src/params/conversion.rs
@@ -1,5 +1,5 @@
-use crypto_bigint::{BitOps, Zero};
-use elliptic_curve::{CurveArithmetic, PrimeField};
+use crypto_bigint::{BitOps, NonZero, Zero};
+use elliptic_curve::{bigint::Encoding, Curve, CurveArithmetic, PrimeField};
 use secrecy::{ExposeSecret, ExposeSecretMut, SecretBox};
 
 use super::traits::SchemeParams;
@@ -9,6 +9,27 @@ use crate::{
     tools::Secret,
     uint::{BoxedEncoding, Extendable, PublicSigned, SecretSigned},
 };
+
+fn curve_order<P: SchemeParams>() -> <P::Paillier as PaillierParams>::Uint {
+    // The current version of `elliptic_curve` uses `crypto-bigint` 0.5,
+    // and our Paillier code uses 0.6. This function converts the integer between the two.
+    let order_repr = P::Curve::ORDER.to_be_bytes();
+    let mut uint_repr = <P::Paillier as PaillierParams>::Uint::zero().to_be_bytes();
+    let uint_repr_len = uint_repr.len();
+    uint_repr
+        .get_mut(uint_repr_len - order_repr.as_ref().len()..)
+        .expect("the curve order fits into `Uint`")
+        .copy_from_slice(order_repr.as_ref());
+    <P::Paillier as PaillierParams>::Uint::try_from_be_bytes(&uint_repr).expect("the representation size is correct")
+}
+
+fn curve_order_uint<P: SchemeParams>() -> NonZero<<P::Paillier as PaillierParams>::Uint> {
+    NonZero::new(curve_order::<P>()).expect("the curve order is non-zero")
+}
+
+fn curve_order_wide_uint<P: SchemeParams>() -> NonZero<<P::Paillier as PaillierParams>::WideUint> {
+    NonZero::new(curve_order::<P>().to_wide()).expect("the curve order is non-zero")
+}
 
 fn uint_from_scalar<P: SchemeParams>(value: &Scalar<P>) -> <P::Paillier as PaillierParams>::Uint {
     let scalar_bytes = value.to_be_bytes();
@@ -30,7 +51,7 @@ fn uint_from_scalar<P: SchemeParams>(value: &Scalar<P>) -> <P::Paillier as Paill
 pub(crate) fn public_signed_from_scalar<P: SchemeParams>(
     value: &Scalar<P>,
 ) -> PublicSigned<<P::Paillier as PaillierParams>::Uint> {
-    let order_bits = P::CURVE_ORDER.as_ref().bits_vartime();
+    let order_bits = curve_order_uint::<P>().bits_vartime();
     PublicSigned::new_positive(uint_from_scalar::<P>(value), order_bits).expect(concat![
         "a curve scalar value is smaller than the half of `PaillierParams::Uint` range, ",
         "so it is still positive when treated as a 2-complement signed value"
@@ -39,7 +60,7 @@ pub(crate) fn public_signed_from_scalar<P: SchemeParams>(
 
 /// Converts an integer to the associated curve scalar type.
 pub(crate) fn scalar_from_wide_uint<P: SchemeParams>(value: &<P::Paillier as PaillierParams>::WideUint) -> Scalar<P> {
-    let r = *value % P::CURVE_ORDER_WIDE;
+    let r = *value % curve_order_wide_uint::<P>();
 
     let repr = r.to_be_bytes();
     let uint_len = repr.as_ref().len();
@@ -81,7 +102,7 @@ pub(crate) fn scalar_from_wide_signed<P: SchemeParams>(
 fn secret_scalar_from_wide_uint<P: SchemeParams>(
     value: &Secret<<P::Paillier as PaillierParams>::WideUint>,
 ) -> Secret<Scalar<P>> {
-    let r = value % &P::CURVE_ORDER_WIDE;
+    let r = value % &curve_order_wide_uint::<P>();
 
     let repr = SecretBox::<[u8]>::from(r.expose_secret().to_be_bytes());
     let uint_len = repr.expose_secret().as_ref().len();
@@ -95,7 +116,7 @@ fn secret_scalar_from_wide_uint<P: SchemeParams>(
                 .get(uint_len - scalar_len..)
                 .expect("Uint is assumed to be bigger than Scalar"),
         )
-        .expect("the value was reduced modulo `CURVE_ORDER`, so it's a valid curve scalar")
+        .expect("the value was reduced modulo curve order, so it's a valid curve scalar")
     })
 }
 
@@ -126,7 +147,7 @@ pub(crate) fn secret_signed_from_scalar<P: SchemeParams>(
 ) -> SecretSigned<<P::Paillier as PaillierParams>::Uint> {
     SecretSigned::new_modulo(
         secret_uint_from_scalar::<P>(value),
-        &P::CURVE_ORDER,
+        &curve_order_uint::<P>(),
         <<P::Curve as CurveArithmetic>::Scalar as PrimeField>::NUM_BITS,
     )
     .expect(concat![

--- a/src/params/dev.rs
+++ b/src/params/dev.rs
@@ -45,10 +45,6 @@ impl SchemeParams for TestParams {
     type WideCurveUint = bigintv05::U384;
     type Digest = Shake256;
     const SECURITY_BITS: usize = 16;
-    const SECURITY_PARAMETER: usize = 32;
-    const L_BOUND: u32 = 32;
-    const EPS_BOUND: u32 = 64;
-    const LP_BOUND: u32 = 160;
     type Paillier = PaillierTest;
     type ExtraWideUint = Uint<{ nlimbs!(640) }>;
 }

--- a/src/params/dev.rs
+++ b/src/params/dev.rs
@@ -1,7 +1,6 @@
 //! Parameters intended for testing, scaled down to small curve orders and integer sizes.
 
 use crypto_bigint::{nlimbs, Uint};
-use elliptic_curve::bigint::{self as bigintv05};
 use serde::{Deserialize, Serialize};
 use sha3::Shake256;
 use tiny_curve::TinyCurve32;
@@ -40,9 +39,6 @@ pub struct TestParams;
 
 impl SchemeParams for TestParams {
     type Curve = TinyCurve32;
-    // TODO: ReprUint is typenum::U192 because of RustCrypto stack internals, hence the U384 here,
-    // but once that is solved, this can be a U128 (or even smaller).
-    type WideCurveUint = bigintv05::U384;
     type Digest = Shake256;
     const SECURITY_BITS: usize = 16;
     type Paillier = PaillierTest;

--- a/src/params/dev.rs
+++ b/src/params/dev.rs
@@ -39,7 +39,6 @@ impl PaillierParams for PaillierTest {
     type UintMod = U256Mod;
     type WideUint = U512;
     type WideUintMod = U512Mod;
-    type ExtraWideUint = U640;
 }
 
 /// Scheme parameters **for testing purposes only**.
@@ -59,6 +58,7 @@ impl SchemeParams for TestParams {
     const EPS_BOUND: u32 = 64;
     const LP_BOUND: u32 = 160;
     type Paillier = PaillierTest;
+    type ExtraWideUint = U640;
     const CURVE_ORDER: NonZero<<Self::Paillier as PaillierParams>::Uint> =
         convert_uint(upcast_uint(Self::Curve::ORDER))
             .to_nz()

--- a/src/params/dev.rs
+++ b/src/params/dev.rs
@@ -1,10 +1,7 @@
 //! Parameters intended for testing, scaled down to small curve orders and integer sizes.
 
-use crypto_bigint::{nlimbs, NonZero, Uint};
-use elliptic_curve::{
-    bigint::{self as bigintv05},
-    Curve,
-};
+use crypto_bigint::{nlimbs, Uint};
+use elliptic_curve::bigint::{self as bigintv05};
 use serde::{Deserialize, Serialize};
 use sha3::Shake256;
 use tiny_curve::TinyCurve32;
@@ -16,7 +13,7 @@ use ::{
     tiny_curve::{PrivateKeyBip32, PublicKeyBip32},
 };
 
-use super::traits::{convert_uint, upcast_uint, SchemeParams};
+use super::traits::SchemeParams;
 use crate::paillier::PaillierParams;
 
 #[cfg(feature = "bip32")]
@@ -54,14 +51,6 @@ impl SchemeParams for TestParams {
     const LP_BOUND: u32 = 160;
     type Paillier = PaillierTest;
     type ExtraWideUint = Uint<{ nlimbs!(640) }>;
-    const CURVE_ORDER: NonZero<<Self::Paillier as PaillierParams>::Uint> =
-        convert_uint(upcast_uint(Self::Curve::ORDER))
-            .to_nz()
-            .expect("Correct by construction");
-    const CURVE_ORDER_WIDE: NonZero<<Self::Paillier as PaillierParams>::WideUint> =
-        convert_uint(upcast_uint(Self::Curve::ORDER))
-            .to_nz()
-            .expect("Correct by construction");
 }
 
 static_assertions::const_assert!(TestParams::SELF_CONSISTENT);

--- a/src/params/dev.rs
+++ b/src/params/dev.rs
@@ -99,10 +99,11 @@ impl SecretTweakable for SigningKey<<TestParams as SchemeParams>::Curve> {
 
 #[cfg(test)]
 mod tests {
-    use super::{SchemeParams, TestParams};
+    use super::{PaillierParams, PaillierTest, SchemeParams, TestParams};
 
     #[test]
     fn parameter_consistency() {
+        assert!(PaillierTest::are_self_consistent());
         assert!(TestParams::are_self_consistent());
     }
 }

--- a/src/params/dev.rs
+++ b/src/params/dev.rs
@@ -25,9 +25,9 @@ pub struct PaillierTest;
 
 impl PaillierParams for PaillierTest {
     const PRIME_BITS: u32 = 128;
-    type HalfUint = Uint<{ nlimbs!(128) }>;
-    type Uint = Uint<{ nlimbs!(256) }>;
-    type WideUint = Uint<{ nlimbs!(512) }>;
+    type HalfUint = Uint<{ nlimbs!(Self::PRIME_BITS) }>;
+    type Uint = Uint<{ nlimbs!(Self::PRIME_BITS * 2) }>;
+    type WideUint = Uint<{ nlimbs!(Self::PRIME_BITS * 4) }>;
 }
 
 static_assertions::const_assert!(PaillierTest::SELF_CONSISTENT);
@@ -42,7 +42,7 @@ impl SchemeParams for TestParams {
     type Digest = Shake256;
     const SECURITY_BITS: usize = 16;
     type Paillier = PaillierTest;
-    type ExtraWideUint = Uint<{ nlimbs!(640) }>;
+    type ExtraWideUint = Uint<{ nlimbs!(Self::Paillier::PRIME_BITS * 5) }>;
 }
 
 static_assertions::const_assert!(TestParams::SELF_CONSISTENT);

--- a/src/params/dev.rs
+++ b/src/params/dev.rs
@@ -1,6 +1,6 @@
 //! Parameters intended for testing, scaled down to small curve orders and integer sizes.
 
-use crypto_bigint::{modular::MontyForm, nlimbs, NonZero, U1024, U128, U256, U512};
+use crypto_bigint::{modular::MontyForm, nlimbs, NonZero, U128, U256, U512, U640};
 use elliptic_curve::{
     bigint::{self as bigintv05},
     Curve,
@@ -39,7 +39,7 @@ impl PaillierParams for PaillierTest {
     type UintMod = U256Mod;
     type WideUint = U512;
     type WideUintMod = U512Mod;
-    type ExtraWideUint = U1024;
+    type ExtraWideUint = U640;
 }
 
 /// Scheme parameters **for testing purposes only**.

--- a/src/params/dev.rs
+++ b/src/params/dev.rs
@@ -41,6 +41,8 @@ impl PaillierParams for PaillierTest {
     type WideUintMod = U512Mod;
 }
 
+static_assertions::const_assert!(PaillierTest::SELF_CONSISTENT);
+
 /// Scheme parameters **for testing purposes only**.
 /// Security is weakened to allow for faster execution.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord)]
@@ -69,6 +71,8 @@ impl SchemeParams for TestParams {
             .expect("Correct by construction");
 }
 
+static_assertions::const_assert!(TestParams::SELF_CONSISTENT);
+
 #[cfg(feature = "bip32")]
 impl PublicTweakable for VerifyingKey<<TestParams as SchemeParams>::Curve> {
     type Bip32Pk = PublicKeyBip32<<TestParams as SchemeParams>::Curve>;
@@ -94,16 +98,5 @@ impl SecretTweakable for SigningKey<<TestParams as SchemeParams>::Curve> {
 
     fn key_from_tweakable_sk(sk: &Self::Bip32Sk) -> Self {
         SigningKey::from(sk.as_ref())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{PaillierParams, PaillierTest, SchemeParams, TestParams};
-
-    #[test]
-    fn parameter_consistency() {
-        assert!(PaillierTest::are_self_consistent());
-        assert!(TestParams::are_self_consistent());
     }
 }

--- a/src/params/dev.rs
+++ b/src/params/dev.rs
@@ -1,6 +1,6 @@
 //! Parameters intended for testing, scaled down to small curve orders and integer sizes.
 
-use crypto_bigint::{modular::MontyForm, nlimbs, NonZero, U128, U256, U512, U640};
+use crypto_bigint::{nlimbs, NonZero, Uint};
 use elliptic_curve::{
     bigint::{self as bigintv05},
     Curve,
@@ -22,10 +22,6 @@ use crate::paillier::PaillierParams;
 #[cfg(feature = "bip32")]
 use crate::curve::{PublicTweakable, SecretTweakable};
 
-type U128Mod = MontyForm<{ nlimbs!(128) }>;
-type U256Mod = MontyForm<{ nlimbs!(256) }>;
-type U512Mod = MontyForm<{ nlimbs!(512) }>;
-
 /// Paillier parameters **for testing purposes only**.
 /// Security is weakened to allow for faster execution.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -33,12 +29,9 @@ pub struct PaillierTest;
 
 impl PaillierParams for PaillierTest {
     const PRIME_BITS: u32 = 128;
-    type HalfUint = U128;
-    type HalfUintMod = U128Mod;
-    type Uint = U256;
-    type UintMod = U256Mod;
-    type WideUint = U512;
-    type WideUintMod = U512Mod;
+    type HalfUint = Uint<{ nlimbs!(128) }>;
+    type Uint = Uint<{ nlimbs!(256) }>;
+    type WideUint = Uint<{ nlimbs!(512) }>;
 }
 
 static_assertions::const_assert!(PaillierTest::SELF_CONSISTENT);
@@ -60,7 +53,7 @@ impl SchemeParams for TestParams {
     const EPS_BOUND: u32 = 64;
     const LP_BOUND: u32 = 160;
     type Paillier = PaillierTest;
-    type ExtraWideUint = U640;
+    type ExtraWideUint = Uint<{ nlimbs!(640) }>;
     const CURVE_ORDER: NonZero<<Self::Paillier as PaillierParams>::Uint> =
         convert_uint(upcast_uint(Self::Curve::ORDER))
             .to_nz()

--- a/src/params/k256.rs
+++ b/src/params/k256.rs
@@ -57,10 +57,6 @@ impl SchemeParams for ProductionParams112 {
     type WideCurveUint = bigintv05::U512;
     type Digest = Shake256;
     const SECURITY_BITS: usize = 112;
-    const SECURITY_PARAMETER: usize = 256;
-    const L_BOUND: u32 = 256;
-    const EPS_BOUND: u32 = Self::L_BOUND * 2;
-    const LP_BOUND: u32 = Self::L_BOUND * 5;
     type Paillier = PaillierProduction112;
     type ExtraWideUint = Uint<{ nlimbs!(5120) }>;
 }
@@ -76,10 +72,6 @@ impl SchemeParams for ProductionParams128 {
     type WideCurveUint = bigintv05::U512;
     type Digest = Shake256;
     const SECURITY_BITS: usize = 128;
-    const SECURITY_PARAMETER: usize = 256;
-    const L_BOUND: u32 = 256;
-    const EPS_BOUND: u32 = 1024;
-    const LP_BOUND: u32 = 1792;
     type Paillier = PaillierProduction128;
     type ExtraWideUint = Uint<{ nlimbs!(7680) }>;
 }

--- a/src/params/k256.rs
+++ b/src/params/k256.rs
@@ -6,18 +6,15 @@ use core::fmt::Debug;
 // and `k256` depends on the released one.
 // So as long as that is the case, `k256` `Uint` is separate
 // from the one used throughout the crate.
-use crypto_bigint::{nlimbs, NonZero, Uint};
-use elliptic_curve::{
-    bigint::{self as bigintv05},
-    Curve,
-};
+use crypto_bigint::{nlimbs, Uint};
+use elliptic_curve::bigint::{self as bigintv05};
 use serde::{Deserialize, Serialize};
 use sha3::Shake256;
 
 #[cfg(feature = "bip32")]
 use ecdsa::{SigningKey, VerifyingKey};
 
-use super::traits::{convert_uint, upcast_uint, SchemeParams};
+use super::traits::SchemeParams;
 use crate::paillier::PaillierParams;
 
 #[cfg(feature = "bip32")]
@@ -66,14 +63,6 @@ impl SchemeParams for ProductionParams112 {
     const LP_BOUND: u32 = Self::L_BOUND * 5;
     type Paillier = PaillierProduction112;
     type ExtraWideUint = Uint<{ nlimbs!(5120) }>;
-    const CURVE_ORDER: NonZero<<Self::Paillier as PaillierParams>::Uint> =
-        convert_uint(upcast_uint(Self::Curve::ORDER))
-            .to_nz()
-            .expect("Correct by construction");
-    const CURVE_ORDER_WIDE: NonZero<<Self::Paillier as PaillierParams>::WideUint> =
-        convert_uint(upcast_uint(Self::Curve::ORDER))
-            .to_nz()
-            .expect("Correct by construction");
 }
 
 static_assertions::const_assert!(ProductionParams112::SELF_CONSISTENT);
@@ -93,14 +82,6 @@ impl SchemeParams for ProductionParams128 {
     const LP_BOUND: u32 = 1792;
     type Paillier = PaillierProduction128;
     type ExtraWideUint = Uint<{ nlimbs!(7680) }>;
-    const CURVE_ORDER: NonZero<<Self::Paillier as PaillierParams>::Uint> =
-        convert_uint(upcast_uint(Self::Curve::ORDER))
-            .to_nz()
-            .expect("Correct by construction");
-    const CURVE_ORDER_WIDE: NonZero<<Self::Paillier as PaillierParams>::WideUint> =
-        convert_uint(upcast_uint(Self::Curve::ORDER))
-            .to_nz()
-            .expect("Correct by construction");
 }
 
 static_assertions::const_assert!(ProductionParams128::SELF_CONSISTENT);

--- a/src/params/k256.rs
+++ b/src/params/k256.rs
@@ -6,7 +6,7 @@ use core::fmt::Debug;
 // and `k256` depends on the released one.
 // So as long as that is the case, `k256` `Uint` is separate
 // from the one used throughout the crate.
-use crypto_bigint::{modular::MontyForm, nlimbs, NonZero, U1024, U2048, U4096, U8192};
+use crypto_bigint::{modular::MontyForm, nlimbs, NonZero, Uint, U1024, U2048, U4096};
 use elliptic_curve::{
     bigint::{self as bigintv05},
     Curve,
@@ -40,7 +40,7 @@ impl PaillierParams for PaillierProduction112 {
     type UintMod = U2048Mod;
     type WideUint = U4096;
     type WideUintMod = U4096Mod;
-    type ExtraWideUint = U8192;
+    type ExtraWideUint = Uint<{ nlimbs!(5120) }>;
 }
 
 /// Production strength parameters.

--- a/src/params/k256.rs
+++ b/src/params/k256.rs
@@ -40,7 +40,6 @@ impl PaillierParams for PaillierProduction112 {
     type UintMod = U2048Mod;
     type WideUint = U4096;
     type WideUintMod = U4096Mod;
-    type ExtraWideUint = Uint<{ nlimbs!(5120) }>;
 }
 
 /// Production strength parameters.
@@ -57,6 +56,7 @@ impl SchemeParams for ProductionParams112 {
     const EPS_BOUND: u32 = Self::L_BOUND * 2;
     const LP_BOUND: u32 = Self::L_BOUND * 5;
     type Paillier = PaillierProduction112;
+    type ExtraWideUint = Uint<{ nlimbs!(5120) }>;
     const CURVE_ORDER: NonZero<<Self::Paillier as PaillierParams>::Uint> =
         convert_uint(upcast_uint(Self::Curve::ORDER))
             .to_nz()

--- a/src/params/k256.rs
+++ b/src/params/k256.rs
@@ -7,7 +7,6 @@ use core::fmt::Debug;
 // So as long as that is the case, `k256` `Uint` is separate
 // from the one used throughout the crate.
 use crypto_bigint::{nlimbs, Uint};
-use elliptic_curve::bigint::{self as bigintv05};
 use serde::{Deserialize, Serialize};
 use sha3::Shake256;
 
@@ -54,7 +53,6 @@ pub struct ProductionParams112;
 
 impl SchemeParams for ProductionParams112 {
     type Curve = k256::Secp256k1;
-    type WideCurveUint = bigintv05::U512;
     type Digest = Shake256;
     const SECURITY_BITS: usize = 112;
     type Paillier = PaillierProduction112;
@@ -69,7 +67,6 @@ pub struct ProductionParams128;
 
 impl SchemeParams for ProductionParams128 {
     type Curve = k256::Secp256k1;
-    type WideCurveUint = bigintv05::U512;
     type Digest = Shake256;
     const SECURITY_BITS: usize = 128;
     type Paillier = PaillierProduction128;

--- a/src/params/k256.rs
+++ b/src/params/k256.rs
@@ -6,7 +6,7 @@ use core::fmt::Debug;
 // and `k256` depends on the released one.
 // So as long as that is the case, `k256` `Uint` is separate
 // from the one used throughout the crate.
-use crypto_bigint::{modular::MontyForm, nlimbs, NonZero, Uint};
+use crypto_bigint::{nlimbs, NonZero, Uint};
 use elliptic_curve::{
     bigint::{self as bigintv05},
     Curve,
@@ -31,11 +31,8 @@ pub struct PaillierProduction112;
 impl PaillierParams for PaillierProduction112 {
     const PRIME_BITS: u32 = 1024;
     type HalfUint = Uint<{ nlimbs!(1024) }>;
-    type HalfUintMod = MontyForm<{ nlimbs!(1024) }>;
     type Uint = Uint<{ nlimbs!(2048) }>;
-    type UintMod = MontyForm<{ nlimbs!(2048) }>;
     type WideUint = Uint<{ nlimbs!(4096) }>;
-    type WideUintMod = MontyForm<{ nlimbs!(4096) }>;
 }
 
 static_assertions::const_assert!(PaillierProduction112::SELF_CONSISTENT);
@@ -48,11 +45,8 @@ pub struct PaillierProduction128;
 impl PaillierParams for PaillierProduction128 {
     const PRIME_BITS: u32 = 1536;
     type HalfUint = Uint<{ nlimbs!(1536) }>;
-    type HalfUintMod = MontyForm<{ nlimbs!(1536) }>;
     type Uint = Uint<{ nlimbs!(3072) }>;
-    type UintMod = MontyForm<{ nlimbs!(3072) }>;
     type WideUint = Uint<{ nlimbs!(6144) }>;
-    type WideUintMod = MontyForm<{ nlimbs!(6144) }>;
 }
 
 static_assertions::const_assert!(PaillierProduction128::SELF_CONSISTENT);

--- a/src/params/k256.rs
+++ b/src/params/k256.rs
@@ -6,7 +6,7 @@ use core::fmt::Debug;
 // and `k256` depends on the released one.
 // So as long as that is the case, `k256` `Uint` is separate
 // from the one used throughout the crate.
-use crypto_bigint::{modular::MontyForm, nlimbs, NonZero, Uint, U1024, U2048, U4096};
+use crypto_bigint::{modular::MontyForm, nlimbs, NonZero, Uint};
 use elliptic_curve::{
     bigint::{self as bigintv05},
     Curve,
@@ -23,10 +23,6 @@ use crate::paillier::PaillierParams;
 #[cfg(feature = "bip32")]
 use crate::curve::{PublicTweakable, SecretTweakable};
 
-type U1024Mod = MontyForm<{ nlimbs!(1024) }>;
-type U2048Mod = MontyForm<{ nlimbs!(2048) }>;
-type U4096Mod = MontyForm<{ nlimbs!(4096) }>;
-
 /// Paillier parameters corresponding to 112 bits of security.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PaillierProduction112;
@@ -34,17 +30,34 @@ pub struct PaillierProduction112;
 // Source of the values: Appendix C.1.
 impl PaillierParams for PaillierProduction112 {
     const PRIME_BITS: u32 = 1024;
-    type HalfUint = U1024;
-    type HalfUintMod = U1024Mod;
-    type Uint = U2048;
-    type UintMod = U2048Mod;
-    type WideUint = U4096;
-    type WideUintMod = U4096Mod;
+    type HalfUint = Uint<{ nlimbs!(1024) }>;
+    type HalfUintMod = MontyForm<{ nlimbs!(1024) }>;
+    type Uint = Uint<{ nlimbs!(2048) }>;
+    type UintMod = MontyForm<{ nlimbs!(2048) }>;
+    type WideUint = Uint<{ nlimbs!(4096) }>;
+    type WideUintMod = MontyForm<{ nlimbs!(4096) }>;
 }
 
 static_assertions::const_assert!(PaillierProduction112::SELF_CONSISTENT);
 
-/// Production strength parameters.
+/// Paillier parameters corresponding to 128 bits of security.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PaillierProduction128;
+
+// Source of the values: Appendix C.1.
+impl PaillierParams for PaillierProduction128 {
+    const PRIME_BITS: u32 = 1536;
+    type HalfUint = Uint<{ nlimbs!(1536) }>;
+    type HalfUintMod = MontyForm<{ nlimbs!(1536) }>;
+    type Uint = Uint<{ nlimbs!(3072) }>;
+    type UintMod = MontyForm<{ nlimbs!(3072) }>;
+    type WideUint = Uint<{ nlimbs!(6144) }>;
+    type WideUintMod = MontyForm<{ nlimbs!(6144) }>;
+}
+
+static_assertions::const_assert!(PaillierProduction128::SELF_CONSISTENT);
+
+/// Production strength parameters corresponding to 112 bits of security.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Ord, PartialOrd)]
 pub struct ProductionParams112;
 
@@ -70,6 +83,33 @@ impl SchemeParams for ProductionParams112 {
 }
 
 static_assertions::const_assert!(ProductionParams112::SELF_CONSISTENT);
+
+/// Production strength parameters corresponding to 128 bits of security.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Ord, PartialOrd)]
+pub struct ProductionParams128;
+
+impl SchemeParams for ProductionParams128 {
+    type Curve = k256::Secp256k1;
+    type WideCurveUint = bigintv05::U512;
+    type Digest = Shake256;
+    const SECURITY_BITS: usize = 128;
+    const SECURITY_PARAMETER: usize = 256;
+    const L_BOUND: u32 = 256;
+    const EPS_BOUND: u32 = 1024;
+    const LP_BOUND: u32 = 1792;
+    type Paillier = PaillierProduction128;
+    type ExtraWideUint = Uint<{ nlimbs!(7680) }>;
+    const CURVE_ORDER: NonZero<<Self::Paillier as PaillierParams>::Uint> =
+        convert_uint(upcast_uint(Self::Curve::ORDER))
+            .to_nz()
+            .expect("Correct by construction");
+    const CURVE_ORDER_WIDE: NonZero<<Self::Paillier as PaillierParams>::WideUint> =
+        convert_uint(upcast_uint(Self::Curve::ORDER))
+            .to_nz()
+            .expect("Correct by construction");
+}
+
+static_assertions::const_assert!(ProductionParams128::SELF_CONSISTENT);
 
 #[cfg(feature = "bip32")]
 impl SecretTweakable for SigningKey<<ProductionParams112 as SchemeParams>::Curve> {

--- a/src/params/k256.rs
+++ b/src/params/k256.rs
@@ -26,9 +26,9 @@ pub struct PaillierProduction112;
 // Source of the values: Appendix C.1.
 impl PaillierParams for PaillierProduction112 {
     const PRIME_BITS: u32 = 1024;
-    type HalfUint = Uint<{ nlimbs!(1024) }>;
-    type Uint = Uint<{ nlimbs!(2048) }>;
-    type WideUint = Uint<{ nlimbs!(4096) }>;
+    type HalfUint = Uint<{ nlimbs!(Self::PRIME_BITS) }>;
+    type Uint = Uint<{ nlimbs!(Self::PRIME_BITS * 2) }>;
+    type WideUint = Uint<{ nlimbs!(Self::PRIME_BITS * 4) }>;
 }
 
 static_assertions::const_assert!(PaillierProduction112::SELF_CONSISTENT);
@@ -40,9 +40,9 @@ pub struct PaillierProduction128;
 // Source of the values: Appendix C.1.
 impl PaillierParams for PaillierProduction128 {
     const PRIME_BITS: u32 = 1536;
-    type HalfUint = Uint<{ nlimbs!(1536) }>;
-    type Uint = Uint<{ nlimbs!(3072) }>;
-    type WideUint = Uint<{ nlimbs!(6144) }>;
+    type HalfUint = Uint<{ nlimbs!(Self::PRIME_BITS) }>;
+    type Uint = Uint<{ nlimbs!(Self::PRIME_BITS * 2) }>;
+    type WideUint = Uint<{ nlimbs!(Self::PRIME_BITS * 4) }>;
 }
 
 static_assertions::const_assert!(PaillierProduction128::SELF_CONSISTENT);
@@ -56,7 +56,7 @@ impl SchemeParams for ProductionParams112 {
     type Digest = Shake256;
     const SECURITY_BITS: usize = 112;
     type Paillier = PaillierProduction112;
-    type ExtraWideUint = Uint<{ nlimbs!(5120) }>;
+    type ExtraWideUint = Uint<{ nlimbs!(Self::Paillier::PRIME_BITS * 5) }>;
 }
 
 static_assertions::const_assert!(ProductionParams112::SELF_CONSISTENT);
@@ -70,7 +70,7 @@ impl SchemeParams for ProductionParams128 {
     type Digest = Shake256;
     const SECURITY_BITS: usize = 128;
     type Paillier = PaillierProduction128;
-    type ExtraWideUint = Uint<{ nlimbs!(7680) }>;
+    type ExtraWideUint = Uint<{ nlimbs!(Self::Paillier::PRIME_BITS * 5) }>;
 }
 
 static_assertions::const_assert!(ProductionParams128::SELF_CONSISTENT);

--- a/src/params/k256.rs
+++ b/src/params/k256.rs
@@ -42,6 +42,8 @@ impl PaillierParams for PaillierProduction112 {
     type WideUintMod = U4096Mod;
 }
 
+static_assertions::const_assert!(PaillierProduction112::SELF_CONSISTENT);
+
 /// Production strength parameters.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Ord, PartialOrd)]
 pub struct ProductionParams112;
@@ -67,6 +69,8 @@ impl SchemeParams for ProductionParams112 {
             .expect("Correct by construction");
 }
 
+static_assertions::const_assert!(ProductionParams112::SELF_CONSISTENT);
+
 #[cfg(feature = "bip32")]
 impl SecretTweakable for SigningKey<<ProductionParams112 as SchemeParams>::Curve> {
     type Bip32Sk = SigningKey<<ProductionParams112 as SchemeParams>::Curve>;
@@ -88,16 +92,5 @@ impl PublicTweakable for VerifyingKey<<ProductionParams112 as SchemeParams>::Cur
     }
     fn key_from_tweakable_pk(pk: &Self::Bip32Pk) -> Self {
         *pk
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{PaillierParams, PaillierProduction112, ProductionParams112, SchemeParams};
-
-    #[test]
-    fn parameter_consistency() {
-        assert!(PaillierProduction112::are_self_consistent());
-        assert!(ProductionParams112::are_self_consistent());
     }
 }

--- a/src/params/k256.rs
+++ b/src/params/k256.rs
@@ -93,10 +93,11 @@ impl PublicTweakable for VerifyingKey<<ProductionParams112 as SchemeParams>::Cur
 
 #[cfg(test)]
 mod tests {
-    use super::{ProductionParams112, SchemeParams};
+    use super::{PaillierParams, PaillierProduction112, ProductionParams112, SchemeParams};
 
     #[test]
     fn parameter_consistency() {
+        assert!(PaillierProduction112::are_self_consistent());
         assert!(ProductionParams112::are_self_consistent());
     }
 }

--- a/src/params/traits.rs
+++ b/src/params/traits.rs
@@ -89,7 +89,7 @@ where
     /// when treated as a 2-complement signed integer).
     type Paillier: PaillierParams<
         WideUint: Extendable<Self::ExtraWideUint>,
-        UintMod: PowBoundedExp<Self::ExtraWideUint>,
+        Uint: Integer<Monty: PowBoundedExp<Self::ExtraWideUint>>,
     >;
 
     /// An integer that fits the squared RSA modulus times a small factor.

--- a/src/params/traits.rs
+++ b/src/params/traits.rs
@@ -83,10 +83,6 @@ where
     /// The error bound for range checks (referred to in the paper as the slackness parameter).
     const EPS_BOUND: u32; // $\eps$, in paper $= 2 \ell$ (see Table 2)
     /// The parameters of the Paillier encryption.
-    ///
-    /// Note: `PaillierParams::Uint` must be able to contain the full range of `Scalar` values
-    /// plus one bit (so that any curve scalar still represents a positive value
-    /// when treated as a 2-complement signed integer).
     type Paillier: PaillierParams<
         WideUint: Extendable<Self::ExtraWideUint>,
         Uint: Integer<Monty: PowBoundedExp<Self::ExtraWideUint>>,

--- a/src/params/traits.rs
+++ b/src/params/traits.rs
@@ -96,9 +96,9 @@ where
     /// Used in some ZK proofs.
     type ExtraWideUint: Bounded + ConditionallySelectable + Integer + RandomMod + BoxedEncoding + Zeroize;
 
-    /// Returns ``true`` if the parameters satisfy a set of inequalities
+    /// Evaluates to ``true`` if the parameters satisfy a set of inequalities
     /// required for them to be used for the CGGMP scheme.
-    fn are_self_consistent() -> bool {
+    const SELF_CONSISTENT: bool =
         // See Appendix C.1
         <Self::Curve as CurveArithmetic>::Scalar::NUM_BITS == Self::SECURITY_PARAMETER as u32
         && Self::L_BOUND >= Self::SECURITY_PARAMETER as u32
@@ -115,8 +115,7 @@ where
         // `< 2^(L + EPS + MODULUS_BITS * 2)`.
         // Therefore `ExtraWideUint::BITS` must fit `L + EPS + MODULUS_BITS * 2` bits,
         // and we make it strictly greater to accommodate 1 bit for the sign.
-        && Self::ExtraWideUint::BITS > Self::Paillier::MODULUS_BITS * 2 + Self::L_BOUND + Self::EPS_BOUND
-    }
+        && Self::ExtraWideUint::BITS > Self::Paillier::MODULUS_BITS * 2 + Self::L_BOUND + Self::EPS_BOUND;
 }
 
 pub(crate) fn chain_scheme_params<P, C>(digest: C) -> C

--- a/src/params/traits.rs
+++ b/src/params/traits.rs
@@ -4,7 +4,7 @@ use core::{fmt::Debug, ops::Add};
 // and `k256` depends on the released one.
 // So as long as that is the case, `k256` `Uint` is separate
 // from the one used throughout the crate.
-use crypto_bigint::{subtle::ConditionallySelectable, Bounded, Integer, NonZero, PowBoundedExp, RandomMod};
+use crypto_bigint::{subtle::ConditionallySelectable, Bounded, Integer, PowBoundedExp, RandomMod};
 use digest::{ExtendableOutput, Update};
 use ecdsa::hazmat::{DigestPrimitive, SignPrimitive, VerifyPrimitive};
 use elliptic_curve::{
@@ -23,27 +23,6 @@ use crate::{
     tools::hashing::Chain,
     uint::{BoxedEncoding, Extendable},
 };
-
-#[cfg(any(test, feature = "k256", feature = "dev"))]
-#[allow(clippy::indexing_slicing)]
-pub(crate) const fn upcast_uint<const N1: usize, const N2: usize>(
-    value: elliptic_curve::bigint::Uint<N1>,
-) -> elliptic_curve::bigint::Uint<N2> {
-    assert!(N2 >= N1, "Upcast target must be bigger than the upcast candidate");
-    let mut result_words = [0; N2];
-    let mut i = 0;
-    let words = value.as_words();
-    while i < N1 {
-        result_words[i] = words[i];
-        i += 1;
-    }
-    elliptic_curve::bigint::Uint::from_words(result_words)
-}
-
-#[cfg(any(test, feature = "k256", feature = "dev"))]
-pub(crate) const fn convert_uint<const N: usize>(value: elliptic_curve::bigint::Uint<N>) -> crypto_bigint::Uint<N> {
-    crypto_bigint::Uint::from_words(value.to_words())
-}
 
 /// Signing scheme parameters.
 pub trait SchemeParams: 'static + Debug + Clone + Send + PartialEq + Eq + Send + Sync + Ord + Copy + Serialize
@@ -70,10 +49,6 @@ where
 
     /// The number of bits of security provided by the scheme.
     const SECURITY_BITS: usize; // $m$ in the paper
-    /// The order of the curve.
-    const CURVE_ORDER: NonZero<<Self::Paillier as PaillierParams>::Uint>; // $q$
-    /// The order of the curve as a wide integer.
-    const CURVE_ORDER_WIDE: NonZero<<Self::Paillier as PaillierParams>::WideUint>;
     /// The scheme's statistical security parameter.
     const SECURITY_PARAMETER: usize; // $\kappa$ in the paper
     /// The bound for secret values.
@@ -127,35 +102,4 @@ where
         .chain_bytes(&P::L_BOUND.to_be_bytes())
         .chain_bytes(&P::LP_BOUND.to_be_bytes())
         .chain_bytes(&P::EPS_BOUND.to_be_bytes())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{
-        bigintv05::{U256, U64},
-        upcast_uint,
-    };
-
-    #[test]
-    fn upcast_uint_results_in_a_bigger_type() {
-        let n = U64::from_u8(10);
-        let expected = U256::from_u8(10);
-        let bigger_n: U256 = upcast_uint(n);
-
-        assert_eq!(bigger_n, expected);
-    }
-
-    #[test]
-    #[should_panic(expected = "Upcast target must be bigger than the upcast candidate")]
-    fn upcast_uint_panics_in_test_if_actually_attempting_downcast() {
-        let n256 = U256::from_u8(8);
-        let _n: U64 = upcast_uint(n256);
-    }
-
-    #[test]
-    fn upcast_uint_allows_casting_to_same_size() {
-        let n256 = U256::from_u8(8);
-        let n: U256 = upcast_uint(n256);
-        assert_eq!(n, n256)
-    }
 }

--- a/src/params/traits.rs
+++ b/src/params/traits.rs
@@ -35,12 +35,10 @@ where
         + VerifyPrimitive<Self::Curve>,
     <Self::Curve as CurveArithmetic>::Scalar: SignPrimitive<Self::Curve> + Ord,
     <<Self::Curve as Curve>::FieldBytesSize as Add>::Output: ArrayLength<u8>,
-    <Self::Curve as Curve>::Uint: Concat<Output = Self::WideCurveUint>,
+    <Self::Curve as Curve>::Uint: Concat<Output: bigintv05::Integer + Split<Output = <Self::Curve as Curve>::Uint>>,
 {
     /// The elliptic curve (of prime order) used.
     type Curve: CurveArithmetic + PrimeCurve + DigestPrimitive;
-    /// Double the curve Scalar-width integer type.
-    type WideCurveUint: bigintv05::Integer + Split<Output = <Self::Curve as Curve>::Uint>;
 
     /// The hash that will be used for protocol's internal purposes.
     ///

--- a/src/tools/secret.rs
+++ b/src/tools/secret.rs
@@ -1,7 +1,7 @@
 use alloc::boxed::Box;
 use core::{
     fmt::Debug,
-    ops::{Add, AddAssign, Div, DivAssign, Mul, Neg, Rem, RemAssign, Sub},
+    ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign},
 };
 
 use crypto_bigint::{
@@ -61,10 +61,6 @@ where
     fn clone(&self) -> Self {
         Self::init_with(|| self.0.expose_secret().clone())
     }
-
-    fn clone_from(&mut self, source: &Self) {
-        *self = source.clone()
-    }
 }
 
 impl<T> Serialize for Secret<T>
@@ -118,7 +114,7 @@ where
 
 impl<T> WrappingAdd for Secret<T>
 where
-    T: Zeroize + Clone + WrappingAdd + for<'a> Add<&'a T, Output = T>,
+    T: Zeroize + Clone + WrappingAdd + for<'a> AddAssign<&'a T>,
 {
     fn wrapping_add(&self, rhs: &Self) -> Self {
         Secret::init_with(|| self.expose_secret().wrapping_add(rhs.expose_secret()))
@@ -127,7 +123,7 @@ where
 
 impl<T> WrappingSub for Secret<T>
 where
-    T: Zeroize + Clone + WrappingSub + for<'a> Sub<&'a T, Output = T>,
+    T: Zeroize + Clone + WrappingSub + for<'a> SubAssign<&'a T>,
 {
     fn wrapping_sub(&self, rhs: &Self) -> Self {
         Secret::init_with(|| self.expose_secret().wrapping_sub(rhs.expose_secret()))
@@ -136,7 +132,7 @@ where
 
 impl<T> WrappingMul for Secret<T>
 where
-    T: Zeroize + Clone + WrappingMul + for<'a> Mul<&'a T, Output = T>,
+    T: Zeroize + Clone + WrappingMul + for<'a> MulAssign<&'a T>,
 {
     fn wrapping_mul(&self, rhs: &Self) -> Self {
         Secret::init_with(|| self.expose_secret().wrapping_mul(rhs.expose_secret()))
@@ -158,60 +154,69 @@ where
 
 // Addition
 
-impl<T> AddAssign<Secret<T>> for Secret<T>
+impl<'a, T> AddAssign<&'a T> for Secret<T>
 where
-    T: Zeroize + Clone + for<'a> Add<&'a T, Output = T>,
+    T: Zeroize + Clone + AddAssign<&'a T>,
 {
-    fn add_assign(&mut self, rhs: Secret<T>) {
-        // Can be done without reallocation when Integer is bound on AddAssign.
-        // See https://github.com/RustCrypto/crypto-bigint/pull/716
-        *self = &*self + &rhs
+    fn add_assign(&mut self, rhs: &'a T) {
+        *self.expose_secret_mut() += rhs
     }
 }
 
-impl<'a, T> Add<&'a T> for &Secret<T>
+impl<T> AddAssign<Secret<T>> for Secret<T>
 where
-    T: Zeroize + Clone + Add<&'a T, Output = T>,
+    T: Zeroize + Clone + for<'a> AddAssign<&'a T>,
 {
-    type Output = Secret<T>;
-    fn add(self, rhs: &'a T) -> Self::Output {
-        Secret::init_with(|| self.expose_secret().clone() + rhs)
+    fn add_assign(&mut self, rhs: Secret<T>) {
+        *self += rhs.expose_secret()
     }
 }
 
 impl<'a, T> Add<&'a T> for Secret<T>
 where
-    T: Zeroize + Clone + Add<&'a T, Output = T>,
+    T: Zeroize + Clone + AddAssign<&'a T>,
 {
     type Output = Secret<T>;
     fn add(self, rhs: &'a T) -> Self::Output {
-        &self + rhs
+        let mut result = self;
+        result += rhs;
+        result
+    }
+}
+
+impl<'a, T> Add<&'a T> for &Secret<T>
+where
+    T: Zeroize + Clone + AddAssign<&'a T>,
+{
+    type Output = Secret<T>;
+    fn add(self, rhs: &'a T) -> Self::Output {
+        self.clone() + rhs
     }
 }
 
 impl<T> Add<Secret<T>> for Secret<T>
 where
-    T: Zeroize + Clone + for<'a> Add<&'a T, Output = T>,
+    T: Zeroize + Clone + for<'a> AddAssign<&'a T>,
 {
     type Output = Secret<T>;
     fn add(self, rhs: Secret<T>) -> Self::Output {
-        &self + rhs.expose_secret()
+        self + rhs.expose_secret()
     }
 }
 
 impl<'a, T> Add<&'a Secret<T>> for Secret<T>
 where
-    T: Zeroize + Clone + Add<&'a T, Output = T>,
+    T: Zeroize + Clone + AddAssign<&'a T>,
 {
     type Output = Secret<T>;
     fn add(self, rhs: &'a Secret<T>) -> Self::Output {
-        &self + rhs.expose_secret()
+        self + rhs.expose_secret()
     }
 }
 
 impl<T> Add<Secret<T>> for &Secret<T>
 where
-    T: Zeroize + Clone + for<'a> Add<&'a T, Output = T>,
+    T: Zeroize + Clone + for<'a> AddAssign<&'a T>,
 {
     type Output = Secret<T>;
     fn add(self, rhs: Secret<T>) -> Self::Output {
@@ -221,7 +226,7 @@ where
 
 impl<'a, T> Add<&'a Secret<T>> for &Secret<T>
 where
-    T: Zeroize + Clone + Add<&'a T, Output = T>,
+    T: Zeroize + Clone + AddAssign<&'a T>,
 {
     type Output = Secret<T>;
     fn add(self, rhs: &'a Secret<T>) -> Self::Output {
@@ -231,99 +236,105 @@ where
 
 // Subtraction
 
-impl<'a, T> Sub<&'a T> for &Secret<T>
-where
-    T: Zeroize + Clone + Sub<&'a T, Output = T>,
-{
-    type Output = Secret<T>;
-    fn sub(self, rhs: &'a T) -> Self::Output {
-        Secret::init_with(|| self.expose_secret().clone() - rhs)
-    }
-}
-
 impl<'a, T> Sub<&'a T> for Secret<T>
 where
-    T: Zeroize + Clone + Sub<&'a T, Output = T>,
+    T: Zeroize + Clone + SubAssign<&'a T>,
 {
     type Output = Secret<T>;
     fn sub(self, rhs: &'a T) -> Self::Output {
-        &self - rhs
+        let mut result = self;
+        *result.expose_secret_mut() -= rhs;
+        result
     }
 }
 
 impl<T> Sub<Secret<T>> for Secret<T>
 where
-    T: Zeroize + Clone + for<'a> Sub<&'a T, Output = T>,
+    T: Zeroize + Clone + for<'a> SubAssign<&'a T>,
 {
     type Output = Secret<T>;
     fn sub(self, rhs: Secret<T>) -> Self::Output {
-        &self - rhs.expose_secret()
+        self - rhs.expose_secret()
     }
 }
 
 // Multiplication
 
-impl<'a, T> Mul<&'a T> for &Secret<T>
+impl<'a, T> MulAssign<&'a T> for Secret<T>
 where
-    T: Zeroize + Clone + Mul<&'a T, Output = T>,
+    T: Zeroize + Clone + MulAssign<&'a T>,
 {
-    type Output = Secret<T>;
-    fn mul(self, rhs: &'a T) -> Self::Output {
-        Secret::init_with(|| self.expose_secret().clone() * rhs)
-    }
-}
-
-impl<T> Mul<T> for &Secret<T>
-where
-    T: Zeroize + Clone + for<'a> Mul<&'a T, Output = T>,
-{
-    type Output = Secret<T>;
-    fn mul(self, rhs: T) -> Self::Output {
-        Secret::init_with(|| self.expose_secret().clone() * &rhs)
+    fn mul_assign(&mut self, rhs: &'a T) {
+        *self.expose_secret_mut() *= rhs
     }
 }
 
 impl<'a, T> Mul<&'a T> for Secret<T>
 where
-    T: Zeroize + Clone + Mul<&'a T, Output = T>,
+    T: Zeroize + Clone + MulAssign<&'a T>,
 {
     type Output = Secret<T>;
     fn mul(self, rhs: &'a T) -> Self::Output {
-        &self * rhs
+        let mut result = self;
+        result *= rhs;
+        result
+    }
+}
+
+impl<'a, T> Mul<&'a T> for &Secret<T>
+where
+    T: Zeroize + Clone + MulAssign<&'a T>,
+{
+    type Output = Secret<T>;
+    fn mul(self, rhs: &'a T) -> Self::Output {
+        self.clone() * rhs
+    }
+}
+
+impl<T> Mul<T> for &Secret<T>
+where
+    T: Zeroize + Clone + for<'a> MulAssign<&'a T>,
+{
+    type Output = Secret<T>;
+    fn mul(self, rhs: T) -> Self::Output {
+        self.clone() * &rhs
     }
 }
 
 impl<T> Mul<T> for Secret<T>
 where
-    T: Zeroize + Clone + for<'a> Mul<&'a T, Output = T>,
+    T: Zeroize + Clone + for<'a> MulAssign<&'a T>,
 {
     type Output = Secret<T>;
     fn mul(self, rhs: T) -> Self::Output {
-        &self * &rhs
+        self * &rhs
     }
 }
 
 impl<T> Mul<Secret<T>> for Secret<T>
 where
-    T: Zeroize + Clone + for<'a> Mul<&'a T, Output = T>,
+    T: Zeroize + Clone + for<'a> MulAssign<&'a T>,
 {
     type Output = Secret<T>;
     fn mul(self, rhs: Secret<T>) -> Self::Output {
-        &self * rhs.expose_secret()
+        self * rhs.expose_secret()
     }
 }
 
 impl<'a, T> Mul<&'a Secret<T>> for Secret<T>
 where
-    T: Zeroize + Clone + Mul<&'a T, Output = T>,
+    T: Zeroize + Clone + MulAssign<&'a T>,
 {
     type Output = Secret<T>;
     fn mul(self, rhs: &'a Secret<T>) -> Self::Output {
-        &self * rhs.expose_secret()
+        self * rhs.expose_secret()
     }
 }
 
-impl<'a, T: Zeroize + Clone + Mul<&'a T, Output = T>> Mul<&'a Secret<T>> for &Secret<T> {
+impl<'a, T> Mul<&'a Secret<T>> for &Secret<T>
+where
+    T: Zeroize + Clone + MulAssign<&'a T>,
+{
     type Output = Secret<T>;
     fn mul(self, rhs: &'a Secret<T>) -> Self::Output {
         self * rhs.expose_secret()

--- a/src/tools/secret.rs
+++ b/src/tools/secret.rs
@@ -15,7 +15,7 @@ use zeroize::Zeroize;
 use crate::{
     curve::{Point, Scalar},
     params::SchemeParams,
-    uint::{Exponentiable, HasWide},
+    uint::{Exponentiable, Extendable},
 };
 
 /// A helper wrapper for managing secret values.
@@ -140,10 +140,13 @@ where
 
 impl<T> Secret<T>
 where
-    T: Zeroize + Clone + HasWide,
-    T::Wide: Zeroize,
+    T: Zeroize + Clone,
 {
-    pub fn to_wide(&self) -> Secret<<T as HasWide>::Wide> {
+    pub fn to_wide<W>(&self) -> Secret<W>
+    where
+        T: Extendable<W>,
+        W: Zeroize + Clone,
+    {
         Secret::init_with(|| self.expose_secret().to_wide())
     }
 }

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -1,9 +1,11 @@
 mod public_signed;
+mod public_uint;
 mod secret_signed;
 mod secret_unsigned;
 mod traits;
 
 pub(crate) use public_signed::PublicSigned;
+pub(crate) use public_uint::PublicUint;
 pub(crate) use secret_signed::SecretSigned;
 pub(crate) use secret_unsigned::SecretUnsigned;
-pub(crate) use traits::{Exponentiable, Extendable, FromXofReader, IsInvertible, MulWide, ToMontgomery};
+pub(crate) use traits::{BoxedEncoding, Exponentiable, Extendable, FromXofReader, IsInvertible, MulWide, ToMontgomery};

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -6,4 +6,4 @@ mod traits;
 pub(crate) use public_signed::PublicSigned;
 pub(crate) use secret_signed::SecretSigned;
 pub(crate) use secret_unsigned::SecretUnsigned;
-pub(crate) use traits::{Exponentiable, FromXofReader, HasWide, IsInvertible, ToMontgomery};
+pub(crate) use traits::{Exponentiable, Extendable, FromXofReader, IsInvertible, MulWide, ToMontgomery};

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -4,8 +4,10 @@ mod secret_signed;
 mod secret_unsigned;
 mod traits;
 
+pub use traits::{BoxedEncoding, Extendable, MulWide};
+
 pub(crate) use public_signed::PublicSigned;
 pub(crate) use public_uint::PublicUint;
 pub(crate) use secret_signed::SecretSigned;
 pub(crate) use secret_unsigned::SecretUnsigned;
-pub(crate) use traits::{BoxedEncoding, Exponentiable, Extendable, FromXofReader, IsInvertible, MulWide, ToMontgomery};
+pub(crate) use traits::{Exponentiable, FromXofReader, IsInvertible, ToMontgomery};

--- a/src/uint/public_signed.rs
+++ b/src/uint/public_signed.rs
@@ -6,7 +6,7 @@ use digest::XofReader;
 use serde::{Deserialize, Serialize};
 use serde_encoded_bytes::{Hex, SliceLike};
 
-use super::{FromXofReader, HasWide};
+use super::{Extendable, FromXofReader};
 
 /// A packed representation for serializing Signed objects.
 /// Usually they have the bound set much lower than the full size of the integer,
@@ -200,11 +200,14 @@ where
 
 impl<T> PublicSigned<T>
 where
-    T: Bounded + HasWide + Encoding + Integer,
-    T::Wide: Bounded,
+    T: Bounded + Encoding + Integer,
 {
     /// Returns a [`PublicSigned`] with the same value, but twice the bit-width.
-    pub fn to_wide(&self) -> PublicSigned<T::Wide> {
+    pub fn to_wide<W>(&self) -> PublicSigned<W>
+    where
+        T: Extendable<W>,
+        W: Integer + Bounded,
+    {
         let abs_result = self.abs().to_wide();
         PublicSigned::new_from_abs(abs_result, self.bound, self.is_negative())
             .expect("the value fit the bound before, and the bound won't overflow for `WideUint`")

--- a/src/uint/public_signed.rs
+++ b/src/uint/public_signed.rs
@@ -1,12 +1,12 @@
 use alloc::{boxed::Box, format, string::String};
 use core::ops::Neg;
 
-use crypto_bigint::{Bounded, Encoding, Integer};
+use crypto_bigint::{Bounded, Integer};
 use digest::XofReader;
 use serde::{Deserialize, Serialize};
 use serde_encoded_bytes::{Hex, SliceLike};
 
-use super::{Extendable, FromXofReader};
+use super::{BoxedEncoding, Extendable, FromXofReader};
 
 /// A packed representation for serializing Signed objects.
 /// Usually they have the bound set much lower than the full size of the integer,
@@ -22,7 +22,7 @@ struct PackedSigned {
 
 impl<T> From<PublicSigned<T>> for PackedSigned
 where
-    T: Integer + Encoding + Bounded,
+    T: Integer + BoxedEncoding + Bounded,
 {
     fn from(val: PublicSigned<T>) -> Self {
         let repr = val.abs().to_be_bytes();
@@ -41,7 +41,7 @@ where
 
 impl<T> TryFrom<PackedSigned> for PublicSigned<T>
 where
-    T: Integer + Encoding + Bounded,
+    T: Integer + BoxedEncoding + Bounded,
 {
     type Error = String;
     fn try_from(val: PackedSigned) -> Result<Self, Self::Error> {
@@ -60,7 +60,7 @@ where
             .get_mut((repr_len - bytes_len)..)
             .expect("Just checked that val's data all fit in a T")
             .copy_from_slice(&val.abs_bytes);
-        let abs_value = T::from_be_bytes(repr);
+        let abs_value = T::try_from_be_bytes(&repr).expect("`repr` has the correct length");
 
         Self::new_from_abs(abs_value, val.bound, val.is_negative)
             .ok_or_else(|| "Invalid values for the signed integer".into())
@@ -72,7 +72,7 @@ where
 #[serde(
     try_from = "PackedSigned",
     into = "PackedSigned",
-    bound = "T: Integer + Encoding + Bounded"
+    bound = "T: Integer + BoxedEncoding + Bounded"
 )]
 pub(crate) struct PublicSigned<T> {
     /// bound on the bit size of the absolute value
@@ -173,7 +173,7 @@ where
 
 impl<T> PublicSigned<T>
 where
-    T: Integer + Bounded + Encoding,
+    T: Integer + Bounded + BoxedEncoding,
 {
     /// Returns a value in range `±2^{exp}` derived from an extendable-output hash.
     ///
@@ -200,7 +200,7 @@ where
 
 impl<T> PublicSigned<T>
 where
-    T: Bounded + Encoding + Integer,
+    T: Bounded + BoxedEncoding + Integer,
 {
     /// Returns a [`PublicSigned`] with the same value, but twice the bit-width.
     pub fn to_wide<W>(&self) -> PublicSigned<W>

--- a/src/uint/public_uint.rs
+++ b/src/uint/public_uint.rs
@@ -1,0 +1,59 @@
+use alloc::boxed::Box;
+
+use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
+use serde_encoded_bytes::{Hex, SliceLike};
+
+use super::BoxedEncoding;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PublicUint<T>(T);
+
+impl<T> PublicUint<T> {
+    pub fn inner(self) -> T {
+        self.0
+    }
+}
+
+impl<T> Serialize for PublicUint<T>
+where
+    T: BoxedEncoding,
+{
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        SliceLike::<Hex>::serialize(&self.0.to_be_bytes(), serializer)
+    }
+}
+
+impl<'de, T> Deserialize<'de> for PublicUint<T>
+where
+    T: BoxedEncoding,
+{
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let bytes: Box<[u8]> = SliceLike::<Hex>::deserialize(deserializer)?;
+        T::try_from_be_bytes(&bytes).map(Self).map_err(D::Error::custom)
+    }
+}
+
+impl<T> core::ops::Deref for PublicUint<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> core::ops::DerefMut for PublicUint<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T> AsRef<T> for PublicUint<T> {
+    fn as_ref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> From<T> for PublicUint<T> {
+    fn from(source: T) -> Self {
+        Self(source)
+    }
+}

--- a/src/uint/secret_signed.rs
+++ b/src/uint/secret_signed.rs
@@ -220,26 +220,6 @@ where
         )
         .expect("the new bound is valid since the sum of the constituent bounds fits in a `T::Wide`")
     }
-
-    /// Multiplies two numbers and returns a new [`SecretSigned`] of twice the bit-width.
-    pub fn mul_wide<R, W>(&self, rhs: &SecretSigned<R>) -> SecretSigned<W>
-    where
-        T: MulWide<R, W>,
-        R: Zeroize + Integer + Bounded + ConditionallySelectable,
-        W: Zeroize + Integer + Bounded + ConditionallySelectable,
-    {
-        let abs_value = Secret::init_with(|| {
-            self.abs_value()
-                .expose_secret()
-                .mul_wide(rhs.abs_value().expose_secret())
-        });
-        SecretSigned::new_from_abs(
-            abs_value,
-            self.bound() + rhs.bound(),
-            self.is_negative() ^ rhs.is_negative(),
-        )
-        .expect("the new bound is valid since the sum of the constituent bounds fits in a `T::Wide`")
-    }
 }
 
 impl<T> CheckedAdd<SecretSigned<T>> for SecretSigned<T>

--- a/src/uint/secret_signed.rs
+++ b/src/uint/secret_signed.rs
@@ -4,11 +4,11 @@ use crypto_bigint::{
     rand_core::CryptoRngCore,
     subtle::{Choice, ConditionallySelectable, ConstantTimeLess, CtOption},
     zeroize::Zeroize,
-    BitOps, Bounded, CheckedAdd, CheckedMul, CheckedSub, Integer, NonZero, RandomMod, ShlVartime, WrappingAdd,
-    WrappingMul, WrappingNeg, WrappingSub,
+    Bounded, CheckedAdd, CheckedMul, CheckedSub, Integer, NonZero, RandomMod, WrappingAdd, WrappingMul, WrappingNeg,
+    WrappingSub,
 };
 
-use super::{HasWide, PublicSigned, SecretUnsigned};
+use super::{Extendable, MulWide, PublicSigned, SecretUnsigned};
 use crate::tools::Secret;
 
 /// A wrapper over secret unsigned integers that treats two's complement numbers as negative.
@@ -192,18 +192,26 @@ where
 
 impl<T> SecretSigned<T>
 where
-    T: ConditionallySelectable + Zeroize + Bounded + HasWide,
-    T::Wide: ConditionallySelectable + Zeroize + Bounded,
+    T: ConditionallySelectable + Zeroize + Integer + Bounded,
 {
     /// Returns a [`SecretSigned`] with the same value, but twice the bit-width.
-    pub fn to_wide(&self) -> SecretSigned<T::Wide> {
+    pub fn to_wide<W>(&self) -> SecretSigned<W>
+    where
+        T: Extendable<W>,
+        W: Zeroize + Integer + Bounded + ConditionallySelectable,
+    {
         let abs_result = self.abs_value().to_wide();
         SecretSigned::new_from_abs(abs_result, self.bound(), self.is_negative())
             .expect("the value fit the bound before, and the bound won't overflow for `T::Wide`")
     }
 
     /// Multiplies two numbers and returns a new [`SecretSigned`] of twice the bit-width.
-    pub fn mul_wide_public(&self, rhs: &PublicSigned<T>) -> SecretSigned<T::Wide> {
+    pub fn mul_wide_public<R, W>(&self, rhs: &PublicSigned<R>) -> SecretSigned<W>
+    where
+        T: MulWide<R, W>,
+        R: Integer + Bounded,
+        W: Zeroize + Integer + Bounded + ConditionallySelectable,
+    {
         let abs_value = Secret::init_with(|| self.abs_value().expose_secret().mul_wide(&rhs.abs()));
         SecretSigned::new_from_abs(
             abs_value,
@@ -214,7 +222,12 @@ where
     }
 
     /// Multiplies two numbers and returns a new [`SecretSigned`] of twice the bit-width.
-    pub fn mul_wide(&self, rhs: &SecretSigned<T>) -> SecretSigned<T::Wide> {
+    pub fn mul_wide<R, W>(&self, rhs: &SecretSigned<R>) -> SecretSigned<W>
+    where
+        T: MulWide<R, W>,
+        R: Zeroize + Integer + Bounded + ConditionallySelectable,
+        W: Zeroize + Integer + Bounded + ConditionallySelectable,
+    {
         let abs_value = Secret::init_with(|| {
             self.abs_value()
                 .expose_secret()
@@ -342,14 +355,17 @@ where
 
 impl<T> SecretSigned<T>
 where
-    T: Zeroize + Integer + Bounded + HasWide,
-    T::Wide: Zeroize + Bounded + RandomMod,
+    T: Zeroize + Integer + Bounded,
 {
     /// Returns a random value in range $±2^{exp} scale$ as defined by the paper, that is
     /// sampling from $[-scale (2^{exp-1}+1), scale 2^{exp-1}]$ (See Section 3, Groups & Fields).
     ///
     /// Note: variable time in `exp` and bit size of `scale`.
-    pub fn random_in_exponent_range_scaled(rng: &mut dyn CryptoRngCore, exp: u32, scale: &T) -> SecretSigned<T::Wide> {
+    pub fn random_in_exponent_range_scaled<W>(rng: &mut dyn CryptoRngCore, exp: u32, scale: &T) -> SecretSigned<W>
+    where
+        T: Extendable<W>,
+        W: Zeroize + Integer + Bounded + ConditionallySelectable + RandomMod,
+    {
         assert!(exp > 0, "`exp` must be greater than zero");
         assert!(
             exp < T::BITS,
@@ -370,10 +386,10 @@ where
             .to_wide()
             .overflowing_shl_vartime(exp - 1)
             .expect("`2^exp` fits into `T`, so the result fits into `T::Wide`")
-            .checked_sub(&T::Wide::one())
+            .checked_sub(&W::one())
             .expect("does not overflow because of the assertions above");
 
-        let positive_result = Secret::init_with(|| T::Wide::random_mod(rng, &positive_bound));
+        let positive_result = Secret::init_with(|| W::random_mod(rng, &positive_bound));
         let value = Secret::init_with(|| positive_result.expose_secret().wrapping_sub(&shift));
 
         SecretSigned::new_from_unsigned_unchecked(value, exp + scale.bits_vartime())
@@ -382,19 +398,22 @@ where
 
 impl<T> SecretSigned<T>
 where
-    T: Zeroize + Integer + Bounded + HasWide,
-    T::Wide: Zeroize + HasWide,
-    <T::Wide as HasWide>::Wide: Zeroize + Bounded,
+    T: Zeroize + Integer + Bounded,
 {
     /// Returns a random value in range $±2^{exp} scale$ as defined by the paper, that is
     /// sampling from $[-scale (2^{exp-1}+1), scale 2^{exp-1}]$ (See Section 3, Groups & Fields).
     ///
     /// Note: variable time in `exp` and bit size of `scale`.
-    pub fn random_in_exponent_range_scaled_wide(
+    pub fn random_in_exponent_range_scaled_wide<W, XW>(
         rng: &mut dyn CryptoRngCore,
         exp: u32,
-        scale: &T::Wide,
-    ) -> SecretSigned<<T::Wide as HasWide>::Wide> {
+        scale: &W,
+    ) -> SecretSigned<XW>
+    where
+        T: Extendable<W>,
+        W: Extendable<XW> + Integer,
+        XW: Zeroize + Integer + Bounded + ConditionallySelectable + RandomMod,
+    {
         assert!(exp > 0, "`exp` must be greater than zero");
         assert!(
             exp < T::BITS,
@@ -415,10 +434,10 @@ where
             .to_wide()
             .overflowing_shl_vartime(exp - 1)
             .expect("`2^exp` fits into `T`, so the result fits into `T::Wide::Wide`")
-            .checked_sub(&<T::Wide as HasWide>::Wide::one())
+            .checked_sub(&XW::one())
             .expect("does not overflow because of the assertions above");
 
-        let positive_result = Secret::init_with(|| <T::Wide as HasWide>::Wide::random_mod(rng, &positive_bound));
+        let positive_result = Secret::init_with(|| XW::random_mod(rng, &positive_bound));
         let value = Secret::init_with(|| positive_result.expose_secret().wrapping_sub(&shift));
 
         SecretSigned::new_from_unsigned_unchecked(value, exp + scale.bits_vartime())
@@ -551,7 +570,7 @@ mod tests {
 
     use crypto_bigint::{
         subtle::{Choice, ConditionallySelectable},
-        Bounded, CheckedMul, CheckedSub, Integer, U1024, U128,
+        Bounded, CheckedMul, CheckedSub, Integer, U1024, U128, U2048,
     };
     use rand::SeedableRng;
     use rand_chacha::{self, ChaCha8Rng};
@@ -615,11 +634,11 @@ mod tests {
     fn mul_wide_sums_bounds() {
         let s = test_new_from_unsigned(U1024::MAX >> 1, 1023).unwrap();
         let s1 = PublicSigned::new_from_unsigned(U1024::MAX >> 1, 1023).unwrap();
-        let mul = s.mul_wide_public(&s1);
+        let mul = s.mul_wide_public::<_, U2048>(&s1);
         assert_eq!(mul.bound(), 2046);
 
         let s2 = PublicSigned::new_from_unsigned(U1024::from_u8(8), 4).unwrap();
-        let mul = s.mul_wide_public(&s2);
+        let mul = s.mul_wide_public::<_, U2048>(&s2);
         assert_eq!(mul.bound(), 1027);
     }
 

--- a/src/uint/secret_unsigned.rs
+++ b/src/uint/secret_unsigned.rs
@@ -3,7 +3,7 @@ use core::ops::BitAnd;
 use crypto_bigint::{subtle::Choice, Bounded, Integer, Monty, NonZero};
 use zeroize::Zeroize;
 
-use super::HasWide;
+use super::Extendable;
 use crate::tools::Secret;
 
 /// A bounded unsigned integer with sensitive data.
@@ -78,10 +78,13 @@ where
 
 impl<T> SecretUnsigned<T>
 where
-    T: Zeroize + Clone + HasWide,
-    T::Wide: Zeroize,
+    T: Zeroize + Clone,
 {
-    pub fn to_wide(&self) -> SecretUnsigned<T::Wide> {
+    pub fn to_wide<W>(&self) -> SecretUnsigned<W>
+    where
+        T: Extendable<W>,
+        W: Zeroize + Clone,
+    {
         SecretUnsigned {
             value: self.value.to_wide(),
             bound: self.bound,

--- a/src/uint/traits.rs
+++ b/src/uint/traits.rs
@@ -124,9 +124,13 @@ where
     }
 }
 
-/// Exposes a way to widen `Self` to `Wide`.
+/// Exposes a way to widen an integer `Self` to `Wide`.
 pub trait Extendable<Wide: Sized>: Sized {
+    /// Converts to `Wide`.
     fn to_wide(&self) -> Wide;
+    /// Attempts to shorten `Wide` to `Self`.
+    ///
+    /// If the number does not fit `Self`, `None` is returned.
     fn try_from_wide(value: &Wide) -> Option<Self>;
 }
 
@@ -164,6 +168,7 @@ impl<const L: usize, const W: usize> Extendable<Uint<W>> for Uint<L> {
 
 /// Exposes a way to multiply `Self` by `Hi` obtaining a `Wide` result.
 pub trait MulWide<Hi, Wide: Sized>: Sized {
+    /// Multiplies `self` by `rhs`.
     fn mul_wide(&self, rhs: &Hi) -> Wide;
 }
 
@@ -184,8 +189,11 @@ impl<const L: usize, const R: usize, const W: usize> MulWide<Uint<R>, Uint<W>> f
     }
 }
 
+/// Allows (de)serializing an object from/to a byte slice.
 pub trait BoxedEncoding: Sized {
+    /// Serializes into a byte slice.
     fn to_be_bytes(&self) -> Box<[u8]>;
+    /// Attempts to deserialize from a byte slice.
     fn try_from_be_bytes(bytes: &[u8]) -> Result<Self, String>;
 }
 

--- a/src/uint/traits.rs
+++ b/src/uint/traits.rs
@@ -195,7 +195,7 @@ impl<const L: usize> BoxedEncoding for Uint<L> {
         // SAFETY:
         // - `rchunks_mut` will not panic as long as `Self::BYTES` is a multiple of `Limb::BYTES`
         // - `copy_from_slice` will not panic as long as `Limb::to_be_bytes()` returns an array of size `Limb::BYTES`
-        for (limb, chunk) in self.as_limbs().iter().zip(result.rchunks_mut(Limb::BYTES)) {
+        for (limb, chunk) in self.as_limbs().iter().zip(result.rchunks_exact_mut(Limb::BYTES)) {
             chunk.copy_from_slice(&limb.to_be_bytes());
         }
         result.into()

--- a/src/zk/fac.rs
+++ b/src/zk/fac.rs
@@ -8,7 +8,7 @@ use crate::{
     paillier::{PaillierParams, PublicKeyPaillier, RPCommitmentWire, RPParams, SecretKeyPaillier},
     params::SchemeParams,
     tools::hashing::{Chain, Hashable, Hasher},
-    uint::{HasWide, PublicSigned, SecretSigned},
+    uint::{MulWide, PublicSigned, SecretSigned},
 };
 
 const HASH_TAG: &[u8] = b"P_fac";

--- a/src/zk/fac.rs
+++ b/src/zk/fac.rs
@@ -108,7 +108,16 @@ impl<P: SchemeParams> FacProof<P> {
         let z2 = (beta + (q * e).to_wide()).to_public();
         let w1 = (x + mu * e_wide).to_public();
         let w2 = (y + &nu * e_wide).to_public();
-        let v = (r - p.mul_wide_public(&e).mul_wide(&nu)).to_public();
+
+        // p ∈ ±2^(MODULUS_BITS / 2)
+        // e ∈ ±2^L_BOUND
+        // nu ∈ ±2^(L_BOUND + MODULUS_BITS)
+        // Now if scheme parameters are self-consistent,
+        //    MODULUS_BITS >= LP_BOUND + EPS_BOUND
+        //                 >= 3 * L_BOUND + 2 * EPS_BOUND
+        //                 >= 5 * L_BOUND + 2 * SECURITY_PARAMETER
+        // Therefore, `p * e * nu` will not overflow 2^(2*MODULUS_BITS) and will fit in `WideUint`.
+        let v = (r - (p.mul_wide_public(&e) * nu).to_wide()).to_public();
 
         Self {
             e,

--- a/src/zk/fac.rs
+++ b/src/zk/fac.rs
@@ -35,7 +35,7 @@ pub(crate) struct FacProof<P: SchemeParams> {
     z2: PublicSigned<<P::Paillier as PaillierParams>::WideUint>,
     w1: PublicSigned<<P::Paillier as PaillierParams>::WideUint>,
     w2: PublicSigned<<P::Paillier as PaillierParams>::WideUint>,
-    v: PublicSigned<<P::Paillier as PaillierParams>::ExtraWideUint>,
+    v: PublicSigned<P::ExtraWideUint>,
 }
 
 impl<P: SchemeParams> FacProof<P> {

--- a/src/zk/prm.rs
+++ b/src/zk/prm.rs
@@ -16,7 +16,7 @@ use crate::{
         bitvec::BitVec,
         hashing::{Chain, Hashable, Hasher},
     },
-    uint::{Exponentiable, SecretUnsigned, ToMontgomery},
+    uint::{Exponentiable, PublicUint, SecretUnsigned, ToMontgomery},
 };
 
 const HASH_TAG: &[u8] = b"P_prm";
@@ -35,11 +35,11 @@ impl<P: SchemeParams> PrmSecret<P> {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct PrmCommitment<P: SchemeParams>(Vec<<P::Paillier as PaillierParams>::Uint>);
+struct PrmCommitment<P: SchemeParams>(Vec<PublicUint<<P::Paillier as PaillierParams>::Uint>>);
 
 impl<P: SchemeParams> PrmCommitment<P> {
     fn new(secret: &PrmSecret<P>, base: &<P::Paillier as PaillierParams>::UintMod) -> Self {
-        let commitment = secret.0.iter().map(|a| base.pow(a).retrieve()).collect();
+        let commitment = secret.0.iter().map(|a| base.pow(a).retrieve().into()).collect();
         Self(commitment)
     }
 }
@@ -65,7 +65,7 @@ impl PrmChallenge {
 pub(crate) struct PrmProof<P: SchemeParams> {
     commitment: PrmCommitment<P>,
     challenge: PrmChallenge,
-    proof: Vec<<P::Paillier as PaillierParams>::Uint>,
+    proof: Vec<PublicUint<<P::Paillier as PaillierParams>::Uint>>,
 }
 
 impl<P: SchemeParams> PrmProof<P> {
@@ -92,7 +92,7 @@ impl<P: SchemeParams> PrmProof<P> {
 
                 let p = if *e { x.expose_secret() } else { a.expose_secret() };
                 // a/x are positive and smaller than the totient by construction
-                *p
+                (*p).into()
             })
             .collect();
         Self {
@@ -119,7 +119,7 @@ impl<P: SchemeParams> PrmProof<P> {
             .zip(self.commitment.0.iter())
         {
             let a = a.to_montgomery(monty_params);
-            let pwr = setup.base_randomizer().pow_bounded_exp(z, z.bits_vartime());
+            let pwr = setup.base_randomizer().pow_bounded_exp(z.as_ref(), z.bits_vartime());
             let test = if *e { pwr == a * setup.base_value() } else { pwr == a };
             if !test {
                 return false;

--- a/src/zk/prm.rs
+++ b/src/zk/prm.rs
@@ -5,7 +5,7 @@
 
 use alloc::vec::Vec;
 
-use crypto_bigint::{modular::Retrieve, BitOps, PowBoundedExp};
+use crypto_bigint::{modular::Retrieve, BitOps, Integer, PowBoundedExp};
 use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
 
@@ -38,7 +38,7 @@ impl<P: SchemeParams> PrmSecret<P> {
 struct PrmCommitment<P: SchemeParams>(Vec<PublicUint<<P::Paillier as PaillierParams>::Uint>>);
 
 impl<P: SchemeParams> PrmCommitment<P> {
-    fn new(secret: &PrmSecret<P>, base: &<P::Paillier as PaillierParams>::UintMod) -> Self {
+    fn new(secret: &PrmSecret<P>, base: &<<P::Paillier as PaillierParams>::Uint as Integer>::Monty) -> Self {
         let commitment = secret.0.iter().map(|a| base.pow(a).retrieve().into()).collect();
         Self(commitment)
     }


### PR DESCRIPTION
- Disbanded `HasWide` into `Extendable` and `MulWide` with blanket implementations. This means that users would be able to implement their own `SchemeParams`, no longer restricted by the orphan rule.
- Replaced `Encoding` with `BoxedEncoding`, blanket-derived for all `Uint`s (and potentially derived for `BoxedUint`)
- Moved `ExtraWideUint` to `SchemeParams`
- Made `ExtraWideUint` smaller since it doesn't have to be double `WideUint` anymore
- Added consistency check for `PaillierParams`
- Made consistency checks compile-time assertions (**question:** is this a good idea? Perhaps we should instead have a method that would be able to return a error saying which specific condition was violated?)
- Added 128-bit security parameters for `k256`. Fixes #189. Note that the `ExtraWideUint` needs `extra-sizes` enabled in `crypto-bigint`. Probably ok?
- Removed `*Mod` types from `PaillierParams` and instead just have bounds on `Integer::Monty`
- Using `*Assign` bounds for arithmetic operations on `Secret`: less potential allocations, and less probability to expose a secret.
- Removed `CURVE_ORDER`, `CURVE_ORDER_WIDE`, and `WideCurveUint` from `SchemeParams`
- Deriving all constants but `SECURITY_BITS` automatically in `SchemeParams`.

#201 may be possible to handle in a similar way after we switch to crypto-bigint 0.7.

I think this generally deals with all the issues with large `Uint`s (although we're still limited by `Gcd` impls, but we only need them for `Uint`, not for the wider ones).