### PR TITLE
Use `SerializableMap` in serializable objects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bip32"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,7 +344,7 @@ checksum = "4919aa33c410cb537c1b2a8458a896f9e47ed4349a2002e5b240f358f7bf6ffc"
 dependencies = [
  "num-traits",
  "rand_core",
- "serdect",
+ "serdect 0.3.0",
  "subtle",
  "zeroize",
 ]
@@ -370,6 +376,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -417,6 +424,7 @@ dependencies = [
  "digest",
  "elliptic-curve",
  "rfc6979",
+ "serdect 0.2.0",
  "signature",
 ]
 
@@ -438,8 +446,11 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
+ "pem-rfc7468",
+ "pkcs8",
  "rand_core",
  "sec1",
+ "serdect 0.2.0",
  "subtle",
  "zeroize",
 ]
@@ -756,10 +767,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "plotters"
@@ -817,6 +847,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
+ "serdect 0.2.0",
 ]
 
 [[package]]
@@ -980,6 +1011,8 @@ dependencies = [
  "base16ct",
  "der",
  "generic-array",
+ "pkcs8",
+ "serdect 0.2.0",
  "subtle",
  "zeroize",
 ]
@@ -1056,6 +1089,16 @@ dependencies = [
 
 [[package]]
 name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f42f67da2385b51a5f9652db9c93d78aeaf7610bf5ec366080b6de810604af53"
@@ -1102,6 +1145,16 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
  "rand_core",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -1188,9 +1241,9 @@ dependencies = [
 
 [[package]]
 name = "tiny-curve"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fee0da040bad62e743441300bd31f211b6d8d34786ff816be58a345ad79dcd8"
+checksum = "3839423882e7687ba6339ed468baea296bc13599969293c560ca3f7fc816be24"
 dependencies = [
  "bip32",
  "ecdsa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ serde = { version = "1", default-features = false, features = ["derive"] }
 serde-encoded-bytes = { version = "0.1", default-features = false, features = ["hex", "base64"] }
 displaydoc = { version = "0.2", default-features = false }
 
-tiny-curve = { version = "0.2", optional = true, features = ["ecdsa"] }
+tiny-curve = { version = "0.2.2", optional = true, features = ["ecdsa", "serde"] }
 k256 = { version = "0.13", optional = true, default-features = false, features = ["ecdsa"] }
 bip32 = { version = "0.5", optional = true, default-features = false, features = ["alloc"] }
 
@@ -47,7 +47,7 @@ tokio = { version = "1", features = ["rt", "sync", "time", "macros"] }
 rand = { version = "0.8", features = ["getrandom"] }
 criterion = "0.5"
 k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
-tiny-curve = { version = "0.2", features = ["ecdsa"] }
+tiny-curve = { version = "0.2.2", features = ["ecdsa", "serde"] }
 impls = "1"
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 test-log = { version = "0.2.16", default-features = false, features = ["trace", "color"] }

--- a/src/entities/full.rs
+++ b/src/entities/full.rs
@@ -6,7 +6,7 @@ use alloc::{
 use core::fmt::Debug;
 
 use ecdsa::VerifyingKey;
-use manul::session::LocalError;
+use manul::{protocol::PartyId, session::LocalError};
 use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
 
@@ -25,7 +25,7 @@ use crate::{
 pub struct KeyShare<P, I>
 where
     P: SchemeParams,
-    I: Ord,
+    I: PartyId,
 {
     owner: I,
     /// Secret key share of this node.
@@ -35,7 +35,7 @@ where
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound(deserialize = "I: for<'x> Deserialize<'x>"))]
-pub struct PublicKeyShares<P: SchemeParams, I: Ord>(BTreeMap<I, Point<P>>);
+pub struct PublicKeyShares<P: SchemeParams, I: PartyId>(BTreeMap<I, Point<P>>);
 
 /// The result of the AuxGen protocol.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -49,7 +49,7 @@ pub struct PublicKeyShares<P: SchemeParams, I: Ord>(BTreeMap<I, Point<P>>);
     SecretAuxInfo<P>: for<'x> Deserialize<'x>,
     PublicAuxInfos<P, I>: for<'x> Deserialize<'x>,
 "))]
-pub struct AuxInfo<P: SchemeParams, I: Ord> {
+pub struct AuxInfo<P: SchemeParams, I: PartyId> {
     pub(crate) owner: I,
     pub(crate) secret: SecretAuxInfo<P>,
     pub(crate) public: PublicAuxInfos<P, I>,
@@ -64,7 +64,7 @@ pub struct AuxInfo<P: SchemeParams, I: Ord> {
     I: for<'x> Deserialize<'x>,
     PublicAuxInfo<P>: for<'x> Deserialize<'x>,
 "))]
-pub struct PublicAuxInfos<P: SchemeParams, I: Ord>(pub(crate) BTreeMap<I, PublicAuxInfo<P>>);
+pub struct PublicAuxInfos<P: SchemeParams, I: PartyId>(pub(crate) BTreeMap<I, PublicAuxInfo<P>>);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound(serialize = "SecretKeyPaillierWire<P::Paillier>: Serialize"))]
@@ -103,7 +103,7 @@ pub(crate) struct PublicAuxInfoPrecomputed<P: SchemeParams> {
 /// The result of the Auxiliary Info & Key Refresh protocol - the update to the key share.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound(deserialize = "I: for<'x> Deserialize<'x>"))]
-pub struct KeyShareChange<P: SchemeParams, I: Ord> {
+pub struct KeyShareChange<P: SchemeParams, I: PartyId> {
     pub(crate) owner: I,
     /// The value to be added to the secret share.
     pub(crate) secret_share_change: Secret<Scalar<P>>, // `x_i^* - x_i == \sum_{j} x_j^i`
@@ -111,7 +111,7 @@ pub struct KeyShareChange<P: SchemeParams, I: Ord> {
     pub(crate) public_share_changes: BTreeMap<I, Point<P>>, // `X_k^* - X_k == \sum_j X_j^k`, for all nodes
 }
 
-impl<P: SchemeParams, I: Ord> PublicAuxInfos<P, I> {
+impl<P: SchemeParams, I: PartyId> PublicAuxInfos<P, I> {
     pub(crate) fn num_parties(&self) -> usize {
         self.0.len()
     }
@@ -137,7 +137,7 @@ impl<P: SchemeParams, I: Ord> PublicAuxInfos<P, I> {
     }
 }
 
-impl<P: SchemeParams, I: Clone + Ord + Debug> PublicKeyShares<P, I> {
+impl<P: SchemeParams, I: PartyId> PublicKeyShares<P, I> {
     pub(crate) fn as_map(&self) -> &BTreeMap<I, Point<P>> {
         &self.0
     }
@@ -146,7 +146,7 @@ impl<P: SchemeParams, I: Clone + Ord + Debug> PublicKeyShares<P, I> {
 impl<P, I> KeyShare<P, I>
 where
     P: SchemeParams,
-    I: Ord + Debug + Clone,
+    I: PartyId,
 {
     pub(crate) fn new(
         owner: I,
@@ -272,7 +272,7 @@ where
     }
 }
 
-impl<P: SchemeParams, I: Ord + Clone> AuxInfo<P, I> {
+impl<P: SchemeParams, I: PartyId> AuxInfo<P, I> {
     /// Returns the owner of this aux data.
     pub fn owner(&self) -> &I {
         &self.owner

--- a/src/entities/full.rs
+++ b/src/entities/full.rs
@@ -49,7 +49,11 @@ pub struct PublicKeyShares<P: SchemeParams, I: PartyId>(BTreeMap<I, Point<P>>);
     SecretAuxInfo<P>: for<'x> Deserialize<'x>,
     PublicAuxInfos<P, I>: for<'x> Deserialize<'x>,
 "))]
-pub struct AuxInfo<P: SchemeParams, I: PartyId> {
+pub struct AuxInfo<P, I>
+where
+    P: SchemeParams,
+    I: PartyId,
+{
     pub(crate) owner: I,
     pub(crate) secret: SecretAuxInfo<P>,
     pub(crate) public: PublicAuxInfos<P, I>,
@@ -69,14 +73,20 @@ pub struct PublicAuxInfos<P: SchemeParams, I: PartyId>(pub(crate) BTreeMap<I, Pu
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound(serialize = "SecretKeyPaillierWire<P::Paillier>: Serialize"))]
 #[serde(bound(deserialize = "SecretKeyPaillierWire<P::Paillier>: for <'x> Deserialize<'x>"))]
-pub(crate) struct SecretAuxInfo<P: SchemeParams> {
+pub(crate) struct SecretAuxInfo<P>
+where
+    P: SchemeParams,
+{
     pub(crate) paillier_sk: SecretKeyPaillierWire<P::Paillier>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound(serialize = "PublicKeyPaillierWire<P::Paillier>: Serialize"))]
 #[serde(bound(deserialize = "PublicKeyPaillierWire<P::Paillier>: for <'x> Deserialize<'x>"))]
-pub(crate) struct PublicAuxInfo<P: SchemeParams> {
+pub(crate) struct PublicAuxInfo<P>
+where
+    P: SchemeParams,
+{
     /// The Paillier public key.
     pub(crate) paillier_pk: PublicKeyPaillierWire<P::Paillier>,
     /// The ring-Pedersen parameters.
@@ -84,18 +94,27 @@ pub(crate) struct PublicAuxInfo<P: SchemeParams> {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct AuxInfoPrecomputed<P: SchemeParams, I> {
+pub(crate) struct AuxInfoPrecomputed<P, I>
+where
+    P: SchemeParams,
+{
     pub(crate) secret_aux: SecretAuxInfoPrecomputed<P>,
     pub(crate) public_aux: BTreeMap<I, PublicAuxInfoPrecomputed<P>>,
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct SecretAuxInfoPrecomputed<P: SchemeParams> {
+pub(crate) struct SecretAuxInfoPrecomputed<P>
+where
+    P: SchemeParams,
+{
     pub(crate) paillier_sk: SecretKeyPaillier<P::Paillier>,
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct PublicAuxInfoPrecomputed<P: SchemeParams> {
+pub(crate) struct PublicAuxInfoPrecomputed<P>
+where
+    P: SchemeParams,
+{
     pub(crate) paillier_pk: PublicKeyPaillier<P::Paillier>,
     pub(crate) rp_params: RPParams<P::Paillier>,
 }
@@ -103,7 +122,11 @@ pub(crate) struct PublicAuxInfoPrecomputed<P: SchemeParams> {
 /// The result of the Auxiliary Info & Key Refresh protocol - the update to the key share.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound(deserialize = "I: for<'x> Deserialize<'x>"))]
-pub struct KeyShareChange<P: SchemeParams, I: PartyId> {
+pub struct KeyShareChange<P, I>
+where
+    P: SchemeParams,
+    I: PartyId,
+{
     pub(crate) owner: I,
     /// The value to be added to the secret share.
     pub(crate) secret_share_change: Secret<Scalar<P>>, // `x_i^* - x_i == \sum_{j} x_j^i`
@@ -111,7 +134,11 @@ pub struct KeyShareChange<P: SchemeParams, I: PartyId> {
     pub(crate) public_share_changes: BTreeMap<I, Point<P>>, // `X_k^* - X_k == \sum_j X_j^k`, for all nodes
 }
 
-impl<P: SchemeParams, I: PartyId> PublicAuxInfos<P, I> {
+impl<P, I> PublicAuxInfos<P, I>
+where
+    P: SchemeParams,
+    I: PartyId,
+{
     pub(crate) fn num_parties(&self) -> usize {
         self.0.len()
     }
@@ -137,7 +164,11 @@ impl<P: SchemeParams, I: PartyId> PublicAuxInfos<P, I> {
     }
 }
 
-impl<P: SchemeParams, I: PartyId> PublicKeyShares<P, I> {
+impl<P, I> PublicKeyShares<P, I>
+where
+    P: SchemeParams,
+    I: PartyId,
+{
     pub(crate) fn as_map(&self) -> &BTreeMap<I, Point<P>> {
         &self.0
     }
@@ -272,7 +303,11 @@ where
     }
 }
 
-impl<P: SchemeParams, I: PartyId> AuxInfo<P, I> {
+impl<P, I> AuxInfo<P, I>
+where
+    P: SchemeParams,
+    I: PartyId,
+{
     /// Returns the owner of this aux data.
     pub fn owner(&self) -> &I {
         &self.owner

--- a/src/entities/threshold.rs
+++ b/src/entities/threshold.rs
@@ -29,7 +29,7 @@ use crate::curve::{apply_tweaks_public, derive_tweaks, DeriveChildKey, PublicTwe
 /// is enough to perform signing.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound(deserialize = "ShareId<P>: for<'x> Deserialize<'x>"))]
-pub struct ThresholdKeyShare<P: SchemeParams, I: Ord + for<'x> Deserialize<'x>> {
+pub struct ThresholdKeyShare<P: SchemeParams, I: PartyId> {
     // TODO (#5): make this private to ensure invariants are held
     // (mainly, that the verifying key is not an identity)
     pub(crate) owner: I,

--- a/src/entities/threshold.rs
+++ b/src/entities/threshold.rs
@@ -29,7 +29,11 @@ use crate::curve::{apply_tweaks_public, derive_tweaks, DeriveChildKey, PublicTwe
 /// is enough to perform signing.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound(deserialize = "ShareId<P>: for<'x> Deserialize<'x>"))]
-pub struct ThresholdKeyShare<P: SchemeParams, I: PartyId> {
+pub struct ThresholdKeyShare<P, I>
+where
+    P: SchemeParams,
+    I: PartyId,
+{
     // TODO (#5): make this private to ensure invariants are held
     // (mainly, that the verifying key is not an identity)
     pub(crate) owner: I,

--- a/src/protocols/aux_gen.rs
+++ b/src/protocols/aux_gen.rs
@@ -805,7 +805,7 @@ impl<P: SchemeParams, Id: PartyId> Round<Id> for Round3<P, Id> {
         let aux_info = AuxInfo {
             owner: my_id.clone(),
             secret: secret_aux,
-            public: PublicAuxInfos(public_aux),
+            public: PublicAuxInfos(public_aux.into()),
         };
 
         Ok(FinalizeOutcome::Result(aux_info))

--- a/src/protocols/interactive_signing.rs
+++ b/src/protocols/interactive_signing.rs
@@ -912,7 +912,7 @@ impl<P: SchemeParams, Id: PartyId> ProtocolError<Id> for InteractiveSigningError
 pub struct InteractiveSigning<P, Id>
 where
     P: SchemeParams,
-    Id: Ord + Debug + Clone,
+    Id: PartyId,
 {
     key_share: KeyShare<P, Id>,
     aux_info: AuxInfo<P, Id>,
@@ -1045,7 +1045,7 @@ impl<P: SchemeParams, Id: PartyId> EntryPoint<Id> for InteractiveSigning<P, Id> 
 pub(super) struct Context<P, Id>
 where
     P: SchemeParams,
-    Id: Ord,
+    Id: PartyId,
 {
     scalar_message: Scalar<P>,
     pub(super) epid: Box<[u8]>,
@@ -1065,7 +1065,7 @@ where
 impl<P, Id> Context<P, Id>
 where
     P: SchemeParams,
-    Id: Ord + Debug + Clone + Serialize + for<'x> Deserialize<'x>,
+    Id: PartyId,
 {
     pub fn public_share(&self, i: &Id) -> Result<&Point<P>, LocalError> {
         self.key_share.public_shares().safe_get("public share", i)
@@ -1080,7 +1080,7 @@ where
 struct Round1<P, Id>
 where
     P: SchemeParams,
-    Id: Ord + Serialize + Clone + Debug + for<'x> Deserialize<'x>,
+    Id: PartyId,
 {
     context: Context<P, Id>,
     r1_echo_broadcast: Round1EchoBroadcast<P>,
@@ -1454,7 +1454,7 @@ impl<P: SchemeParams, Id: PartyId> Round<Id> for Round1<P, Id> {
 }
 
 #[derive(Debug)]
-pub(super) struct Round2<P: SchemeParams, Id: Ord + Clone + Debug> {
+pub(super) struct Round2<P: SchemeParams, Id: PartyId> {
     pub(super) context: Context<P, Id>,
     betas: BTreeMap<Id, SecretSigned<<P::Paillier as PaillierParams>::Uint>>,
     rs: BTreeMap<Id, Randomizer<P::Paillier>>,
@@ -1827,7 +1827,7 @@ impl<P: SchemeParams, Id: PartyId> Round<Id> for Round2<P, Id> {
 }
 
 #[derive(Debug)]
-pub(super) struct Round3<P: SchemeParams, Id: Ord> {
+pub(super) struct Round3<P: SchemeParams, Id: PartyId> {
     pub(super) context: Context<P, Id>,
     pub(super) cap_k: Ciphertext<P::Paillier>,
     pub(super) cap_gamma_combined: Point<P>,
@@ -2029,7 +2029,7 @@ impl<P: SchemeParams, Id: PartyId> Round<Id> for Round3<P, Id> {
 }
 
 #[derive(Debug)]
-struct Round4<P: SchemeParams, Id: Ord> {
+struct Round4<P: SchemeParams, Id: PartyId> {
     context: Context<P, Id>,
     presigning_data: PresigningData<P, Id>,
     sigma: Scalar<P>,

--- a/src/protocols/key_resharing.rs
+++ b/src/protocols/key_resharing.rs
@@ -464,14 +464,14 @@ impl<P: SchemeParams, I: PartyId> Round<I> for Round1<P, I> {
                 let public_share = shamir_join_points(&public_subshares);
                 (id.clone(), public_share)
             })
-            .collect();
+            .collect::<BTreeMap<_, _>>();
 
         Ok(FinalizeOutcome::Result(Some(ThresholdKeyShare {
             owner: self.my_id.clone(),
             threshold: self.new_threshold as u32,
             secret_share,
-            share_ids: self.new_share_ids,
-            public_shares,
+            share_ids: self.new_share_ids.into(),
+            public_shares: public_shares.into(),
         })))
     }
 }

--- a/src/protocols/key_resharing.rs
+++ b/src/protocols/key_resharing.rs
@@ -100,14 +100,14 @@ impl<I> ProtocolError<I> for KeyResharingError {
 
 /// Old share data.
 #[derive(Debug, Clone)]
-pub struct OldHolder<P: SchemeParams, I: Ord + for<'x> Deserialize<'x>> {
+pub struct OldHolder<P: SchemeParams, I: PartyId> {
     /// The threshold key share.
     pub key_share: ThresholdKeyShare<P, I>,
 }
 
 /// New share data.
 #[derive(Debug, Clone)]
-pub struct NewHolder<P: SchemeParams, I: Ord> {
+pub struct NewHolder<P: SchemeParams, I: PartyId> {
     /// The verifying key the old shares add up to.
     pub verifying_key: VerifyingKey<P::Curve>,
     /// The old threshold.
@@ -118,7 +118,7 @@ pub struct NewHolder<P: SchemeParams, I: Ord> {
 
 /// An entry point for the [`KeyResharingProtocol`].
 #[derive(Debug, Clone)]
-pub struct KeyResharing<P: SchemeParams, I: Ord + for<'x> Deserialize<'x>> {
+pub struct KeyResharing<P: SchemeParams, I: PartyId> {
     /// Old share data if the node holds it, or `None`.
     old_holder: Option<OldHolder<P, I>>,
     /// New share data if the node is one of the new holders, or `None`.
@@ -132,7 +132,7 @@ pub struct KeyResharing<P: SchemeParams, I: Ord + for<'x> Deserialize<'x>> {
 impl<P, I> KeyResharing<P, I>
 where
     P: SchemeParams,
-    I: Ord + for<'x> Deserialize<'x>,
+    I: PartyId,
 {
     /// Creates a new entry point for the node with the given ID.
     pub fn new(
@@ -245,12 +245,12 @@ struct OldHolderData<P: SchemeParams> {
 }
 
 #[derive(Debug)]
-struct NewHolderData<P: SchemeParams, I: Ord> {
+struct NewHolderData<P: SchemeParams, I: PartyId> {
     inputs: NewHolder<P, I>,
 }
 
 #[derive(Debug)]
-struct Round1<P: SchemeParams, I: Ord> {
+struct Round1<P: SchemeParams, I: PartyId> {
     old_holder: Option<OldHolderData<P>>,
     new_holder: Option<NewHolderData<P, I>>,
     new_share_ids: BTreeMap<I, ShareId<P>>,


### PR DESCRIPTION
Fixes #185

Had to bump `tiny-curve` because in 0.2.0 activating `serde` feature did not actually make `VerifyingKey<TinyCurve>` serde-serializable; in 0.2.2 it does. 