### PR TITLE
Test that `Secret` is zeroized

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ private-benches = ["k256", "dep:criterion"]
 k256 = ["dep:k256", "bip32?/secp256k1", "sha3"]
 bip32 = ["dep:bip32", "tiny-curve?/bip32"]
 dev = ["tiny-curve", "sha3"]
+test-allocator = []
 
 [[bench]]
 bench = true

--- a/src/tools/secret.rs
+++ b/src/tools/secret.rs
@@ -497,16 +497,59 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use core::ptr;
-    use crypto_bigint::U128;
 
-    #[allow(unsafe_code, trivial_casts, unused_assignments)]
-    #[test]
-    fn clears_memory_when_scope_ends() {
-        let mut ptr: *const U128 = ptr::null();
-        unsafe {
-            {
+    #[cfg(feature = "test-allocator")]
+    mod secret_with_custom_allocator {
+
+        use super::super::*;
+        use core::ptr;
+        use crypto_bigint::U128;
+
+        use std::alloc::{GlobalAlloc, Layout, System};
+        // Allocator that leaks all memory it allocates, thus leaving the memory open for inspection.
+        struct UnfreeAllocator;
+        #[allow(unsafe_code)]
+        unsafe impl GlobalAlloc for UnfreeAllocator {
+            unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+                System.alloc(layout)
+            }
+            unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+                // eprintln!("Leaking {:p}", ptr);
+                let _ = (ptr, layout);
+            }
+        }
+
+        #[global_allocator]
+        static UNFREE_ALLOCATOR: UnfreeAllocator = UnfreeAllocator;
+
+        #[allow(unsafe_code, trivial_casts, unused_assignments)]
+        #[test]
+        fn clears_memory_when_scope_ends() {
+            let mut ptr: *const U128 = ptr::null();
+            unsafe {
+                {
+                    let secret = Secret::init_with(|| U128::from_u128(0xdeadbeefu128));
+                    let secretboxptr = &secret.0 as *const SecretBox<U128>;
+                    // Points to the inner_secret of the `SecretBox`
+                    let boxptr = secretboxptr as *const *const U128;
+                    // Pointer to actual heap data
+                    ptr = *boxptr;
+
+                    assert!(!ptr.is_null(), "ptr is null before drop, not ok");
+                    let bytes: &[u8] = core::slice::from_raw_parts(ptr as *const u8, size_of::<U128>());
+                    assert!(!bytes.iter().all(|&b| b == 0), "ptr points to all 0: {:X?}", bytes);
+                }
+                // Check that the memory is cleared after the scope ends
+                let bytes: &[u8] = core::slice::from_raw_parts(ptr as *const u8, size_of::<U128>());
+                assert!(bytes.iter().all(|&b| b == 0), "ptr is not all 0: {:X?}", bytes);
+            }
+        }
+
+        #[allow(unsafe_code, trivial_casts, unused_assignments)]
+        #[test]
+        fn clears_memory_when_dropped() {
+            let mut ptr: *const U128 = ptr::null();
+            unsafe {
                 let secret = Secret::init_with(|| U128::from_u128(0xdeadbeefu128));
                 let secretboxptr = &secret.0 as *const SecretBox<U128>;
                 // Points to the inner_secret of the `SecretBox`
@@ -517,33 +560,12 @@ mod test {
                 assert!(!ptr.is_null(), "ptr is null before drop, not ok");
                 let bytes: &[u8] = core::slice::from_raw_parts(ptr as *const u8, size_of::<U128>());
                 assert!(!bytes.iter().all(|&b| b == 0), "ptr points to all 0: {:X?}", bytes);
+
+                drop(secret);
+                // Check that the memory is cleared after explicit drop
+                let bytes: &[u8] = core::slice::from_raw_parts(ptr as *const u8, size_of::<U128>());
+                assert!(bytes.iter().all(|&b| b == 0), "ptr is not all 0: {:X?}", bytes);
             }
-            // Check that the memory is cleared after the scope ends
-            let bytes: &[u8] = core::slice::from_raw_parts(ptr as *const u8, size_of::<U128>());
-            assert!(bytes.iter().all(|&b| b == 0), "ptr is not all 0: {:X?}", bytes);
-        }
-    }
-
-    #[allow(unsafe_code, trivial_casts, unused_assignments)]
-    #[test]
-    fn clears_memory_when_dropped() {
-        let mut ptr: *const U128 = ptr::null();
-        unsafe {
-            let secret = Secret::init_with(|| U128::from_u128(0xdeadbeefu128));
-            let secretboxptr = &secret.0 as *const SecretBox<U128>;
-            // Points to the inner_secret of the `SecretBox`
-            let boxptr = secretboxptr as *const *const U128;
-            // Pointer to actual heap data
-            ptr = *boxptr;
-
-            assert!(!ptr.is_null(), "ptr is null before drop, not ok");
-            let bytes: &[u8] = core::slice::from_raw_parts(ptr as *const u8, size_of::<U128>());
-            assert!(!bytes.iter().all(|&b| b == 0), "ptr points to all 0: {:X?}", bytes);
-
-            drop(secret);
-            // Check that the memory is cleared after explicit drop
-            let bytes: &[u8] = core::slice::from_raw_parts(ptr as *const u8, size_of::<U128>());
-            assert!(bytes.iter().all(|&b| b == 0), "ptr is not all 0: {:X?}", bytes);
         }
     }
 }


### PR DESCRIPTION
I was looking through the source code of the `secret` crate today and saw that they have a test for zeroizing secrets. Their impl relies on an FFI call to ensure `rustc` keeps the code.

My impl is unsafe, all kinds of UB and reliant on the inner working of `SecretBox`. 

The question is: is this better than nothing?
