### PR TITLE
Use `derive-where` instead of explicit bounds to derive `serde` traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "derive-where"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e73f2692d4bd3cac41dca28934a39894200c9fabf49586d77d0e5954af1d7902"
+checksum = "510c292c8cf384b1a340b816a9a6cf2599eb8f566a44949024af88418000c50b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -766,9 +766,8 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "manul"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e547eb94f2f4c2a62a916a9ca9aa4a9fef5b7a19a001c31f291859bad96348a7"
+version = "0.3.0-dev"
+source = "git+https://github.com/entropyxyz/manul.git?rev=d23fcb8cc9e88729a55006874c464d918197a965#d23fcb8cc9e88729a55006874c464d918197a965"
 dependencies = [
  "derive-where",
  "digest",
@@ -1326,6 +1325,7 @@ dependencies = [
  "criterion",
  "crypto-bigint 0.6.1",
  "crypto-primes",
+ "derive-where",
  "digest",
  "displaydoc",
  "dudect-bencher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ readme = "README.md"
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-manul = "0.2"
+#manul = "0.2"
+manul = { git = "https://github.com/entropyxyz/manul.git", rev = "d23fcb8cc9e88729a55006874c464d918197a965" }
 signature = { version = "2", default-features = false }
 rand_core = { version = "0.6.4", default-features = false }
 digest = { version = "0.10", default-features = false, features = ["alloc"] }
@@ -23,6 +24,8 @@ rand_chacha = { version = "0.3", default-features = false }
 rand = { version = "0.8", default-features = false }
 elliptic-curve = { version = "0.13", default-features = false }
 ecdsa = { version = "0.16", default-features = false, features = ["signing", "verifying"] }
+derive-where = { version = "1.5", features = ["serde"] }
+
 criterion = { version = "0.5", optional = true }
 
 # Note: `alloc` is needed for `crytpto-bigint`'s dependency `serdect` to be able
@@ -42,7 +45,8 @@ sha3 = { version = "0.10", optional = true, default-features = false }
 dudect-bencher = { version = "0.6", optional = true }
 
 [dev-dependencies]
-manul = { version = "0.2", features = ["dev"] }
+#manul = { version = "0.2", features = ["dev"] }
+manul = { git = "https://github.com/entropyxyz/manul.git", rev = "d23fcb8cc9e88729a55006874c464d918197a965", features = ["dev"] }
 serde_assert = "0.8"
 tokio = { version = "1", features = ["rt", "sync", "time", "macros"] }
 rand = { version = "0.8", features = ["getrandom"] }

--- a/src/entities/full.rs
+++ b/src/entities/full.rs
@@ -8,7 +8,6 @@ use core::fmt::Debug;
 use ecdsa::VerifyingKey;
 use manul::{protocol::PartyId, session::LocalError, utils::SerializableMap};
 use rand_core::CryptoRngCore;
-use serde::{Deserialize, Serialize};
 
 use crate::{
     curve::{secret_split, Point, Scalar},
@@ -20,8 +19,8 @@ use crate::{
 };
 
 /// The result of the KeyInit protocol.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(deserialize = "I: for<'x> Deserialize<'x>"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub struct KeyShare<P, I>
 where
     P: SchemeParams,
@@ -33,22 +32,13 @@ where
     public: PublicKeyShares<P, I>, // `X_j`
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(deserialize = "I: for<'x> Deserialize<'x>"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub struct PublicKeyShares<P: SchemeParams, I: PartyId>(SerializableMap<I, Point<P>>);
 
 /// The result of the AuxGen protocol.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "
-    I: Serialize,
-    SecretAuxInfo<P>: Serialize,
-    PublicAuxInfos<P, I>: Serialize,
-"))]
-#[serde(bound(deserialize = "
-    I: for<'x> Deserialize<'x>,
-    SecretAuxInfo<P>: for<'x> Deserialize<'x>,
-    PublicAuxInfos<P, I>: for<'x> Deserialize<'x>,
-"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub struct AuxInfo<P, I>
 where
     P: SchemeParams,
@@ -59,20 +49,12 @@ where
     pub(crate) public: PublicAuxInfos<P, I>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "
-    I: Serialize,
-    PublicAuxInfo<P>: Serialize,
-"))]
-#[serde(bound(deserialize = "
-    I: for<'x> Deserialize<'x>,
-    PublicAuxInfo<P>: for<'x> Deserialize<'x>,
-"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub struct PublicAuxInfos<P: SchemeParams, I: PartyId>(pub(crate) SerializableMap<I, PublicAuxInfo<P>>);
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "SecretKeyPaillierWire<P::Paillier>: Serialize"))]
-#[serde(bound(deserialize = "SecretKeyPaillierWire<P::Paillier>: for <'x> Deserialize<'x>"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(crate) struct SecretAuxInfo<P>
 where
     P: SchemeParams,
@@ -80,9 +62,8 @@ where
     pub(crate) paillier_sk: SecretKeyPaillierWire<P::Paillier>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "PublicKeyPaillierWire<P::Paillier>: Serialize"))]
-#[serde(bound(deserialize = "PublicKeyPaillierWire<P::Paillier>: for <'x> Deserialize<'x>"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(crate) struct PublicAuxInfo<P>
 where
     P: SchemeParams,
@@ -120,8 +101,8 @@ where
 }
 
 /// The result of the Auxiliary Info & Key Refresh protocol - the update to the key share.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(deserialize = "I: for<'x> Deserialize<'x>"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub struct KeyShareChange<P, I>
 where
     P: SchemeParams,

--- a/src/entities/threshold.rs
+++ b/src/entities/threshold.rs
@@ -7,7 +7,6 @@ use core::fmt::Debug;
 use ecdsa::{SigningKey, VerifyingKey};
 use manul::{protocol::PartyId, session::LocalError, utils::SerializableMap};
 use rand_core::CryptoRngCore;
-use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "bip32")]
 use bip32::{DerivationPath, PrivateKey as _};
@@ -27,8 +26,8 @@ use crate::curve::{apply_tweaks_public, derive_tweaks, DeriveChildKey, PublicTwe
 
 /// A threshold variant of the key share, where any `threshold` shares our of the total number
 /// is enough to perform signing.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(deserialize = "ShareId<P>: for<'x> Deserialize<'x>"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub struct ThresholdKeyShare<P, I>
 where
     P: SchemeParams,

--- a/src/paillier/keys.rs
+++ b/src/paillier/keys.rs
@@ -8,7 +8,6 @@ use crypto_bigint::{
 };
 use digest::XofReader;
 use rand_core::CryptoRngCore;
-use serde::{Deserialize, Serialize};
 
 use super::{
     params::PaillierParams,
@@ -19,9 +18,8 @@ use crate::{
     uint::{Extendable, MulWide, PublicSigned, SecretSigned, SecretUnsigned, ToMontgomery},
 };
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "SecretPrimesWire<P>: Serialize"))]
-#[serde(bound(deserialize = "for<'x> SecretPrimesWire<P>: Deserialize<'x>"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(crate) struct SecretKeyPaillierWire<P: PaillierParams> {
     primes: SecretPrimesWire<P>,
 }
@@ -297,9 +295,8 @@ where
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(bound(serialize = "PublicModulusWire<P>: Serialize"))]
-#[serde(bound(deserialize = "for<'x> PublicModulusWire<P>: Deserialize<'x>"))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(crate) struct PublicKeyPaillierWire<P: PaillierParams> {
     modulus: PublicModulusWire<P>,
 }

--- a/src/paillier/ring_pedersen.rs
+++ b/src/paillier/ring_pedersen.rs
@@ -158,9 +158,8 @@ impl<P: PaillierParams> RPParams<P> {
 }
 
 /// Minimal public ring-Pedersen parameters suitable for serialization and transmission.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "PublicModulusWire<P>: Serialize"))]
-#[serde(bound(deserialize = "for<'x> PublicModulusWire<P>: Deserialize<'x>"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(crate) struct RPParamsWire<P: PaillierParams> {
     /// The public modulus $\hat{N}$
     modulus: PublicModulusWire<P>,

--- a/src/protocols/aux_gen.rs
+++ b/src/protocols/aux_gen.rs
@@ -86,12 +86,6 @@ impl<P: SchemeParams, Id: PartyId> Protocol<Id> for AuxGenProtocol<P, Id> {
 
 /// Provable AuxGen faults.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "
-    Error<Id>: Serialize,
-"))]
-#[serde(bound(deserialize = "
-    Error<Id>: for<'x> Deserialize<'x>,
-"))]
 pub struct AuxGenError<P, Id> {
     error: Error<Id>,
     phantom: PhantomData<P>,
@@ -475,13 +469,8 @@ struct Round2<P: SchemeParams, Id: PartyId> {
     cap_vs: BTreeMap<Id, HashOutput>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "
-    PrmProof<P>: Serialize,
-"))]
-#[serde(bound(deserialize = "
-    PrmProof<P>: for<'x> Deserialize<'x>,
-"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(super) struct Round2NormalBroadcast<P: SchemeParams> {
     pub(super) paillier_pk: PublicKeyPaillierWire<P::Paillier>, // $N_i$
     pub(super) psi: PrmProof<P>,
@@ -629,24 +618,14 @@ struct Round3<P: SchemeParams, Id> {
     psi_prime: ModProof<P>,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "
-    ModProof<P>: Serialize,
-"))]
-#[serde(bound(deserialize = "
-    ModProof<P>: for<'x> Deserialize<'x>,
-"))]
+#[derive(Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(super) struct Round3NormalBroadcast<P: SchemeParams> {
     pub(super) psi_prime: ModProof<P>,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "
-    FacProof<P>: Serialize,
-"))]
-#[serde(bound(deserialize = "
-    FacProof<P>: for<'x> Deserialize<'x>,
-"))]
+#[derive(Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(super) struct Round3DirectMessage<P: SchemeParams> {
     pub(super) psi: FacProof<P>,
 }

--- a/src/protocols/interactive_signing.rs
+++ b/src/protocols/interactive_signing.rs
@@ -1093,9 +1093,8 @@ where
     r1_echo_broadcast: Round1EchoBroadcast<P>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "CiphertextWire<P::Paillier>: Serialize"))]
-#[serde(bound(deserialize = "CiphertextWire<P::Paillier>: for<'x> Deserialize<'x>"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(super) struct Round1EchoBroadcast<P: SchemeParams> {
     pub(super) cap_k: CiphertextWire<P::Paillier>,
     pub(super) cap_g: CiphertextWire<P::Paillier>,
@@ -1106,9 +1105,8 @@ pub(super) struct Round1EchoBroadcast<P: SchemeParams> {
     pub(super) cap_b2: Point<P>,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "EncElgProof<P>: Serialize"))]
-#[serde(bound(deserialize = "EncElgProof<P>: for<'x> Deserialize<'x>"))]
+#[derive(Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 struct Round1DirectMessage<P: SchemeParams> {
     psi0: EncElgProof<P>,
     psi1: EncElgProof<P>,
@@ -1469,15 +1467,8 @@ pub(super) struct Round2<P: SchemeParams, Id: PartyId> {
     hat_psis: BTreeMap<Id, AffGProof<P>>,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "
-    ElogProof<P>: Serialize,
-    AffGProof<P>: Serialize,
-"))]
-#[serde(bound(deserialize = "
-    ElogProof<P>: for<'x> Deserialize<'x>,
-    AffGProof<P>: for<'x> Deserialize<'x>,
-"))]
+#[derive(Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(super) struct Round2NormalBroadcast<P: SchemeParams, Id: PartyId> {
     pub(super) cap_ds: SerializableMap<Id, CiphertextWire<P::Paillier>>,
     pub(super) hat_cap_ds: SerializableMap<Id, CiphertextWire<P::Paillier>>,
@@ -1486,13 +1477,8 @@ pub(super) struct Round2NormalBroadcast<P: SchemeParams, Id: PartyId> {
     pub(super) hat_psis: SerializableMap<Id, AffGProof<P>>,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "
-    CiphertextWire<P::Paillier>: Serialize,
-"))]
-#[serde(bound(deserialize = "
-    CiphertextWire<P::Paillier>: for<'x> Deserialize<'x>,
-"))]
+#[derive(Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(super) struct Round2EchoBroadcast<P: SchemeParams, Id: PartyId> {
     pub(super) cap_gamma: Point<P>,
     pub(super) cap_fs: SerializableMap<Id, CiphertextWire<P::Paillier>>,
@@ -1835,15 +1821,14 @@ pub(super) struct Round3<P: SchemeParams, Id: PartyId> {
     pub(super) hat_ss: BTreeMap<Id, Randomizer<P::Paillier>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(deserialize = "Scalar<P>: for<'x> Deserialize<'x>,"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(super) struct Round3EchoBroadcast<P: SchemeParams> {
     pub(super) delta: Scalar<P>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "ElogProof<P>: Serialize"))]
-#[serde(bound(deserialize = "ElogProof<P>: for<'x> Deserialize<'x>"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(super) struct Round3NormalBroadcast<P: SchemeParams> {
     pub(super) cap_delta: Point<P>,
     psi_prime: ElogProof<P>,
@@ -2012,8 +1997,8 @@ struct Round4<P: SchemeParams, Id: PartyId> {
     sigma: Scalar<P>,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
-#[serde(bound(deserialize = "Scalar<P>: for<'x> Deserialize<'x>,"))]
+#[derive(Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(super) struct Round4NormalBroadcast<P: SchemeParams> {
     pub(crate) sigma: Scalar<P>,
 }
@@ -2108,15 +2093,8 @@ pub(super) struct Round5<P: SchemeParams, Id: PartyId> {
     pub(super) cap_fs: BTreeMap<(Id, Id), Ciphertext<P::Paillier>>, // $F_{i,j}$ for $j != i$
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "
-    DecProof<P>: Serialize,
-    AffGStarProof<P>: Serialize,
-"))]
-#[serde(bound(deserialize = "
-    DecProof<P>: for<'x> Deserialize<'x>,
-    AffGStarProof<P>: for<'x> Deserialize<'x>,
-"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(super) struct Round5EchoBroadcast<P: SchemeParams, Id: PartyId> {
     pub(super) psi_star: DecProof<P>,
     pub(super) psis: SerializableMap<Id, AffGStarProof<P>>,
@@ -2333,16 +2311,8 @@ pub(super) struct Round6<P: SchemeParams, Id: PartyId> {
     pub(super) hat_cap_fs: BTreeMap<(Id, Id), Ciphertext<P::Paillier>>, // $\hat{F}_{i,j}$ for $j != i$
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "
-    DecProof<P>: Serialize,
-    AffGStarProof<P>: Serialize,
-"))]
-#[serde(bound(deserialize = "
-    Id: for<'x> Deserialize<'x>,
-    DecProof<P>: for<'x> Deserialize<'x>,
-    AffGStarProof<P>: for<'x> Deserialize<'x>
-"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(super) struct Round6EchoBroadcast<P: SchemeParams, Id: PartyId> {
     pub(super) hat_psi_star: DecProof<P>,
     pub(super) hat_psis: SerializableMap<Id, AffGStarProof<P>>,

--- a/src/protocols/key_init.rs
+++ b/src/protocols/key_init.rs
@@ -371,8 +371,8 @@ struct Round2EchoBroadcast {
     rho: BitVec,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
-#[serde(bound(deserialize = "Point<P>: for<'x> Deserialize<'x>"))]
+#[derive(Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(super) struct Round2NormalBroadcast<P: SchemeParams> {
     cap_x: Point<P>,
     cap_a: SchCommitment<P>,
@@ -490,8 +490,8 @@ pub(super) struct Round3<P: SchemeParams, Id> {
     pub(super) rho_combined: BitVec,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
-#[serde(bound(deserialize = "SchProof<P>: for<'x> Deserialize<'x>"))]
+#[derive(Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(super) struct Round3NormalBroadcast<P: SchemeParams> {
     pub(super) psi: SchProof<P>,
 }

--- a/src/protocols/key_refresh.rs
+++ b/src/protocols/key_refresh.rs
@@ -95,15 +95,11 @@ where
 }
 
 /// Provable KeyRefresh faults.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "
-    Error<P, Id>: Serialize,
-"))]
-#[serde(bound(deserialize = "
-    Error<P, Id>: for<'x> Deserialize<'x>,
-"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub struct KeyRefreshError<P, Id>
 where
+    Id: PartyId,
     P: SchemeParams,
 {
     error: Error<P, Id>,
@@ -111,6 +107,7 @@ where
 
 impl<P, Id> From<Error<P, Id>> for KeyRefreshError<P, Id>
 where
+    Id: PartyId,
     P: SchemeParams,
 {
     fn from(source: Error<P, Id>) -> Self {
@@ -148,10 +145,11 @@ where
 }
 
 /// KeyRefresh error
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(deserialize = "Id: for<'x> Deserialize<'x>"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 enum Error<P, Id>
 where
+    Id: PartyId,
     P: SchemeParams,
 {
     R2HashMismatch,
@@ -670,14 +668,8 @@ struct Round2<P: SchemeParams, Id: PartyId> {
     cap_vs: BTreeMap<Id, HashOutput>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "
-    PrmProof<P>: Serialize,
-"))]
-#[serde(bound(deserialize = "
-    PrmProof<P>: for<'x> Deserialize<'x>,
-    SchCommitment<P>: for<'x> Deserialize<'x>,
-"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(super) struct Round2NormalBroadcast<P: SchemeParams, Id: PartyId> {
     pub(super) cap_xs: SerializableMap<Id, Point<P>>, // $X_{i,j}$ where $i$ is this party's index
     pub(super) cap_as: SerializableMap<Id, SchCommitment<P>>, // $A_{i,j}$ where $i$ is this party's index
@@ -686,13 +678,8 @@ pub(super) struct Round2NormalBroadcast<P: SchemeParams, Id: PartyId> {
     u: BitVec,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "
-    Id: Serialize,
-"))]
-#[serde(bound(deserialize = "
-    Id: for<'x> Deserialize<'x>,
-"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(super) struct Round2EchoBroadcast<P: SchemeParams, Id: PartyId> {
     pub(super) rp_params: RPParamsWire<P::Paillier>, // $\hat{N}_i$, $s_i$, and $t_i$
     pub(super) cap_ys: SerializableMap<Id, Point<P>>, // $Y_{i,j}$ where $i$ is this party's index
@@ -879,36 +866,20 @@ struct Round3<P: SchemeParams, Id> {
     hat_psis: BTreeMap<Id, SchProof<P>>,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "
-    SchProof<P>: Serialize,
-"))]
-#[serde(bound(deserialize = "
-    SchProof<P>: for<'x> Deserialize<'x>,
-    Id: for<'x> Deserialize<'x>,
-"))]
+#[derive(Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(super) struct Round3EchoBroadcast<P: SchemeParams, Id: PartyId> {
     pub(super) hat_psis: SerializableMap<Id, SchProof<P>>,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "
-    ModProof<P>: Serialize,
-"))]
-#[serde(bound(deserialize = "
-    ModProof<P>: for<'x> Deserialize<'x>,
-"))]
+#[derive(Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(super) struct Round3NormalBroadcast<P: SchemeParams> {
     pub(super) psi_prime: ModProof<P>,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "
-    FacProof<P>: Serialize,
-"))]
-#[serde(bound(deserialize = "
-    FacProof<P>: for<'x> Deserialize<'x>,
-"))]
+#[derive(Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(super) struct Round3DirectMessage<P: SchemeParams> {
     pub(super) psi: FacProof<P>,
     pub(super) cap_c: Scalar<P>,

--- a/src/protocols/key_resharing.rs
+++ b/src/protocols/key_resharing.rs
@@ -264,18 +264,15 @@ struct Round1<P: SchemeParams, I: PartyId> {
     phantom: PhantomData<P>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(deserialize = "
-    for<'x> PublicPolynomial<P>: Deserialize<'x>,
-    for<'x> ShareId<P>: Deserialize<'x>
-"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 struct Round1BroadcastMessage<P: SchemeParams> {
     public_polynomial: PublicPolynomial<P>,
     old_share_id: ShareId<P>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(deserialize = "Secret<Scalar<P>>: for<'x> Deserialize<'x>"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 struct Round1DirectMessage<P: SchemeParams> {
     subshare: Secret<Scalar<P>>,
 }

--- a/src/tools/sss.rs
+++ b/src/tools/sss.rs
@@ -3,7 +3,6 @@ use core::ops::{Add, Mul};
 
 use manul::session::LocalError;
 use rand_core::CryptoRngCore;
-use serde::{Deserialize, Serialize};
 
 use crate::{
     curve::{Point, Scalar},
@@ -11,8 +10,8 @@ use crate::{
     tools::Secret,
 };
 
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
-#[serde(bound(deserialize = "for<'x> Scalar<P>: Deserialize<'x>"))]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub struct ShareId<P: SchemeParams>(Scalar<P>);
 
 impl<P> ShareId<P>
@@ -87,8 +86,8 @@ where
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(deserialize = "for<'x> Point<P>: Deserialize<'x>"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(crate) struct PublicPolynomial<P: SchemeParams>(Vec<Point<P>>);
 
 impl<P> PublicPolynomial<P>

--- a/src/zk/aff_g.rs
+++ b/src/zk/aff_g.rs
@@ -1,7 +1,6 @@
 //! Paillier Affine Operation with Group Commitment in Range ($\Pi^{aff-g}$, Fig. 25)
 
 use rand_core::CryptoRngCore;
-use serde::{Deserialize, Serialize};
 
 use crate::{
     curve::{Point, Scalar},
@@ -48,11 +47,8 @@ pub(crate) struct AffGPublicInputs<'a, P: SchemeParams> {
 }
 
 /// ZK proof: Paillier Affine Operation with Group Commitment in Range.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(deserialize = "
-    Scalar<P>: for<'x> Deserialize<'x>,
-    Point<P>: for<'x> Deserialize<'x>
-"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(crate) struct AffGProof<P: SchemeParams> {
     e: Scalar<P>,
     cap_a: CiphertextWire<P::Paillier>,

--- a/src/zk/aff_g_star.rs
+++ b/src/zk/aff_g_star.rs
@@ -56,8 +56,8 @@ struct AffGStarProofEphemeral<P: SchemeParams> {
     s: Randomizer<P::Paillier>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(deserialize = "Point<P>: for<'x> Deserialize<'x>,"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 struct AffGStarProofCommitment<P: SchemeParams> {
     cap_a: CiphertextWire<P::Paillier>,
     cap_r: Point<P>,
@@ -72,12 +72,8 @@ struct AffGStarProofElement<P: SchemeParams> {
     lambda: MaskedRandomizer<P::Paillier>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "
-    AffGStarProofCommitment<P>: Serialize,
-    AffGStarProofElement<P>: Serialize,
-"))]
-#[serde(bound(deserialize = "AffGStarProofCommitment<P>: for<'x> Deserialize<'x>,"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(crate) struct AffGStarProof<P: SchemeParams> {
     e: BitVec,
     commitments: Box<[AffGStarProofCommitment<P>]>,

--- a/src/zk/dec.rs
+++ b/src/zk/dec.rs
@@ -59,15 +59,8 @@ pub(crate) struct DecPublicInputs<'a, P: SchemeParams> {
 }
 
 /// ZK proof: Paillier decryption modulo $q$.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "
-    DecProofCommitment<P>: Serialize,
-    DecProofElement<P>: Serialize,
-"))]
-#[serde(bound(deserialize = "
-    DecProofCommitment<P>: for<'x> Deserialize<'x>,
-    DecProofElement<P>: for<'x> Deserialize<'x>
-"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(crate) struct DecProof<P: SchemeParams> {
     e: BitVec,
     commitments: Box<[DecProofCommitment<P>]>,
@@ -80,8 +73,8 @@ struct DecProofEphemeral<P: SchemeParams> {
     r: Randomizer<P::Paillier>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(deserialize = "Point<P>: for<'x> Deserialize<'x>,"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(crate) struct DecProofCommitment<P: SchemeParams> {
     cap_a: CiphertextWire<P::Paillier>,
     cap_b: Point<P>,

--- a/src/zk/elog.rs
+++ b/src/zk/elog.rs
@@ -1,7 +1,6 @@
 //! Dlog with El-Gamal Commitment ($\Pi^{elog}$, Section A.1, Fig. 23)
 
 use rand_core::CryptoRngCore;
-use serde::{Deserialize, Serialize};
 
 use crate::{
     curve::{Point, Scalar},
@@ -34,11 +33,8 @@ pub(crate) struct ElogPublicInputs<'a, P: SchemeParams> {
 }
 
 /// ZK proof: Paillier decryption modulo $q$.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(deserialize = "
-    Scalar<P>: for<'x> Deserialize<'x>,
-    Point<P>: for<'x> Deserialize<'x>
-"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(crate) struct ElogProof<P: SchemeParams> {
     e: Scalar<P>,
     cap_a: Point<P>,

--- a/src/zk/enc_elg.rs
+++ b/src/zk/enc_elg.rs
@@ -1,7 +1,6 @@
 //! Range Proof w/ EL-Gamal Commitment ($\Pi^{enc-elg}$, Section A.2, Fig. 24)
 
 use rand_core::CryptoRngCore;
-use serde::{Deserialize, Serialize};
 
 use crate::{
     curve::{Point, Scalar},
@@ -43,11 +42,8 @@ pub struct EncElgPublicInputs<'a, P: SchemeParams> {
 }
 
 /// ZK proof: Paillier encryption in range.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(deserialize = "
-    Scalar<P>: for<'x> Deserialize<'x>,
-    Point<P>: for<'x> Deserialize<'x>
-"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(crate) struct EncElgProof<P: SchemeParams> {
     e: Scalar<P>,
     cap_s: RPCommitmentWire<P::Paillier>,

--- a/src/zk/mod_.rs
+++ b/src/zk/mod_.rs
@@ -65,11 +65,8 @@ Secret inputs:
 Public inputs:
 - Paillier public key $N = p q$,
 */
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "ModCommitment<P>: Serialize,
-    ModChallenge<P>: Serialize"))]
-#[serde(bound(deserialize = "ModCommitment<P>: for<'x> Deserialize<'x>,
-    ModChallenge<P>: for<'x> Deserialize<'x>"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(crate) struct ModProof<P: SchemeParams> {
     commitment: ModCommitment<P>,
     challenge: ModChallenge<P>,

--- a/src/zk/prm.rs
+++ b/src/zk/prm.rs
@@ -59,9 +59,8 @@ impl PrmChallenge {
 }
 
 /// Pedersen Parameters ZK proof.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "PrmCommitment<P>: Serialize"))]
-#[serde(bound(deserialize = "PrmCommitment<P>: for<'x> Deserialize<'x>"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(crate) struct PrmProof<P: SchemeParams> {
     commitment: PrmCommitment<P>,
     challenge: PrmChallenge,

--- a/src/zk/sch.rs
+++ b/src/zk/sch.rs
@@ -4,7 +4,6 @@
 //! where $g$ is the EC generator.
 
 use rand_core::CryptoRngCore;
-use serde::{Deserialize, Serialize};
 
 use crate::{
     curve::{Point, Scalar},
@@ -31,8 +30,8 @@ impl<P: SchemeParams> SchSecret<P> {
 }
 
 /// Public data for the proof (~ verifying key)
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(deserialize = "Point<P>: for<'x> Deserialize<'x>"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(crate) struct SchCommitment<P: SchemeParams>(Point<P>);
 
 impl<P: SchemeParams> SchCommitment<P> {
@@ -41,8 +40,8 @@ impl<P: SchemeParams> SchCommitment<P> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(bound(deserialize = "Scalar<P>: for<'x> Deserialize<'x>"))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 struct SchChallenge<P: SchemeParams>(Scalar<P>);
 
 impl<P: SchemeParams> SchChallenge<P> {
@@ -57,8 +56,8 @@ impl<P: SchemeParams> SchChallenge<P> {
 }
 
 /// ZK proof: Schnorr proof of knowledge.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(deserialize = "for<'x> SchChallenge<P>: Deserialize<'x>"))]
+#[derive(Debug, Clone)]
+#[derive_where::derive_where(Serialize, Deserialize)]
 pub(crate) struct SchProof<P: SchemeParams> {
     challenge: SchChallenge<P>,
     proof: Scalar<P>,


### PR DESCRIPTION
Fixes #10

Also pin the trunk version of `manul` since it requires some fixes to work around a bug in `derive-where` (see https://github.com/ModProg/derive-where/pull/122)